### PR TITLE
Added an option to force the compilation of Raspberry Pi specific bits.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 2.8)
 
 option(GLES "Set to ON if targeting OpenGL ES" ${GLES})
 option(GL "Set to ON if targeting Desktop OpenGL" ${GL})
+option(RPI "Set to ON to enable the Raspberry PI video player (omxplayer)" ${RPI})
 
 # batocera
 option(ENABLE_FILEMANAGER "Set to ON to enable f1 shortcut for filesystem")
@@ -91,7 +92,7 @@ endif()
 
 #-------------------------------------------------------------------------------
 #set up compiler flags and excutable names
-if(DEFINED BCMHOST)
+if(DEFINED BCMHOST OR RPI)
     add_definitions(-D_RPI_)
 endif()
 


### PR DESCRIPTION
Useful when the VC4 legacy driver is not used for GLES, but usage of 'omxplayer' is still desired.

Source: https://github.com/RetroPie/EmulationStation/commit/0903bb36ff87879b24d366eb27c59721e780c928
Credit: @cmitu