### PR TITLE
Fix for audio when selecting a non-system category

### DIFF
--- a/es-app/src/FileData.cpp
+++ b/es-app/src/FileData.cpp
@@ -301,8 +301,12 @@ void FileData::launchGame(Window* window)
 	Scripting::fireEvent("game-end");
 
 	window->init();
-	VolumeControl::getInstance()->init();
-	AudioManager::getInstance()->setName(mSystem->getName()); // batocera system-specific music
+	VolumeControl::getInstance()->init(); 
+	// batocera system-specific music
+	if (mSystem != NULL)
+		AudioManager::getInstance()->setName(mSystem->getName());
+	else
+		AudioManager::getInstance()->setName("");
         AudioManager::getInstance()->init(); // batocera
 	window->normalizeNextUpdate();
 


### PR DESCRIPTION
Hot fix when you have music background and a category that is non-sytem (like "all games", "favorites", etc.). In that case `FileData::mSystem == NULL`, and that led to an ES crash.