### PR TITLE
Scraper: change ScreenScraper API URL

### DIFF
--- a/es-app/src/scrapers/ScreenScraper.h
+++ b/es-app/src/scrapers/ScreenScraper.h
@@ -27,7 +27,7 @@ public:
 		const std::string API_DEV_U = { 91, 32, 7, 17 };
 		const std::string API_DEV_P = { 108, 28, 54, 55, 83, 43, 91, 44, 30, 22, 41, 12, 0, 108, 38, 29 };
 		const std::string API_DEV_KEY = { 54, 73, 115, 100, 101, 67, 111, 107, 79, 66, 68, 66, 67, 56, 118, 77, 54, 88, 101, 54 };
-		const std::string API_URL_BASE = "https://screenscraper.fr/api2";
+		const std::string API_URL_BASE = "https://www.screenscraper.fr/api2";
 		const std::string API_SOFT_NAME = "Emulationstation " + static_cast<std::string>(PROGRAM_VERSION_STRING);
 
 		/** Which type of image artwork we need. Possible values (not a comprehensive list):


### PR DESCRIPTION
ScreensScraper.fr has changed the SSL certificate, they now use a wildcard (*.screenscraper.fr) certificate.
This makes the screenscraper.fr hostname no longer available, so let's switch to www. for the API url. The change happened sometime around 20 April, but it doesn't seem to affect a lot of users.Apparently other scrapers haven't been using the non-www API endpoint.

Credit: Cristi Mitrana
Commit: 6e123ba8c60897a6f7e9dff8cb1f606576ab859c
Source: https://github.com/RetroPie/EmulationStation/pull/561/commits/6e123ba8c60897a6f7e9dff8cb1f606576ab859c