### PR TITLE
Fix Segmentation fault when stopping

### DIFF
--- a/es-core/src/AudioManager.cpp
+++ b/es-core/src/AudioManager.cpp
@@ -60,6 +60,7 @@ void AudioManager::deinit() {
     //completely tear down SDL audio. else SDL hogs audio resources and emulators might fail to start...
     LOG(LogInfo) << "Shutting down SDL AUDIO";
 
+    Mix_HookMusicFinished(NULL);
     Mix_HaltMusic();
     Mix_CloseAudio();
     SDL_QuitSubSystem(SDL_INIT_AUDIO);


### PR DESCRIPTION
A quick fix for Segmentation fault when ES stopping: 
release the Mix_HookMusicFinished callback when the AudioManager deinit, otherwise it will access a null callback.