### PR TITLE
Integration with theBezelProject

### DIFF
--- a/es-app/CMakeLists.txt
+++ b/es-app/CMakeLists.txt
@@ -50,6 +50,9 @@ set(ES_HEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/src/guis/GuiThemeInstall.h # batocera
     ${CMAKE_CURRENT_SOURCE_DIR}/src/guis/GuiThemeInstall.cpp # batocera
     ${CMAKE_CURRENT_SOURCE_DIR}/src/guis/GuiSystemsHide.h # batocera
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/guis/GuiBezelInstallStart.h # batocera
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/guis/GuiBezelInstall.h # batocera
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/guis/GuiBezelInstall.cpp # batocera
 
     # Scrapers
     ${CMAKE_CURRENT_SOURCE_DIR}/src/scrapers/Scraper.h
@@ -120,6 +123,7 @@ set(ES_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/guis/GuiLoading.cpp # batocera
     ${CMAKE_CURRENT_SOURCE_DIR}/src/guis/GuiThemeInstallStart.cpp # batocera
     ${CMAKE_CURRENT_SOURCE_DIR}/src/guis/GuiSystemsHide.cpp # batocera
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/guis/GuiBezelInstallStart.cpp # batocera
 
     # Scrapers
     ${CMAKE_CURRENT_SOURCE_DIR}/src/scrapers/Scraper.cpp

--- a/es-app/src/ApiSystem.h
+++ b/es-app/src/ApiSystem.h
@@ -101,6 +101,9 @@ public:
     std::vector<std::string> getRetroAchievements();
     std::vector<std::string> getBatoceraThemesList();
     std::pair<std::string,int> installBatoceraTheme(BusyComponent* ui, std::string thname);
+    std::vector<std::string> getBatoceraBezelsList();
+    std::pair<std::string,int> installBatoceraBezel(BusyComponent* ui, std::string bezelsystem);
+    std::pair<std::string,int> uninstallBatoceraBezel(BusyComponent* ui, std::string bezelsystem);
 
 private:
     static ApiSystem *instance;

--- a/es-app/src/guis/GuiBezelInstall.cpp
+++ b/es-app/src/guis/GuiBezelInstall.cpp
@@ -8,7 +8,6 @@
 #include "ApiSystem.h"
 #include "LocaleES.h"
 #include "GuiBezelInstall.h"
-#include "views/ViewController.h"
 
 // Batcera - theBezelProject Install
 GuiBezelInstall::GuiBezelInstall(Window* window, char *bezel) : GuiComponent(window), mBusyAnim(window)
@@ -17,7 +16,7 @@ GuiBezelInstall::GuiBezelInstall(Window* window, char *bezel) : GuiComponent(win
         mLoading = true;
 	mState = 1;
         mBusyAnim.setSize(mSize);
-	mBezelName = bezel; //FIXME
+	mBezelName = bezel;
 }
 
 GuiBezelInstall::~GuiBezelInstall()
@@ -67,8 +66,6 @@ void GuiBezelInstall::update(int deltaTime) {
 					}
 					)
 			  );
-	  // In case you have no active theme
-	  // ViewController::get()->reloadAll();
 	  mState = 0;
         }
         if(mState == 3){
@@ -89,8 +86,6 @@ void GuiBezelInstall::update(int deltaTime) {
 
 void GuiBezelInstall::threadBezel() 
 {
-    // Batocera script will be invoked there 
-    // FIXME
     std::pair<std::string,int> updateStatus = ApiSystem::getInstance()->installBatoceraBezel(&mBusyAnim, mBezelName);
     
     if(updateStatus.second == 0){
@@ -123,7 +118,7 @@ GuiBezelUninstall::GuiBezelUninstall(Window* window, char *bezel) : GuiComponent
         mLoading = true;
 	mState = 1;
         mBusyAnim.setSize(mSize);
-	mBezelName = bezel; //FIXME
+	mBezelName = bezel;
 }
 
 GuiBezelUninstall::~GuiBezelUninstall()
@@ -173,8 +168,6 @@ void GuiBezelUninstall::update(int deltaTime) {
 					}
 					)
 			  );
-	  // In case you have no active theme
-	  // ViewController::get()->reloadAll();
 	  mState = 0;
         }
         if(mState == 3){
@@ -195,8 +188,6 @@ void GuiBezelUninstall::update(int deltaTime) {
 
 void GuiBezelUninstall::threadBezel() 
 {
-    // Batocera script will be invoked there 
-    // FIXME
     std::pair<std::string,int> updateStatus = ApiSystem::getInstance()->uninstallBatoceraBezel(&mBusyAnim, mBezelName);
     
     if(updateStatus.second == 0){

--- a/es-app/src/guis/GuiBezelInstall.cpp
+++ b/es-app/src/guis/GuiBezelInstall.cpp
@@ -1,0 +1,224 @@
+#include "guis/GuiBackup.h"
+#include "guis/GuiMsgBox.h"
+#include "Window.h"
+#include <boost/thread.hpp>
+#include <string>
+#include "Log.h"
+#include "Settings.h"
+#include "ApiSystem.h"
+#include "LocaleES.h"
+#include "GuiBezelInstall.h"
+#include "views/ViewController.h"
+
+// Batcera - theBezelProject Install
+GuiBezelInstall::GuiBezelInstall(Window* window, char *bezel) : GuiComponent(window), mBusyAnim(window)
+{
+	setSize((float)Renderer::getScreenWidth(), (float)Renderer::getScreenHeight());
+        mLoading = true;
+	mState = 1;
+        mBusyAnim.setSize(mSize);
+	mBezelName = bezel; //FIXME
+}
+
+GuiBezelInstall::~GuiBezelInstall()
+{
+}
+
+bool GuiBezelInstall::input(InputConfig* config, Input input)
+{
+        return false;
+}
+
+std::vector<HelpPrompt> GuiBezelInstall::getHelpPrompts()
+{
+	return std::vector<HelpPrompt>();
+}
+
+void GuiBezelInstall::render(const Transform4x4f& parentTrans)
+{
+        Transform4x4f trans = parentTrans * getTransform();
+
+        renderChildren(trans);
+
+        Renderer::setMatrix(trans);
+        Renderer::drawRect(0.f, 0.f, mSize.x(), mSize.y(), 0x00000011);
+
+        if(mLoading)
+        mBusyAnim.render(trans);
+
+}
+
+void GuiBezelInstall::update(int deltaTime) {
+        GuiComponent::update(deltaTime);
+        mBusyAnim.update(deltaTime);
+       
+        Window* window = mWindow;
+        if(mState == 1){
+	  mLoading = true;
+	  mHandle = new boost::thread(boost::bind(&GuiBezelInstall::threadBezel, this));
+	  mState = 0;
+        }
+
+        if(mState == 2){
+	  window->pushGui(
+			  new GuiMsgBox(window, _("FINISHED") + "\n" + _("BEZELS INSTALLED SUCCESSFULLY"), _("OK"),
+					[this] {
+					  mState = -1;
+					}
+					)
+			  );
+	  // In case you have no active theme
+	  // ViewController::get()->reloadAll();
+	  mState = 0;
+        }
+        if(mState == 3){
+            window->pushGui(
+                    new GuiMsgBox(window, mResult.first, _("OK"),
+                                  [this] {
+                                      mState = -1;
+                                  }
+                    )
+            );
+            mState = 0;
+        }
+
+        if(mState == -1){
+	  delete this;
+        }
+}
+
+void GuiBezelInstall::threadBezel() 
+{
+    // Batocera script will be invoked there 
+    // FIXME
+    std::pair<std::string,int> updateStatus = ApiSystem::getInstance()->installBatoceraBezel(&mBusyAnim, mBezelName);
+    
+    if(updateStatus.second == 0){
+        this->onInstallOk();
+    }else {
+        this->onInstallError(updateStatus);
+    } 
+    
+}
+
+void GuiBezelInstall::onInstallError(std::pair<std::string, int> result)
+{
+    mLoading = false;
+    mState = 3;
+    mResult = result;
+    mResult.first = _("AN ERROR OCCURED");
+}
+
+void GuiBezelInstall::onInstallOk()
+{
+    mLoading = false;
+    mState = 2;
+}
+
+
+// And now the UnInstall for this
+GuiBezelUninstall::GuiBezelUninstall(Window* window, char *bezel) : GuiComponent(window), mBusyAnim(window)
+{
+	setSize((float)Renderer::getScreenWidth(), (float)Renderer::getScreenHeight());
+        mLoading = true;
+	mState = 1;
+        mBusyAnim.setSize(mSize);
+	mBezelName = bezel; //FIXME
+}
+
+GuiBezelUninstall::~GuiBezelUninstall()
+{
+}
+
+bool GuiBezelUninstall::input(InputConfig* config, Input input)
+{
+        return false;
+}
+
+std::vector<HelpPrompt> GuiBezelUninstall::getHelpPrompts()
+{
+	return std::vector<HelpPrompt>();
+}
+
+void GuiBezelUninstall::render(const Transform4x4f& parentTrans)
+{
+        Transform4x4f trans = parentTrans * getTransform();
+
+        renderChildren(trans);
+
+        Renderer::setMatrix(trans);
+        Renderer::drawRect(0.f, 0.f, mSize.x(), mSize.y(), 0x00000011);
+
+        if(mLoading)
+        mBusyAnim.render(trans);
+
+}
+
+void GuiBezelUninstall::update(int deltaTime) {
+        GuiComponent::update(deltaTime);
+        mBusyAnim.update(deltaTime);
+       
+        Window* window = mWindow;
+        if(mState == 1){
+	  mLoading = true;
+	  mHandle = new boost::thread(boost::bind(&GuiBezelUninstall::threadBezel, this));
+	  mState = 0;
+        }
+
+        if(mState == 2){
+	  window->pushGui(
+			  new GuiMsgBox(window, _("FINISHED") + "\n" + _("BEZELS DELETED SUCCESSFULLY"), _("OK"),
+					[this] {
+					  mState = -1;
+					}
+					)
+			  );
+	  // In case you have no active theme
+	  // ViewController::get()->reloadAll();
+	  mState = 0;
+        }
+        if(mState == 3){
+            window->pushGui(
+                    new GuiMsgBox(window, mResult.first, _("OK"),
+                                  [this] {
+                                      mState = -1;
+                                  }
+                    )
+            );
+            mState = 0;
+        }
+
+        if(mState == -1){
+	  delete this;
+        }
+}
+
+void GuiBezelUninstall::threadBezel() 
+{
+    // Batocera script will be invoked there 
+    // FIXME
+    std::pair<std::string,int> updateStatus = ApiSystem::getInstance()->uninstallBatoceraBezel(&mBusyAnim, mBezelName);
+    
+    if(updateStatus.second == 0){
+        this->onInstallOk();
+    }else {
+        this->onInstallError(updateStatus);
+    } 
+    
+}
+
+void GuiBezelUninstall::onInstallError(std::pair<std::string, int> result)
+{
+    mLoading = false;
+    mState = 3;
+    mResult = result;
+    mResult.first = _("AN ERROR OCCURED");
+}
+
+void GuiBezelUninstall::onInstallOk()
+{
+    mLoading = false;
+    mState = 2;
+}
+
+

--- a/es-app/src/guis/GuiBezelInstall.h
+++ b/es-app/src/guis/GuiBezelInstall.h
@@ -1,0 +1,72 @@
+#pragma once
+
+#include "GuiComponent.h"
+#include "components/MenuComponent.h"
+#include "components/BusyComponent.h"
+
+#include <boost/thread.hpp>
+
+class GuiBezelInstall : public GuiComponent {
+public:
+    GuiBezelInstall(Window *window, char *theme);
+
+    virtual ~GuiBezelInstall();
+
+    void render(const Transform4x4f &parentTrans) override;
+
+    bool input(InputConfig *config, Input input) override;
+
+    std::vector<HelpPrompt> getHelpPrompts() override;
+
+    void update(int deltaTime) override;
+
+private:
+    BusyComponent mBusyAnim;
+    bool mLoading;
+    int mState;
+    std::pair<std::string, int> mResult;
+
+    std::string mBezelName;
+    
+    boost::thread *mHandle;
+
+    void onInstallError(std::pair<std::string, int>);
+
+    void onInstallOk();
+
+    void threadBezel();
+
+};
+
+class GuiBezelUninstall : public GuiComponent {
+public:
+    GuiBezelUninstall(Window *window, char *theme);
+
+    virtual ~GuiBezelUninstall();
+
+    void render(const Transform4x4f &parentTrans) override;
+
+    bool input(InputConfig *config, Input input) override;
+
+    std::vector<HelpPrompt> getHelpPrompts() override;
+
+    void update(int deltaTime) override;
+
+private:
+    BusyComponent mBusyAnim;
+    bool mLoading;
+    int mState;
+    std::pair<std::string, int> mResult;
+
+    std::string mBezelName;
+    
+    boost::thread *mHandle;
+
+    void onInstallError(std::pair<std::string, int>);
+
+    void onInstallOk();
+
+    void threadBezel();
+
+};
+

--- a/es-app/src/guis/GuiBezelInstallStart.cpp
+++ b/es-app/src/guis/GuiBezelInstallStart.cpp
@@ -1,0 +1,252 @@
+#include "guis/GuiBezelInstallStart.h"
+
+#include "ApiSystem.h"
+#include "components/OptionListComponent.h"
+#include "guis/GuiBezelInstall.h"
+#include "guis/GuiSettings.h"
+#include <boost/algorithm/string/predicate.hpp>
+#include <boost/algorithm/string/split.hpp>
+#include <boost/algorithm/string/classification.hpp>
+#include "views/ViewController.h"
+#include "SystemData.h"
+
+#include "LocaleES.h"
+
+// Batocera integration with theBezelProject
+GuiBezelInstallMenu::GuiBezelInstallMenu(Window* window)
+        :GuiComponent(window), mMenu(window, _("THE BEZEL PROJECT").c_str())
+{
+	addChild(&mMenu);
+	ComponentListRow row;
+      {
+        auto openBezelInstallNow = [this] { mWindow->pushGui(new GuiBezelInstallStart(mWindow)); };
+        row.makeAcceptInputHandler(openBezelInstallNow);
+        auto BezelInstallSettings = std::make_shared<TextComponent>(mWindow, _("INSTALL BEZELS"),
+                                                          Font::get(FONT_SIZE_MEDIUM), 0x777777FF);
+        auto bracket = makeArrow(mWindow);
+        row.addElement(BezelInstallSettings, true);
+        row.addElement(bracket, false);
+	mMenu.addRow(row);
+	row.elements.clear();
+      }
+      { // Also add the ability to remove bezels installed previously 
+        auto openBezelUninstallNow = [this] { mWindow->pushGui(new GuiBezelUninstallStart(mWindow)); };
+        row.makeAcceptInputHandler(openBezelUninstallNow);
+        auto BezelUninstallSettings = std::make_shared<TextComponent>(mWindow, _("UNINSTALL BEZELS"),
+                                                          Font::get(FONT_SIZE_MEDIUM), 0x777777FF);
+        auto bracket = makeArrow(mWindow);
+        row.addElement(BezelUninstallSettings, true);
+        row.addElement(bracket, false);
+	mMenu.addRow(row);
+	row.elements.clear();
+      }
+
+        mMenu.addButton(_("BACK"), "back", [&] { delete this; });
+	mMenu.setPosition((Renderer::getScreenWidth() - mMenu.getSize().x()) / 2, Renderer::getScreenHeight() * 0.15f);
+}
+
+bool GuiBezelInstallMenu::input(InputConfig* config, Input input)
+{
+	bool consumed = GuiComponent::input(config, input);
+	if(consumed)
+		return true;
+	
+	if(input.value != 0 && config->isMappedTo("a", input))
+	{
+		delete this;
+		return true;
+	}
+	if(config->isMappedTo("start", input) && input.value != 0)
+	{
+		// close everything
+		Window* window = mWindow;
+		while(window->peekGui() && window->peekGui() != ViewController::get())
+			delete window->peekGui();
+	}
+	return false;
+}
+
+std::vector<HelpPrompt> GuiBezelInstallMenu::getHelpPrompts()
+{
+        std::vector<HelpPrompt> prompts = mMenu.getHelpPrompts();
+        prompts.push_back(HelpPrompt("a", _("BACK")));
+        prompts.push_back(HelpPrompt("start", _("CLOSE")));
+        return prompts;
+}
+
+// Batocera install theBezelProject
+GuiBezelInstallStart::GuiBezelInstallStart(Window* window)
+	:GuiComponent(window), mMenu(window, _("INSTALL THE BEZEL PROJECT").c_str())
+{
+	addChild(&mMenu);
+	ComponentListRow row;
+	
+	row.addElement(std::make_shared<TextComponent>(window, _("SELECT SYSTEM WHERE BEZELS WILL BE INSTALLED"), Font::get(FONT_SIZE_MEDIUM), 0x777777FF), true);
+	mMenu.addRow(row);
+	row.elements.clear();
+
+	//list all bezels available from TheBezelProject
+	std::vector<std::string> availableBezels = ApiSystem::getInstance()->getBatoceraBezelsList();
+
+        for(auto it = availableBezels.begin(); it != availableBezels.end(); it++){
+
+                auto itstring = std::make_shared<TextComponent>(mWindow,
+                                (*it).c_str(), Font::get(FONT_SIZE_SMALL), 0x777777FF);
+
+                char *tmp=new char [(*it).length()+1];
+                mSelectedBezel=new char [(*it).length()+1];
+                std::strcpy (tmp, (*it).c_str());
+                // Get Bezel_System name (from string '[A] Bezel_name http://url_of_this_Bezel')
+		// as bezel_cli
+                char *bezel_cli = strtok (tmp, " \t");
+                bezel_cli = strtok (NULL, " \t");
+		
+                // Names longer than this will crash GuiMsgBox downstream
+                // "48" found by trials and errors. Ideally should be fixed
+                // in es-core MsgBox -- FIXME
+                if (strlen(bezel_cli) > 48)
+                        bezel_cli[47]='\0';
+                row.makeAcceptInputHandler([this, bezel_cli] {
+                                strcpy (mSelectedBezel, bezel_cli);
+                                this->start();
+                                });
+                row.addElement(itstring, true);
+                mMenu.addRow(row);
+                row.elements.clear();
+        }
+
+        mMenu.addButton(_("BACK"), "back", [&] { delete this; });
+	mMenu.setPosition((Renderer::getScreenWidth() - mMenu.getSize().x()) / 2, Renderer::getScreenHeight() * 0.15f);
+}
+
+void GuiBezelInstallStart::start()
+{
+  if(strcmp(mSelectedBezel,"")) {
+    mWindow->pushGui(new GuiBezelInstall(mWindow, mSelectedBezel));
+    delete this;
+  }
+}
+
+bool GuiBezelInstallStart::input(InputConfig* config, Input input)
+{
+	bool consumed = GuiComponent::input(config, input);
+	if(consumed)
+		return true;
+	
+	if(input.value != 0 && config->isMappedTo("a", input))
+	{
+		delete this;
+		return true;
+	}
+	if(config->isMappedTo("start", input) && input.value != 0)
+	{
+		// close everything
+		Window* window = mWindow;
+		while(window->peekGui() && window->peekGui() != ViewController::get())
+			delete window->peekGui();
+	}
+	return false;
+}
+
+std::vector<HelpPrompt> GuiBezelInstallStart::getHelpPrompts()
+{
+        std::vector<HelpPrompt> prompts = mMenu.getHelpPrompts();
+        prompts.push_back(HelpPrompt("a", _("BACK")));
+        prompts.push_back(HelpPrompt("start", _("CLOSE")));
+	return prompts;
+}
+
+// And now uninstall them
+GuiBezelUninstallStart::GuiBezelUninstallStart(Window* window)
+	:GuiComponent(window), mMenu(window, _("UNINSTALL THE BEZEL PROJECT").c_str())
+{
+	addChild(&mMenu);
+	ComponentListRow row;
+	
+	row.addElement(std::make_shared<TextComponent>(window, _("SELECT SYSTEM WHERE BEZELS WILL BE REMOVED"), Font::get(FONT_SIZE_MEDIUM), 0x777777FF), true);
+	mMenu.addRow(row);
+	row.elements.clear();
+
+	//list all bezels available from TheBezelProject
+	std::vector<std::string> availableBezels = ApiSystem::getInstance()->getBatoceraBezelsList();
+
+        for(auto it = availableBezels.begin(); it != availableBezels.end(); it++){
+
+                auto itstring = std::make_shared<TextComponent>(mWindow,
+                                (*it).c_str(), Font::get(FONT_SIZE_SMALL), 0x777777FF);
+                char *tmp=new char [(*it).length()+1];
+                mSelectedBezel=new char [(*it).length()+1];
+                std::strcpy (tmp, (*it).c_str());
+                // Get Bezel_System name (from string '[I] Bezel_name http://url_of_this_Bezel')
+		// as bezel_cli (short system name, long names will be fetched below)
+                char *bezel_cli = strtok (tmp, " \t");
+                bezel_cli = strtok (NULL, " \t");
+
+		// Only show [I]nstalled bezels not the other
+		if (strcmp (tmp, "[I]"))
+			continue;
+
+		std::vector<SystemData*>::const_iterator itSystem;
+		for (itSystem = SystemData::sFileSystemVector.cbegin(); itSystem != SystemData::sFileSystemVector.cend(); itSystem++)
+		{
+			// Let's put the pretty name of the system
+			if (! strcmp ((*itSystem)->getName().c_str(), bezel_cli))
+				itstring = std::make_shared<TextComponent>(mWindow,
+						(*itSystem)->getFullName(), Font::get(FONT_SIZE_SMALL), 0x777777FF);
+		}
+
+                // Names longer than this will crash GuiMsgBox downstream
+                // "48" found by trials and errors. Ideally should be fixed
+                // in es-core MsgBox -- FIXME
+                if (strlen(bezel_cli) > 48)
+                        bezel_cli[47]='\0';
+                row.makeAcceptInputHandler([this, bezel_cli] {
+                                strcpy (mSelectedBezel, bezel_cli);
+                                this->start();
+                                });
+                row.addElement(itstring, true);
+                mMenu.addRow(row);
+                row.elements.clear();
+        }
+
+        mMenu.addButton(_("BACK"), "back", [&] { delete this; });
+	mMenu.setPosition((Renderer::getScreenWidth() - mMenu.getSize().x()) / 2, Renderer::getScreenHeight() * 0.15f);
+}
+
+void GuiBezelUninstallStart::start()
+{
+  if(strcmp(mSelectedBezel,"")) {
+    mWindow->pushGui(new GuiBezelUninstall(mWindow, mSelectedBezel));
+    delete this;
+  }
+}
+
+bool GuiBezelUninstallStart::input(InputConfig* config, Input input)
+{
+	bool consumed = GuiComponent::input(config, input);
+	if(consumed)
+		return true;
+	
+	if(input.value != 0 && config->isMappedTo("a", input))
+	{
+		delete this;
+		return true;
+	}
+	if(config->isMappedTo("start", input) && input.value != 0)
+	{
+		// close everything
+		Window* window = mWindow;
+		while(window->peekGui() && window->peekGui() != ViewController::get())
+			delete window->peekGui();
+	}
+	return false;
+}
+
+std::vector<HelpPrompt> GuiBezelUninstallStart::getHelpPrompts()
+{
+        std::vector<HelpPrompt> prompts = mMenu.getHelpPrompts();
+        prompts.push_back(HelpPrompt("a", _("BACK")));
+        prompts.push_back(HelpPrompt("start", _("CLOSE")));
+	return prompts;
+}
+

--- a/es-app/src/guis/GuiBezelInstallStart.h
+++ b/es-app/src/guis/GuiBezelInstallStart.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include "GuiComponent.h"
+#include "components/MenuComponent.h"
+
+template<typename T>
+class OptionListComponent;
+
+// Batocera
+class GuiBezelInstallStart : public GuiComponent
+{
+public:
+	GuiBezelInstallStart(Window* window);
+	bool input(InputConfig* config, Input input) override;
+	virtual std::vector<HelpPrompt> getHelpPrompts() override;
+
+private:
+	void start();
+	MenuComponent mMenu;
+	char *mSelectedBezel;
+};
+
+class GuiBezelUninstallStart : public GuiComponent
+{
+public:
+	GuiBezelUninstallStart(Window* window);
+	bool input(InputConfig* config, Input input) override;
+	virtual std::vector<HelpPrompt> getHelpPrompts() override;
+
+private:
+	void start();
+	MenuComponent mMenu;
+	char *mSelectedBezel;
+};
+
+class GuiBezelInstallMenu : public GuiComponent
+{
+public:
+	GuiBezelInstallMenu(Window* window);
+	bool input(InputConfig* config, Input input) override;
+	virtual std::vector<HelpPrompt> getHelpPrompts() override;
+
+private:
+	MenuComponent mMenu;
+};
+

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -10,7 +10,8 @@
 #include "guis/GuiVideoScreensaverOptions.h"
 #include "guis/GuiMsgBox.h"
 #include "guis/GuiScraperStart.h"
-#include "guis/GuiThemeInstallStart.h"
+#include "guis/GuiThemeInstallStart.h" //batocera
+#include "guis/GuiBezelInstallStart.h" //batocera
 #include "guis/GuiSettings.h"
 #include "guis/GuiSystemsHide.h" //batocera
 #include "views/UIModeController.h"
@@ -880,7 +881,20 @@ void GuiMenu::openSystemSettings_batocera() {
 	row.addElement(bracket, false);
 	updateGui->addRow(row);
       }
-      
+
+      // Batocera integration with theBezelProject
+      {
+	auto openBezelMenuNow = [this] { mWindow->pushGui(new GuiBezelInstallMenu(mWindow)); };
+	ComponentListRow row;
+	row.makeAcceptInputHandler(openBezelMenuNow);
+	auto BezelInstallMenuSettings = std::make_shared<TextComponent>(mWindow, _("THE BEZEL PROJECT"),
+			Font::get(FONT_SIZE_MEDIUM), 0x777777FF);
+	auto bracket = makeArrow(mWindow);
+	row.addElement(BezelInstallMenuSettings, true);
+	row.addElement(bracket, false);
+	updateGui->addRow(row);
+      }
+
       // Enable updates
       auto updates_enabled = std::make_shared<SwitchComponent>(mWindow);
       updates_enabled->setState(


### PR DESCRIPTION
New menu in EmulationStation (`System Settings` / `Updates`, next to the themes manager as it's very similar in its concept) to install/remove theBezelProject for each system installed on Batocera. Obviously, it requires the `batocera-es-thebezelproject` menu and changes in the libretro configgen that have been PRed earlier.

Once installed, it can be enabled in the `decorations` menu, as other decorations.