### PR TITLE
Add an option for per-system background music

### DIFF
--- a/es-app/src/FileData.cpp
+++ b/es-app/src/FileData.cpp
@@ -302,6 +302,7 @@ void FileData::launchGame(Window* window)
 
 	window->init();
 	VolumeControl::getInstance()->init();
+	AudioManager::getInstance()->setName(mSystem->getName()); // batocera system-specific music
         AudioManager::getInstance()->init(); // batocera
 	window->normalizeNextUpdate();
 

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -1855,6 +1855,14 @@ void GuiMenu::openSoundSettings_batocera() {
 	AudioManager::getInstance()->stopMusic();
     });
 
+  // batocera - music per system
+  auto music_per_system = std::make_shared<SwitchComponent>(mWindow);
+  music_per_system->setState(!(SystemConf::getInstance()->get("audio.persystem") == "0"));
+  s->addWithLabel(_("ONLY PLAY SYSTEM-SPECIFIC MUSIC FOLDER"), music_per_system);
+  s->addSaveFunc([music_per_system] {
+      SystemConf::getInstance()->set("audio.persystem", music_per_system->getState() ? "1" : "0");
+    });
+
   // disable sounds
   //auto sounds_enabled = std::make_shared<SwitchComponent>(mWindow);
   //sounds_enabled->setState(Settings::getInstance()->getBool("EnableSounds"));

--- a/es-app/src/views/SystemView.cpp
+++ b/es-app/src/views/SystemView.cpp
@@ -13,6 +13,7 @@
 #include "ApiSystem.h"
 #include "SystemConf.h"
 #include "guis/GuiMenu.h"
+#include "AudioManager.h"
 
 // buffer values for scrolling velocity (left, stopped, right)
 const int logoBuffersLeft[] = { -5, -2, -1 };
@@ -298,6 +299,16 @@ void SystemView::onCursorChanged(const CursorState& /*state*/)
 	{
 		mSystemInfo.setOpacity((unsigned char)(Math::lerp(infoStartOpacity, 0.f, t) * 255));
 	}, (int)(infoStartOpacity * (goFast ? 10 : 150)));
+
+        // batocera - per system music folder
+        if(SystemConf::getInstance()->get("audio.persystem") == "1" && SystemConf::getInstance()->get("audio.bgmusic") != "0")  {
+		if (getSelected()->isGameSystem()) {
+			if (AudioManager::getInstance()->getName() != getSelected()->getName()) {
+				AudioManager::getInstance()->setName(getSelected()->getName());
+				AudioManager::getInstance()->playRandomMusic(0);
+			}
+		}
+        }
 
 	unsigned int gameCount = getSelected()->getDisplayedGameCount();
 

--- a/es-app/src/views/ViewController.cpp
+++ b/es-app/src/views/ViewController.cpp
@@ -17,6 +17,8 @@
 #include "SystemData.h"
 #include "Window.h"
 #include "guis/GuiDetectDevice.h"
+#include "SystemConf.h"
+#include "AudioManager.h"
 
 ViewController* ViewController::sInstance = NULL;
 
@@ -130,6 +132,14 @@ void ViewController::goToGameList(SystemData* system)
 
 	mState.viewing = GAME_LIST;
 	mState.system = system;
+
+        // batocera
+        if(SystemConf::getInstance()->get("audio.persystem") == "1" && SystemConf::getInstance()->get("audio.bgmusic") != "0") {
+		if (AudioManager::getInstance()->getName() != system->getName()) {
+			AudioManager::getInstance()->setName(system->getName());
+			AudioManager::getInstance()->playRandomMusic(0);
+		}
+	}
 
 	if (mCurrentView)
 	{

--- a/es-core/src/AudioManager.cpp
+++ b/es-core/src/AudioManager.cpp
@@ -6,6 +6,7 @@
 #include <SDL.h>
 #include <unistd.h>
 #include "utils/FileSystemUtil.h"
+#include "SystemConf.h"
 
 std::vector<std::shared_ptr<Sound>> AudioManager::sSoundVector;
 SDL_AudioSpec AudioManager::sAudioFormat;
@@ -169,10 +170,16 @@ void AudioManager::stop()
 	SDL_PauseAudio(1);
 }
 
+// batocera - per system music folder
+void AudioManager::setName(std::string newname) {
+        mSystem = newname;
+}
+
 // batocera
 void AudioManager::getMusicIn(const std::string &path, std::vector<std::string>& all_matching_files) {
     Utils::FileSystem::stringList dirContent;
     std::string extension;
+    std::string last_path;
 
     if(!Utils::FileSystem::isDirectory(path)) {
         return;
@@ -187,7 +194,14 @@ void AudioManager::getMusicIn(const std::string &path, std::vector<std::string>&
 	}
       } else if(Utils::FileSystem::isDirectory(*it)) {
 	if(strcmp(extension.c_str(), ".") != 0 && strcmp(extension.c_str(), "..") != 0) {
-	  getMusicIn(*it, all_matching_files);
+		// batocera - if music_per_system
+		last_path = it->substr(it->find_last_of("/") + 1);
+		if (SystemConf::getInstance()->get("audio.persystem") != "1") {
+			getMusicIn(*it, all_matching_files);
+		}
+		else if (strcmp(getName().c_str(), last_path.c_str()) == 0) {
+			getMusicIn(*it, all_matching_files);
+		}
 	}
       }
     }

--- a/es-core/src/AudioManager.h
+++ b/es-core/src/AudioManager.h
@@ -6,6 +6,7 @@
 #include <memory>
 #include <vector>
 #include "SDL_mixer.h"
+#include <string> // batocera
 
 class Sound;
 
@@ -22,6 +23,7 @@ class AudioManager
 	static Mix_Music* currentMusic; // batocera
 	void getMusicIn(const std::string &path, std::vector<std::string>& all_matching_files); // batocera
 	static void musicEnd_callback(); // batocera
+	std::string mSystem = ""; // batocera (per system music folder)
 
 public:
 	static std::shared_ptr<AudioManager> & getInstance();
@@ -38,7 +40,9 @@ public:
 	// batocera
 	void playRandomMusic(bool continueIfPlaying = true);
 	void stopMusic();
-	
+	inline const std::string getName() const { return mSystem; }
+	void setName(std::string name);
+
 	virtual ~AudioManager();
 };
 


### PR DESCRIPTION
Enable system-specific background music (`audio.persystem=1` in `batocera.conf`) in order to play only the .mp3 and .ogg files that are in `/userdata/music/` and `/userdata/music/system_that_is_currently_on`.

For example, if you have two folders `/userdata/music/nes` and `/userdata/music/psx`, only the `nes` musics will be played when you are in the NES system in ES, while only the `psx` musics will be played when you are in PlayStation. Musics in the top folder `/userdata/music/` will be played anywhere.

There is also a new GUI option in "Sound settings" to set this up.