### PR TITLE
Added a menu for RetroAchievements score and standings

### DIFF
--- a/es-app/src/ApiSystem.cpp
+++ b/es-app/src/ApiSystem.cpp
@@ -861,3 +861,25 @@ bool ApiSystem::setAudioOutputDevice(std::string selected) {
 
     return exitcode == 0;
 }
+
+// Batocera
+std::string ApiSystem::getRetroAchievements() {
+
+    std::ostringstream oss;
+    oss << "/recalbox/scripts/batocera-retroachievements-info" ;
+    FILE *pipe = popen(oss.str().c_str(), "r");
+    char line[1024];
+
+    if (pipe == NULL) {
+        return "";
+    }
+
+    if (fgets(line, 1024, pipe)) {
+        strtok(line, "\n");
+        pclose(pipe);
+        return std::string(line);
+    }
+    return "";
+}
+
+

--- a/es-app/src/ApiSystem.h
+++ b/es-app/src/ApiSystem.h
@@ -97,6 +97,9 @@ public:
     /* video output */
     std::vector<std::string> getAvailableVideoOutputDevices();
 
+    // Batocera
+    std::string getRetroAchievements();
+
 private:
     static ApiSystem *instance;
 

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -74,6 +74,9 @@ GuiMenu::GuiMenu(Window *window) : GuiComponent(window), mMenu(window, _("MAIN M
     addEntry(_("NETWORK SETTINGS").c_str(), 0x777777FF, true, [this] { openNetworkSettings_batocera(); });
 
   if (isFullUI)
+    addEntry(_("RETROACHIEVEMENTS").c_str(), 0x777777FF, true, [this] { openRetroAchievements_batocera(); });
+
+  if (isFullUI)
     addEntry(_("SCRAPE").c_str(), 0x777777FF, true, [this] { openScraperSettings_batocera(); });
 
   // SYSTEM
@@ -1926,6 +1929,22 @@ void GuiMenu::openNetworkSettings_batocera() {
 	ApiSystem::getInstance()->disableWifi();
       }
     });
+  mWindow->pushGui(s);
+}
+
+void GuiMenu::openRetroAchievements_batocera() {
+  Window *window = mWindow;
+  auto s = new GuiSettings(mWindow, _("RETROACHIEVEMENTS").c_str());
+  ComponentListRow row;
+  std::string RetroAchievementsString = ApiSystem::getInstance()->getRetroAchievements();
+  if (RetroAchievementsString.empty()) {
+    RetroAchievementsString = std::string("Please configure [Games Settings]->[Retroachievements Settings] first");
+  }
+  auto RAString = std::make_shared<TextComponent>(mWindow,
+  	     RetroAchievementsString,
+  	     Font::get(FONT_SIZE_SMALL), 0x777777FF);
+  row.addElement(RAString, false);
+  s->addRow(row);
   mWindow->pushGui(s);
 }
 

--- a/es-app/src/guis/GuiMenu.h
+++ b/es-app/src/guis/GuiMenu.h
@@ -51,6 +51,7 @@ private:
 	void openControllersSettings_batocera();
 	void openUISettings_batocera();
 	void openSoundSettings_batocera();
+	void openRetroAchievements_batocera();
 	void openNetworkSettings_batocera();
 	void openScraperSettings_batocera();
 	void openQuitMenu_batocera();


### PR DESCRIPTION
This relies on a Bash script located in /recalbox/scripts/batocera-retroachievements-info
which retrieved the webpage from https://retroachievements.org and parses it
to produce a 1-line summary of the current score and standings.
PR for the Bash script will be following this one.