### PR TITLE
Set VSync on by default on Raspberry Pi

### DIFF
--- a/es-core/src/Settings.cpp
+++ b/es-core/src/Settings.cpp
@@ -80,14 +80,7 @@ void Settings::setDefaults()
         mStringMap["INPUT P5"] = "DEFAULT";
         mStringMap["Overclock"] = "none";
 
-        // batocera
-#ifdef _RPI_
-	// don't enable VSync by default on the Pi, since it already
-	// has trouble trying to render things at 60fps in certain menus
-	mBoolMap["VSync"] = false;
-    #else
-    mBoolMap["VSync"] = true;
-#endif
+		mBoolMap["VSync"] = true;
 
     mBoolMap["EnableSounds"] = false; // batocera
 	mBoolMap["ShowHelpPrompts"] = true;


### PR DESCRIPTION
On a TV with a Raspberry Pi, ES looks like it is flickering.
Set to true by default on every system.