### PR TITLE
Screensavers: added "random video" (aka demo mode) and "slideshow"

### DIFF
--- a/es-app/src/guis/GuiMenu.h
+++ b/es-app/src/guis/GuiMenu.h
@@ -41,6 +41,8 @@ private:
 	void openQuitMenu();
 	void openScraperSettings();
 	void openScreensaverOptions();
+	void openSlideshowScreensaverOptions();
+	void openVideoScreensaverOptions();
 	void openSoundSettings();
 	void openUISettings();
 

--- a/es-app/src/guis/GuiScreensaverOptions.cpp
+++ b/es-app/src/guis/GuiScreensaverOptions.cpp
@@ -33,7 +33,7 @@ void GuiScreensaverOptions::save()
 
 bool GuiScreensaverOptions::input(InputConfig* config, Input input)
 {
-	if(config->isMappedTo("b", input) && input.value != 0)
+	if(config->isMappedTo("a", input) && input.value != 0) // batocera "a" instead of "b"
 	{
 		delete this;
 		return true;


### PR DESCRIPTION
- "Random video" will play all the videos that have been scraped. When you fancy play the game that is showing up, press "start". Several options, like adding the name of the game and the console as an overlay over the video. 
- "Slideshow" will take the images that were scraped and display them as a screensaver.
- Added two sub-menus in "UI Settings" to configure the options for those two screensavers.