### PR TITLE
Make EmulationStation buildable in Windows & Visual Studio

### DIFF
--- a/es-app/src/ApiSystem.cpp
+++ b/es-app/src/ApiSystem.cpp
@@ -25,977 +25,1047 @@
 #if !defined(WIN32)
 #include <arpa/inet.h>
 #endif
-#include <boost/algorithm/string/replace.hpp>
-#include <boost/algorithm/string/predicate.hpp>
-#include <boost/algorithm/string/split.hpp>
-#include <boost/algorithm/string/classification.hpp>
-
+#include "utils/FileSystemUtil.h"
+#include "utils/StringUtil.h"
 #include <fstream>
 #include <SDL.h>
 #include <Sound.h>
 
 #if defined(WIN32)
+#include "EmulationStation.h"
 #define popen _popen
 #define pclose _pclose
 #endif
 
-ApiSystem::ApiSystem() {
+ApiSystem::ApiSystem() 
+{
 }
 
-ApiSystem *ApiSystem::instance = NULL;
+ApiSystem* ApiSystem::instance = NULL;
 
+ApiSystem *ApiSystem::getInstance() 
+{
+	if (ApiSystem::instance == NULL)
+		ApiSystem::instance = new ApiSystem();
 
-ApiSystem *ApiSystem::getInstance() {
-    if (ApiSystem::instance == NULL) {
-        ApiSystem::instance = new ApiSystem();
-    }
-    return ApiSystem::instance;
+	return ApiSystem::instance;
 }
 
-unsigned long ApiSystem::getFreeSpaceGB(std::string mountpoint) {
+unsigned long ApiSystem::getFreeSpaceGB(std::string mountpoint) 
+{
 #if !defined(WIN32)
-    struct statvfs fiData;
-    const char *fnPath = mountpoint.c_str();
-    int free = 0;
-    if ((statvfs(fnPath, &fiData)) >= 0) {
-        free = (fiData.f_bfree * fiData.f_bsize) / (1024 * 1024 * 1024);
-    }
-    return free;
+	struct statvfs fiData;
+	const char *fnPath = mountpoint.c_str();
+	int free = 0;
+	if ((statvfs(fnPath, &fiData)) >= 0) {
+		free = (fiData.f_bfree * fiData.f_bsize) / (1024 * 1024 * 1024);
+	}
+	return free;
 #else
-    return 0;
+
+	unsigned __int64 i64FreeBytesToCaller, i64TotalBytes, i64FreeBytes;
+
+	std::string drive = Utils::FileSystem::getHomePath()[0] + std::string(":");
+
+	BOOL  fResult = GetDiskFreeSpaceExA(drive.c_str(),
+		(PULARGE_INTEGER)&i64FreeBytesToCaller,
+		(PULARGE_INTEGER)&i64TotalBytes,
+		(PULARGE_INTEGER)&i64FreeBytes);
+
+	if (fResult)
+		return i64FreeBytes / (1024 * 1024 * 1024);
+
+	return 0;
 #endif
 }
 
-std::string ApiSystem::getFreeSpaceInfo() {
-    std::string sharePart = "/userdata/";
-    if (sharePart.size() > 0) {
-        const char *fnPath = sharePart.c_str();
+std::string ApiSystem::getFreeSpaceInfo() 
+{
+	std::string sharePart = "/userdata/";
+	if (sharePart.size() > 0) {
+		const char *fnPath = sharePart.c_str();
 #if !defined(WIN32)
-        struct statvfs fiData;
-        if ((statvfs(fnPath, &fiData)) < 0) {
-            return "";
-        } else {
-            unsigned long total = (fiData.f_blocks * (fiData.f_bsize / 1024)) / (1024L * 1024L);
-            unsigned long free = (fiData.f_bfree * (fiData.f_bsize / 1024)) / (1024L * 1024L);
-            unsigned long used = total - free;
-            unsigned long percent = 0;
-            std::ostringstream oss;
-            if (total != 0){  //for small SD card ;) with share < 1GB
+		struct statvfs fiData;
+		if ((statvfs(fnPath, &fiData)) < 0) {
+			return "";
+		}
+		else {
+			unsigned long total = (fiData.f_blocks * (fiData.f_bsize / 1024)) / (1024L * 1024L);
+			unsigned long free = (fiData.f_bfree * (fiData.f_bsize / 1024)) / (1024L * 1024L);
+			unsigned long used = total - free;
+			unsigned long percent = 0;
+			std::ostringstream oss;
+			if (total != 0) {  //for small SD card ;) with share < 1GB
 				percent = used * 100 / total;
-                oss << used << "GB/" << total << "GB (" << percent << "%)";
+				oss << used << "GB/" << total << "GB (" << percent << "%)";
 			}
 			else
-			    oss << "N/A";
-            return oss.str();
-        }
+				oss << "N/A";
+			return oss.str();
+		}
 #else
-        (void)(fnPath);
-        return "TODO";
+		unsigned __int64 i64FreeBytesToCaller, i64TotalBytes, i64FreeBytes;
+
+		std::string drive = Utils::FileSystem::getHomePath()[0] + std::string(":");
+
+		BOOL  fResult = GetDiskFreeSpaceExA(drive.c_str(),
+			(PULARGE_INTEGER)&i64FreeBytesToCaller,
+			(PULARGE_INTEGER)&i64TotalBytes,
+			(PULARGE_INTEGER)&i64FreeBytes);
+
+		if (fResult)
+		{
+			unsigned long total = i64TotalBytes / (1024L * 1024L);
+			unsigned long free = i64FreeBytes / (1024L * 1024L);
+			unsigned long used = total - free;
+			unsigned long percent = 0;
+			std::ostringstream oss;
+			if (total != 0) {  //for small SD card ;) with share < 1GB
+				percent = used * 100 / total;
+				oss << used << "GB/" << total << "GB (" << percent << "%)";
+			}
+			else
+				oss << "N/A";
+
+			return oss.str();
+		}
+
+		return "N/A";
 #endif
-    } else {
-        return "ERROR";
-    }
+	}
+	else
+		return "ERROR";	
 }
 
 bool ApiSystem::isFreeSpaceLimit() {
-    std::string sharePart = "/userdata/";
-    if (sharePart.size() > 0) {
-        return getFreeSpaceGB(sharePart) < 2;
-    } else {
-        return "ERROR";
-    }
+	std::string sharePart = "/userdata/";
+	if (sharePart.size() > 0) {
+		return getFreeSpaceGB(sharePart) < 2;
+	}
+	else {
+		return "ERROR";
+	}
 
 }
 
-std::string ApiSystem::getVersion() {
-    std::string version = "/usr/share/batocera/batocera.version";
-    if (version.size() > 0) {
-        std::ifstream ifs(version);
+std::string ApiSystem::getVersion() 
+{
+#if WIN32
+	return PROGRAM_VERSION_STRING;
+#endif
 
-        if (ifs.good()) {
-            std::string contents;
-            std::getline(ifs, contents);
-            return contents;
-        }
-    }
-    return "";
+	std::string version = "/usr/share/batocera/batocera.version";
+	if (version.size() > 0) {
+		std::ifstream ifs(version);
+
+		if (ifs.good()) {
+			std::string contents;
+			std::getline(ifs, contents);
+			return contents;
+		}
+	}
+	return "";
 }
 
 bool ApiSystem::needToShowVersionMessage() {
-    createLastVersionFileIfNotExisting();
-    std::string versionFile = "/userdata/system/update.done";
-    if (versionFile.size() > 0) {
-        std::ifstream lvifs(versionFile);
-        if (lvifs.good()) {
-            std::string lastVersion;
-            std::getline(lvifs, lastVersion);
-            std::string currentVersion = getVersion();
-            if (lastVersion == currentVersion) {
-                return false;
-            }
-        }
-    }
-    return true;
+	createLastVersionFileIfNotExisting();
+	std::string versionFile = "/userdata/system/update.done";
+	if (versionFile.size() > 0) {
+		std::ifstream lvifs(versionFile);
+		if (lvifs.good()) {
+			std::string lastVersion;
+			std::getline(lvifs, lastVersion);
+			std::string currentVersion = getVersion();
+			if (lastVersion == currentVersion) {
+				return false;
+			}
+		}
+	}
+	return true;
 }
 
 bool ApiSystem::createLastVersionFileIfNotExisting() {
-    std::string versionFile = "/userdata/system/update.done";
+	std::string versionFile = "/userdata/system/update.done";
 
-    FILE *file;
-    if (file = fopen(versionFile.c_str(), "r")) {
-        fclose(file);
-        return true;
-    }
-    return updateLastVersionFile();
+	FILE *file;
+	if (file = fopen(versionFile.c_str(), "r")) {
+		fclose(file);
+		return true;
+	}
+	return updateLastVersionFile();
 }
 
 bool ApiSystem::updateLastVersionFile() {
-    std::string versionFile = "/userdata/system/update.done";
-    std::string currentVersion = getVersion();
-    std::ostringstream oss;
-    oss << "echo " << currentVersion << " > " << versionFile;
-    if (system(oss.str().c_str())) {
-        LOG(LogWarning) << "Error executing " << oss.str().c_str();
-        return false;
-    } else {
-        LOG(LogError) << "Last version file updated";
-        return true;
-    }
+	std::string versionFile = "/userdata/system/update.done";
+	std::string currentVersion = getVersion();
+	std::ostringstream oss;
+	oss << "echo " << currentVersion << " > " << versionFile;
+	if (system(oss.str().c_str())) {
+		LOG(LogWarning) << "Error executing " << oss.str().c_str();
+		return false;
+	}
+	else {
+		LOG(LogError) << "Last version file updated";
+		return true;
+	}
 }
 
 bool ApiSystem::setOverscan(bool enable) {
 
-    std::ostringstream oss;
-    oss << "batocera-config" << " " << "overscan";
-    if (enable) {
-        oss << " " << "enable";
-    } else {
-        oss << " " << "disable";
-    }
-    std::string command = oss.str();
-    LOG(LogInfo) << "Launching " << command;
-    if (system(command.c_str())) {
-        LOG(LogWarning) << "Error executing " << command;
-        return false;
-    } else {
-        LOG(LogInfo) << "Overscan set to : " << enable;
-        return true;
-    }
+	std::ostringstream oss;
+	oss << "batocera-config" << " " << "overscan";
+	if (enable) {
+		oss << " " << "enable";
+	}
+	else {
+		oss << " " << "disable";
+	}
+	std::string command = oss.str();
+	LOG(LogInfo) << "Launching " << command;
+	if (system(command.c_str())) {
+		LOG(LogWarning) << "Error executing " << command;
+		return false;
+	}
+	else {
+		LOG(LogInfo) << "Overscan set to : " << enable;
+		return true;
+	}
 
 }
 
 bool ApiSystem::setOverclock(std::string mode) {
-    if (mode != "") {
-        std::ostringstream oss;
-        oss << "batocera-overclock set " << mode;
-        std::string command = oss.str();
-        LOG(LogInfo) << "Launching " << command;
-        if (system(command.c_str())) {
-            LOG(LogWarning) << "Error executing " << command;
-            return false;
-        } else {
-            LOG(LogInfo) << "Overclocking set to " << mode;
-            return true;
-        }
-    }
+	if (mode != "") {
+		std::ostringstream oss;
+		oss << "batocera-overclock set " << mode;
+		std::string command = oss.str();
+		LOG(LogInfo) << "Launching " << command;
+		if (system(command.c_str())) {
+			LOG(LogWarning) << "Error executing " << command;
+			return false;
+		}
+		else {
+			LOG(LogInfo) << "Overclocking set to " << mode;
+			return true;
+		}
+	}
 
-    return false;
+	return false;
 }
 
 
-std::pair<std::string,int> ApiSystem::updateSystem(BusyComponent* ui) {
-  std::string updatecommand = "batocera-upgrade";
-    FILE *pipe = popen(updatecommand.c_str(), "r");
-    char line[1024] = "";
-    if (pipe == NULL) {
-        return std::pair<std::string,int>(std::string("Cannot call update command"),-1);
-    }
+std::pair<std::string, int> ApiSystem::updateSystem(BusyComponent* ui) {
+	std::string updatecommand = "batocera-upgrade";
+	FILE *pipe = popen(updatecommand.c_str(), "r");
+	char line[1024] = "";
+	if (pipe == NULL) {
+		return std::pair<std::string, int>(std::string("Cannot call update command"), -1);
+	}
 
-    FILE *flog = fopen("/userdata/system/logs/batocera-upgrade.log", "w");
-    while (fgets(line, 1024, pipe)) {
-        strtok(line, "\n");
-	if(flog != NULL) fprintf(flog, "%s\n", line);
-        ui->setText(std::string(line));
-    }
-    if(flog != NULL) fclose(flog);
+	FILE *flog = fopen("/userdata/system/logs/batocera-upgrade.log", "w");
+	while (fgets(line, 1024, pipe)) {
+		strtok(line, "\n");
+		if (flog != NULL) fprintf(flog, "%s\n", line);
+		ui->setText(std::string(line));
+	}
+	if (flog != NULL) fclose(flog);
 
-    int exitCode = pclose(pipe);
-    return std::pair<std::string,int>(std::string(line), exitCode);
+	int exitCode = pclose(pipe);
+	return std::pair<std::string, int>(std::string(line), exitCode);
 }
 
-std::pair<std::string,int> ApiSystem::backupSystem(BusyComponent* ui, std::string device) {
-    std::string updatecommand = std::string("batocera-sync sync ") + device;
-    FILE *pipe = popen(updatecommand.c_str(), "r");
-    char line[1024] = "";
-    if (pipe == NULL) {
-        return std::pair<std::string,int>(std::string("Cannot call sync command"),-1);
-    }
+std::pair<std::string, int> ApiSystem::backupSystem(BusyComponent* ui, std::string device) {
+	std::string updatecommand = std::string("batocera-sync sync ") + device;
+	FILE *pipe = popen(updatecommand.c_str(), "r");
+	char line[1024] = "";
+	if (pipe == NULL) {
+		return std::pair<std::string, int>(std::string("Cannot call sync command"), -1);
+	}
 
-    FILE *flog = fopen("/userdata/system/logs/batocera-sync.log", "w");
-    while (fgets(line, 1024, pipe)) {
-        strtok(line, "\n");
-	if(flog != NULL) fprintf(flog, "%s\n", line);
-        ui->setText(std::string(line));
-    }
-    if(flog != NULL) fclose(flog);
+	FILE *flog = fopen("/userdata/system/logs/batocera-sync.log", "w");
+	while (fgets(line, 1024, pipe)) {
+		strtok(line, "\n");
+		if (flog != NULL) fprintf(flog, "%s\n", line);
+		ui->setText(std::string(line));
+	}
+	if (flog != NULL) fclose(flog);
 
-    int exitCode = pclose(pipe);
-    return std::pair<std::string,int>(std::string(line), exitCode);
+	int exitCode = pclose(pipe);
+	return std::pair<std::string, int>(std::string(line), exitCode);
 }
 
-std::pair<std::string,int> ApiSystem::installSystem(BusyComponent* ui, std::string device, std::string architecture) {
-    std::string updatecommand = std::string("batocera-install install ") + device + " " + architecture;
-    FILE *pipe = popen(updatecommand.c_str(), "r");
-    char line[1024] = "";
-    if (pipe == NULL) {
-        return std::pair<std::string,int>(std::string("Cannot call install command"),-1);
-    }
+std::pair<std::string, int> ApiSystem::installSystem(BusyComponent* ui, std::string device, std::string architecture) {
+	std::string updatecommand = std::string("batocera-install install ") + device + " " + architecture;
+	FILE *pipe = popen(updatecommand.c_str(), "r");
+	char line[1024] = "";
+	if (pipe == NULL) {
+		return std::pair<std::string, int>(std::string("Cannot call install command"), -1);
+	}
 
-    FILE *flog = fopen("/userdata/system/logs/batocera-install.log", "w");
-    while (fgets(line, 1024, pipe)) {
-        strtok(line, "\n");
-	if(flog != NULL) fprintf(flog, "%s\n", line);
-        ui->setText(std::string(line));
-    }
-    if(flog != NULL) fclose(flog);
+	FILE *flog = fopen("/userdata/system/logs/batocera-install.log", "w");
+	while (fgets(line, 1024, pipe)) {
+		strtok(line, "\n");
+		if (flog != NULL) fprintf(flog, "%s\n", line);
+		ui->setText(std::string(line));
+	}
+	if (flog != NULL) fclose(flog);
 
-    int exitCode = pclose(pipe);
-    return std::pair<std::string,int>(std::string(line), exitCode);
+	int exitCode = pclose(pipe);
+	return std::pair<std::string, int>(std::string(line), exitCode);
 }
 
-std::pair<std::string,int> ApiSystem::scrape(BusyComponent* ui) {
-  std::string scrapecommand = std::string("batocera-scraper");
-  FILE *pipe = popen(scrapecommand.c_str(), "r");
-  char line[1024] = "";
-  if (pipe == NULL) {
-    return std::pair<std::string,int>(std::string("Cannot call scrape command"),-1);
-  }
-  
-  FILE *flog = fopen("/userdata/system/logs/batocera-scraper.log", "w");
-  while (fgets(line, 1024, pipe)) {
-    strtok(line, "\n");
-    if(flog != NULL) fprintf(flog, "%s\n", line);
+std::pair<std::string, int> ApiSystem::scrape(BusyComponent* ui) {
+	std::string scrapecommand = std::string("batocera-scraper");
+	FILE *pipe = popen(scrapecommand.c_str(), "r");
+	char line[1024] = "";
+	if (pipe == NULL) {
+		return std::pair<std::string, int>(std::string("Cannot call scrape command"), -1);
+	}
 
-    if(boost::starts_with(line, "GAME: ")) {
-      ui->setText(std::string(line));
-    }
-  }
-  if(flog != NULL) fclose(flog);
-  
-  int exitCode = pclose(pipe);
-  return std::pair<std::string,int>(std::string(line), exitCode);
+	FILE *flog = fopen("/userdata/system/logs/batocera-scraper.log", "w");
+	while (fgets(line, 1024, pipe)) {
+		strtok(line, "\n");
+		if (flog != NULL) fprintf(flog, "%s\n", line);
+
+
+		if (Utils::String::startsWith(line, "GAME: ")) {
+			ui->setText(std::string(line));
+		}
+	}
+	if (flog != NULL) fclose(flog);
+
+	int exitCode = pclose(pipe);
+	return std::pair<std::string, int>(std::string(line), exitCode);
 }
 
 bool ApiSystem::ping() {
-    std::string updateserver = "batocera-linux.xorhub.com";
-    std::string s("timeout 1 fping -c 1 -t 1000 " + updateserver);
-    int exitcode = system(s.c_str());
-    return exitcode == 0;
+	std::string updateserver = "batocera-linux.xorhub.com";
+	std::string s("timeout 1 fping -c 1 -t 1000 " + updateserver);
+	int exitcode = system(s.c_str());
+	return exitcode == 0;
 }
 
 bool ApiSystem::canUpdate(std::vector<std::string>& output) {
-    int res;
-    int exitCode;
-    std::ostringstream oss;
-    oss << "batocera-config" << " " << "canupdate";
-    std::string command = oss.str();
-    LOG(LogInfo) << "Launching " << command;
+	int res;
+	int exitCode;
+	std::ostringstream oss;
+	oss << "batocera-config" << " " << "canupdate";
+	std::string command = oss.str();
+	LOG(LogInfo) << "Launching " << command;
 
-    FILE *pipe = popen(oss.str().c_str(), "r");
-    char line[1024];
+	FILE *pipe = popen(oss.str().c_str(), "r");
+	char line[1024];
 
-    if (pipe == NULL) {
-      return false;
-    }
+	if (pipe == NULL) {
+		return false;
+	}
 
-    while (fgets(line, 1024, pipe)) {
-        strtok(line, "\n");
-        output.push_back(std::string(line));
-    }
-    exitCode = pclose(pipe);
-    res = WEXITSTATUS(exitCode);
+	while (fgets(line, 1024, pipe)) {
+		strtok(line, "\n");
+		output.push_back(std::string(line));
+	}
+	exitCode = pclose(pipe);
 
-    if (res == 0) {
-        LOG(LogInfo) << "Can update ";
-        return true;
-    } else {
-        LOG(LogInfo) << "Cannot update ";
-        return false;
-    }
+#ifdef WIN32
+	res = exitCode;
+#else
+	res = WEXITSTATUS(exitCode);
+#endif
+
+	if (res == 0) {
+		LOG(LogInfo) << "Can update ";
+		return true;
+	}
+	else {
+		LOG(LogInfo) << "Cannot update ";
+		return false;
+	}
 }
 
 void ApiSystem::launchExternalWindow_before(Window *window) {
-    AudioManager::getInstance()->deinit();
-    VolumeControl::getInstance()->deinit();
-    window->deinit();
+	AudioManager::getInstance()->deinit();
+	VolumeControl::getInstance()->deinit();
+	window->deinit();
 }
 
 void ApiSystem::launchExternalWindow_after(Window *window) {
-  window->init();
-  VolumeControl::getInstance()->init();
-  AudioManager::getInstance()->init();
-  window->normalizeNextUpdate();
+	window->init();
+	VolumeControl::getInstance()->init();
+	AudioManager::getInstance()->init();
+	window->normalizeNextUpdate();
 
-  if(SystemConf::getInstance()->get("audio.bgmusic") != "0") {
-    AudioManager::getInstance()->playRandomMusic();
-  }
+	if (SystemConf::getInstance()->get("audio.bgmusic") != "0") {
+		AudioManager::getInstance()->playRandomMusic();
+	}
 }
 
 bool ApiSystem::launchKodi(Window *window) {
-  std::string commandline = InputManager::getInstance()->configureEmulators();
-  std::string command = "python /usr/lib/python2.7/site-packages/configgen/emulatorlauncher.py -system kodi -rom '' " + commandline;
+	std::string commandline = InputManager::getInstance()->configureEmulators();
+	std::string command = "python /usr/lib/python2.7/site-packages/configgen/emulatorlauncher.py -system kodi -rom '' " + commandline;
 
-  ApiSystem::launchExternalWindow_before(window);
+	ApiSystem::launchExternalWindow_before(window);
 
-  int exitCode = system(command.c_str());
+	int exitCode = system(command.c_str());
 #if !defined(WIN32)
-    // WIFEXITED returns a nonzero value if the child process terminated normally with exit or _exit.
-    // https://www.gnu.org/software/libc/manual/html_node/Process-Completion-Status.html
-    if (WIFEXITED(exitCode)) {
-        exitCode = WEXITSTATUS(exitCode);
-    }
+	// WIFEXITED returns a nonzero value if the child process terminated normally with exit or _exit.
+	// https://www.gnu.org/software/libc/manual/html_node/Process-Completion-Status.html
+	if (WIFEXITED(exitCode)) {
+		exitCode = WEXITSTATUS(exitCode);
+	}
 #endif
 
-    ApiSystem::launchExternalWindow_after(window);
+	ApiSystem::launchExternalWindow_after(window);
 
-    // handle end of kodi
-    switch (exitCode) {
-        case 10: // reboot code
-            reboot();
-            return true;
-            break;
-        case 11: // shutdown code
-            shutdown();
-            return true;
-            break;
-    }
+	// handle end of kodi
+	switch (exitCode) {
+	case 10: // reboot code
+		reboot();
+		return true;
+		break;
+	case 11: // shutdown code
+		shutdown();
+		return true;
+		break;
+	}
 
-    return exitCode == 0;
+	return exitCode == 0;
 
 }
 
 bool ApiSystem::launchFileManager(Window *window) {
-    std::string command = "filemanagerlauncher";
+	std::string command = "filemanagerlauncher";
 
-    ApiSystem::launchExternalWindow_before(window);
+	ApiSystem::launchExternalWindow_before(window);
 
-    int exitCode = system(command.c_str());
+	int exitCode = system(command.c_str());
 #if !defined(WIN32)
-    if (WIFEXITED(exitCode)) {
-        exitCode = WEXITSTATUS(exitCode);
-    }
+	if (WIFEXITED(exitCode)) {
+		exitCode = WEXITSTATUS(exitCode);
+	}
 #endif
 
-    ApiSystem::launchExternalWindow_after(window);
+	ApiSystem::launchExternalWindow_after(window);
 
-    return exitCode == 0;
+	return exitCode == 0;
 }
 
 bool ApiSystem::enableWifi(std::string ssid, std::string key) {
-    std::ostringstream oss;
-    boost::replace_all(ssid, "\"", "\\\"");
-    boost::replace_all(key, "\"", "\\\"");
-    oss << "batocera-config" << " "
-    << "wifi" << " "
-    << "enable" << " \""
-    << ssid << "\" \"" << key << "\"";
-    std::string command = oss.str();
-    LOG(LogInfo) << "Launching " << command;
-    if (system(command.c_str()) == 0) {
-        LOG(LogInfo) << "Wifi enabled ";
-        return true;
-    } else {
-        LOG(LogInfo) << "Cannot enable wifi ";
-        return false;
-    }
+	std::ostringstream oss;
+
+	Utils::String::replace(ssid, "\"", "\\\"");
+	Utils::String::replace(key, "\"", "\\\"");
+
+	oss << "batocera-config" << " "
+		<< "wifi" << " "
+		<< "enable" << " \""
+		<< ssid << "\" \"" << key << "\"";
+	std::string command = oss.str();
+	LOG(LogInfo) << "Launching " << command;
+	if (system(command.c_str()) == 0) {
+		LOG(LogInfo) << "Wifi enabled ";
+		return true;
+	}
+	else {
+		LOG(LogInfo) << "Cannot enable wifi ";
+		return false;
+	}
 }
 
 bool ApiSystem::disableWifi() {
-    std::ostringstream oss;
-    oss << "batocera-config" << " "
-    << "wifi" << " "
-    << "disable";
-    std::string command = oss.str();
-    LOG(LogInfo) << "Launching " << command;
-    if (system(command.c_str()) == 0) {
-        LOG(LogInfo) << "Wifi disabled ";
-        return true;
-    } else {
-        LOG(LogInfo) << "Cannot disable wifi ";
-        return false;
-    }
+	std::ostringstream oss;
+	oss << "batocera-config" << " "
+		<< "wifi" << " "
+		<< "disable";
+	std::string command = oss.str();
+	LOG(LogInfo) << "Launching " << command;
+	if (system(command.c_str()) == 0) {
+		LOG(LogInfo) << "Wifi disabled ";
+		return true;
+	}
+	else {
+		LOG(LogInfo) << "Cannot disable wifi ";
+		return false;
+	}
 }
 
 
 bool ApiSystem::halt(bool reboot, bool fast) {
-    SDL_Event *quit = new SDL_Event();
-    if (fast)
-        if (reboot)
-            quit->type = SDL_FAST_QUIT | SDL_SYS_REBOOT;
-        else
-            quit->type = SDL_FAST_QUIT | SDL_SYS_SHUTDOWN;
-    else
-        if (reboot)
-            quit->type = SDL_QUIT | SDL_SYS_REBOOT;
-        else
-            quit->type = SDL_QUIT | SDL_SYS_SHUTDOWN;
-    SDL_PushEvent(quit);
-    return 0;
+	SDL_Event *quit = new SDL_Event();
+	if (fast)
+		if (reboot)
+			quit->type = SDL_FAST_QUIT | SDL_SYS_REBOOT;
+		else
+			quit->type = SDL_FAST_QUIT | SDL_SYS_SHUTDOWN;
+	else
+		if (reboot)
+			quit->type = SDL_QUIT | SDL_SYS_REBOOT;
+		else
+			quit->type = SDL_QUIT | SDL_SYS_SHUTDOWN;
+	SDL_PushEvent(quit);
+	return 0;
 }
 
 bool ApiSystem::reboot() {
-    return halt(true, false);
+	return halt(true, false);
 }
 
 bool ApiSystem::fastReboot() {
-    return halt(true, true);
+	return halt(true, true);
 }
 
 bool ApiSystem::shutdown() {
-    return halt(false, false);
+	return halt(false, false);
 }
 
 bool ApiSystem::fastShutdown() {
-    return halt(false, true);
+	return halt(false, true);
 }
 
 
 std::string ApiSystem::getIpAdress() {
 #if !defined(WIN32)
-    struct ifaddrs *ifAddrStruct = NULL;
-    struct ifaddrs *ifa = NULL;
-    void *tmpAddrPtr = NULL;
+	struct ifaddrs *ifAddrStruct = NULL;
+	struct ifaddrs *ifa = NULL;
+	void *tmpAddrPtr = NULL;
 
-    std::string result = "NOT CONNECTED";
-    getifaddrs(&ifAddrStruct);
+	std::string result = "NOT CONNECTED";
+	getifaddrs(&ifAddrStruct);
 
-    for (ifa = ifAddrStruct; ifa != NULL; ifa = ifa->ifa_next) {
-        if (!ifa->ifa_addr) {
-            continue;
-        }
-        if (ifa->ifa_addr->sa_family == AF_INET) { // check it is IP4
-            // is a valid IP4 Address
-            tmpAddrPtr = &((struct sockaddr_in *) ifa->ifa_addr)->sin_addr;
-            char addressBuffer[INET_ADDRSTRLEN];
-            inet_ntop(AF_INET, tmpAddrPtr, addressBuffer, INET_ADDRSTRLEN);
-            printf("%s IP Address %s\n", ifa->ifa_name, addressBuffer);
-            if (std::string(ifa->ifa_name).find("eth") != std::string::npos ||
-                std::string(ifa->ifa_name).find("wlan") != std::string::npos) {
-                result = std::string(addressBuffer);
-            }
-        }
-    }
-    // Seeking for ipv6 if no IPV4
-    if (result.compare("NOT CONNECTED") == 0) {
-        for (ifa = ifAddrStruct; ifa != NULL; ifa = ifa->ifa_next) {
-            if (!ifa->ifa_addr) {
-                continue;
-            }
-            if (ifa->ifa_addr->sa_family == AF_INET6) { // check it is IP6
-                // is a valid IP6 Address
-                tmpAddrPtr = &((struct sockaddr_in6 *) ifa->ifa_addr)->sin6_addr;
-                char addressBuffer[INET6_ADDRSTRLEN];
-                inet_ntop(AF_INET6, tmpAddrPtr, addressBuffer, INET6_ADDRSTRLEN);
-                printf("%s IP Address %s\n", ifa->ifa_name, addressBuffer);
-                if (std::string(ifa->ifa_name).find("eth") != std::string::npos ||
-                    std::string(ifa->ifa_name).find("wlan") != std::string::npos) {
-                    return std::string(addressBuffer);
-                }
-            }
-        }
-    }
-    if (ifAddrStruct != NULL) freeifaddrs(ifAddrStruct);
-    return result;
+	for (ifa = ifAddrStruct; ifa != NULL; ifa = ifa->ifa_next) {
+		if (!ifa->ifa_addr) {
+			continue;
+		}
+		if (ifa->ifa_addr->sa_family == AF_INET) { // check it is IP4
+			// is a valid IP4 Address
+			tmpAddrPtr = &((struct sockaddr_in *) ifa->ifa_addr)->sin_addr;
+			char addressBuffer[INET_ADDRSTRLEN];
+			inet_ntop(AF_INET, tmpAddrPtr, addressBuffer, INET_ADDRSTRLEN);
+			printf("%s IP Address %s\n", ifa->ifa_name, addressBuffer);
+			if (std::string(ifa->ifa_name).find("eth") != std::string::npos ||
+				std::string(ifa->ifa_name).find("wlan") != std::string::npos) {
+				result = std::string(addressBuffer);
+			}
+		}
+	}
+	// Seeking for ipv6 if no IPV4
+	if (result.compare("NOT CONNECTED") == 0) {
+		for (ifa = ifAddrStruct; ifa != NULL; ifa = ifa->ifa_next) {
+			if (!ifa->ifa_addr) {
+				continue;
+			}
+			if (ifa->ifa_addr->sa_family == AF_INET6) { // check it is IP6
+				// is a valid IP6 Address
+				tmpAddrPtr = &((struct sockaddr_in6 *) ifa->ifa_addr)->sin6_addr;
+				char addressBuffer[INET6_ADDRSTRLEN];
+				inet_ntop(AF_INET6, tmpAddrPtr, addressBuffer, INET6_ADDRSTRLEN);
+				printf("%s IP Address %s\n", ifa->ifa_name, addressBuffer);
+				if (std::string(ifa->ifa_name).find("eth") != std::string::npos ||
+					std::string(ifa->ifa_name).find("wlan") != std::string::npos) {
+					return std::string(addressBuffer);
+				}
+			}
+		}
+	}
+	if (ifAddrStruct != NULL) freeifaddrs(ifAddrStruct);
+	return result;
 #else
-    return std::string();
+	return std::string();
 #endif
 }
 
 bool ApiSystem::scanNewBluetooth() {
-    std::vector<std::string> *res = new std::vector<std::string>();
-    std::ostringstream oss;
-    oss << "batocera-bt-pair-device";
-    FILE *pipe = popen(oss.str().c_str(), "r");
-    char line[1024];
+	std::vector<std::string> *res = new std::vector<std::string>();
+	std::ostringstream oss;
+	oss << "batocera-bt-pair-device";
+	FILE *pipe = popen(oss.str().c_str(), "r");
+	char line[1024];
 
-    if (pipe == NULL) {
-        return false;
-    }
+	if (pipe == NULL) {
+		return false;
+	}
 
-    while (fgets(line, 1024, pipe)) {
-        strtok(line, "\n");
-        res->push_back(std::string(line));
-    }
+	while (fgets(line, 1024, pipe)) {
+		strtok(line, "\n");
+		res->push_back(std::string(line));
+	}
 
-    int exitCode = pclose(pipe);
-    return exitCode == 0;
+	int exitCode = pclose(pipe);
+	return exitCode == 0;
 }
 
-std::vector<std::string> ApiSystem::getAvailableStorageDevices() {
+std::vector<std::string> ApiSystem::getAvailableStorageDevices() 
+{
+	std::vector<std::string> res;
 
-    std::vector<std::string> res;
-    std::ostringstream oss;
-    oss << "batocera-config" << " " << "storage list";
-    FILE *pipe = popen(oss.str().c_str(), "r");
-    char line[1024];
+#if WIN32
+	res.push_back("DEFAULT");
+	return res;
+#endif
 
-    if (pipe == NULL) {
-        return res;
-    }
+	std::ostringstream oss;
+	oss << "batocera-config" << " " << "storage list";
+	FILE *pipe = popen(oss.str().c_str(), "r");
+	char line[1024];
 
-    while (fgets(line, 1024, pipe)) {
-        strtok(line, "\n");
-        res.push_back(std::string(line));
-    }
-    pclose(pipe);
+	if (pipe == NULL) {
+		return res;
+	}
 
-    return res;
+	while (fgets(line, 1024, pipe)) {
+		strtok(line, "\n");
+		res.push_back(std::string(line));
+	}
+	pclose(pipe);
+
+	return res;
 }
 
 std::vector<std::string> ApiSystem::getVideoModes() {
-  std::vector<std::string> res;
-  std::ostringstream oss;
-  oss << "batocera-resolution listModes";
-  FILE *pipe = popen(oss.str().c_str(), "r");
-  char line[1024];
-  
-  if (pipe == NULL) {
-    return res;
-  }
-  
-  while (fgets(line, 1024, pipe)) {
-    strtok(line, "\n");
-    res.push_back(std::string(line));
-  }
-  pclose(pipe);
+	std::vector<std::string> res;
+	std::ostringstream oss;
+	oss << "batocera-resolution listModes";
+	FILE *pipe = popen(oss.str().c_str(), "r");
+	char line[1024];
 
-  return res;
+	if (pipe == NULL) {
+		return res;
+	}
+
+	while (fgets(line, 1024, pipe)) {
+		strtok(line, "\n");
+		res.push_back(std::string(line));
+	}
+	pclose(pipe);
+
+	return res;
 }
 
 std::vector<std::string> ApiSystem::getAvailableBackupDevices() {
 
-    std::vector<std::string> res;
-    std::ostringstream oss;
-    oss << "batocera-sync list";
-    FILE *pipe = popen(oss.str().c_str(), "r");
-    char line[1024];
+	std::vector<std::string> res;
+	std::ostringstream oss;
+	oss << "batocera-sync list";
+	FILE *pipe = popen(oss.str().c_str(), "r");
+	char line[1024];
 
-    if (pipe == NULL) {
-        return res;
-    }
+	if (pipe == NULL) {
+		return res;
+	}
 
-    while (fgets(line, 1024, pipe)) {
-        strtok(line, "\n");
-        res.push_back(std::string(line));
-    }
-    pclose(pipe);
+	while (fgets(line, 1024, pipe)) {
+		strtok(line, "\n");
+		res.push_back(std::string(line));
+	}
+	pclose(pipe);
 
-    return res;
+	return res;
 }
 
 std::vector<std::string> ApiSystem::getAvailableInstallDevices() {
 
-    std::vector<std::string> res;
-    std::ostringstream oss;
-    oss << "batocera-install listDisks";
-    FILE *pipe = popen(oss.str().c_str(), "r");
-    char line[1024];
+	std::vector<std::string> res;
+	std::ostringstream oss;
+	oss << "batocera-install listDisks";
+	FILE *pipe = popen(oss.str().c_str(), "r");
+	char line[1024];
 
-    if (pipe == NULL) {
-        return res;
-    }
+	if (pipe == NULL) {
+		return res;
+	}
 
-    while (fgets(line, 1024, pipe)) {
-        strtok(line, "\n");
-        res.push_back(std::string(line));
-    }
-    pclose(pipe);
+	while (fgets(line, 1024, pipe)) {
+		strtok(line, "\n");
+		res.push_back(std::string(line));
+	}
+	pclose(pipe);
 
-    return res;
+	return res;
 }
 
 std::vector<std::string> ApiSystem::getAvailableInstallArchitectures() {
 
-    std::vector<std::string> res;
-    std::ostringstream oss;
-    oss << "batocera-install listArchs";
-    FILE *pipe = popen(oss.str().c_str(), "r");
-    char line[1024];
+	std::vector<std::string> res;
+	std::ostringstream oss;
+	oss << "batocera-install listArchs";
+	FILE *pipe = popen(oss.str().c_str(), "r");
+	char line[1024];
 
-    if (pipe == NULL) {
-        return res;
-    }
+	if (pipe == NULL) {
+		return res;
+	}
 
-    while (fgets(line, 1024, pipe)) {
-        strtok(line, "\n");
-        res.push_back(std::string(line));
-    }
-    pclose(pipe);
+	while (fgets(line, 1024, pipe)) {
+		strtok(line, "\n");
+		res.push_back(std::string(line));
+	}
+	pclose(pipe);
 
-    return res;
+	return res;
 }
 
 std::vector<std::string> ApiSystem::getAvailableOverclocking() {
-  std::vector<std::string> res;
-  std::ostringstream oss;
-  oss << "batocera-overclock list";
-  FILE *pipe = popen(oss.str().c_str(), "r");
-  char line[1024];
-  
-  if (pipe == NULL) {
-    return res;
-  }
-  
-  while (fgets(line, 1024, pipe)) {
-    strtok(line, "\n");
-    res.push_back(std::string(line));
-  }
-  pclose(pipe);
-  
-  return res;
+	std::vector<std::string> res;
+	std::ostringstream oss;
+	oss << "batocera-overclock list";
+	FILE *pipe = popen(oss.str().c_str(), "r");
+	char line[1024];
+
+	if (pipe == NULL) {
+		return res;
+	}
+
+	while (fgets(line, 1024, pipe)) {
+		strtok(line, "\n");
+		res.push_back(std::string(line));
+	}
+	pclose(pipe);
+
+	return res;
 }
 
 std::vector<std::string> ApiSystem::getSystemInformations() {
-    std::vector<std::string> res;
-    FILE *pipe = popen("batocera-info", "r");
-    char line[1024];
+	std::vector<std::string> res;
+	FILE *pipe = popen("batocera-info", "r");
+	char line[1024];
 
-    if (pipe == NULL) {
-      return res;
-    }
+	if (pipe == NULL) {
+		return res;
+	}
 
-    while(fgets(line, 1024, pipe)) {
-      strtok(line, "\n");
-      res.push_back(std::string(line));
-    }
-    pclose(pipe);
+	while (fgets(line, 1024, pipe)) {
+		strtok(line, "\n");
+		res.push_back(std::string(line));
+	}
+	pclose(pipe);
 
-    return res;
+	return res;
 }
 
 std::vector<BiosSystem> ApiSystem::getBiosInformations() {
-  std::vector<BiosSystem> res;
-  BiosSystem current;
-  bool isCurrent = false;
+	std::vector<BiosSystem> res;
+	BiosSystem current;
+	bool isCurrent = false;
 
-  FILE *pipe = popen("batocera-systems", "r");
-  char line[1024];
+	FILE *pipe = popen("batocera-systems", "r");
+	char line[1024];
 
-  if (pipe == NULL) {
-    return res;
-  }
-
-  while(fgets(line, 1024, pipe)) {
-    strtok(line, "\n");
-    if(boost::starts_with(line, "> ")) {
-      if(isCurrent) {
-	res.push_back(current);
-      }
-      isCurrent = true;
-      current.name = std::string(std::string(line).substr(2));
-      current.bios.clear();
-    } else {
-      BiosFile biosFile;
-      std::vector<std::string> tokens;
-      boost::split( tokens, line, boost::is_any_of(" "));
-
-      if(tokens.size() >= 3) {
-	biosFile.status = tokens.at(0);
-	biosFile.md5    = tokens.at(1);
-
-	// concatenat the ending words
-	std::string vname = "";
-	for(unsigned int i=2; i<tokens.size(); i++) {
-	  if(i > 2) vname += " ";
-	  vname += tokens.at(i);
+	if (pipe == NULL) {
+		return res;
 	}
-	biosFile.path = vname;
 
-	current.bios.push_back(biosFile);
-      }
-    }
-  }
-  if(isCurrent) {
-    res.push_back(current);
-  }
-  pclose(pipe);
-  return res;
+	while (fgets(line, 1024, pipe)) {
+		strtok(line, "\n");
+		if (Utils::String::startsWith(line, "> ")) {
+			if (isCurrent) {
+				res.push_back(current);
+			}
+			isCurrent = true;
+			current.name = std::string(std::string(line).substr(2));
+			current.bios.clear();
+		}
+		else {
+			BiosFile biosFile;
+			std::vector<std::string> tokens = Utils::String::split(line, ' ');
+			if (tokens.size() >= 3) {
+				biosFile.status = tokens.at(0);
+				biosFile.md5 = tokens.at(1);
+
+				// concatenat the ending words
+				std::string vname = "";
+				for (unsigned int i = 2; i < tokens.size(); i++) {
+					if (i > 2) vname += " ";
+					vname += tokens.at(i);
+				}
+				biosFile.path = vname;
+
+				current.bios.push_back(biosFile);
+			}
+		}
+	}
+	if (isCurrent) {
+		res.push_back(current);
+	}
+	pclose(pipe);
+	return res;
 }
 
 bool ApiSystem::generateSupportFile() {
 #if !defined(WIN32)
-  std::string cmd = "batocera-support";
-  int exitcode = system(cmd.c_str());
-  if (WIFEXITED(exitcode)) {
-    exitcode = WEXITSTATUS(exitcode);
-  }
-  return exitcode == 0;
+	std::string cmd = "batocera-support";
+	int exitcode = system(cmd.c_str());
+	if (WIFEXITED(exitcode)) {
+		exitcode = WEXITSTATUS(exitcode);
+	}
+	return exitcode == 0;
 #else
-    return false;
+	return false;
 #endif
 }
 
-std::string ApiSystem::getCurrentStorage() {
+std::string ApiSystem::getCurrentStorage() 
+{
+#if WIN32
+	return "DEFAULT";
+#endif
 
-    std::ostringstream oss;
-    oss << "batocera-config" << " " << "storage current";
-    FILE *pipe = popen(oss.str().c_str(), "r");
-    char line[1024];
+	std::ostringstream oss;
+	oss << "batocera-config" << " " << "storage current";
+	FILE *pipe = popen(oss.str().c_str(), "r");
+	char line[1024];
 
-    if (pipe == NULL) {
-        return "";
-    }
+	if (pipe == NULL) {
+		return "";
+	}
 
-    if (fgets(line, 1024, pipe)) {
-        strtok(line, "\n");
-        pclose(pipe);
-        return std::string(line);
-    }
-    return "INTERNAL";
+	if (fgets(line, 1024, pipe)) {
+		strtok(line, "\n");
+		pclose(pipe);
+		return std::string(line);
+	}
+	return "INTERNAL";
 }
 
 bool ApiSystem::setStorage(std::string selected) {
-    std::ostringstream oss;
-    oss << "batocera-config" << " " << "storage" << " " << selected;
-    int exitcode = system(oss.str().c_str());
-    return exitcode == 0;
+	std::ostringstream oss;
+	oss << "batocera-config" << " " << "storage" << " " << selected;
+	int exitcode = system(oss.str().c_str());
+	return exitcode == 0;
 }
 
 bool ApiSystem::forgetBluetoothControllers() {
-    std::ostringstream oss;
-    oss << "batocera-config" << " " << "forgetBT";
-    int exitcode = system(oss.str().c_str());
-    return exitcode == 0;
+	std::ostringstream oss;
+	oss << "batocera-config" << " " << "forgetBT";
+	int exitcode = system(oss.str().c_str());
+	return exitcode == 0;
 }
 
 std::string ApiSystem::getRootPassword() {
 
-    std::ostringstream oss;
-    oss << "batocera-config" << " " << "getRootPassword";
-    FILE *pipe = popen(oss.str().c_str(), "r");
-    char line[1024];
+	std::ostringstream oss;
+	oss << "batocera-config" << " " << "getRootPassword";
+	FILE *pipe = popen(oss.str().c_str(), "r");
+	char line[1024];
 
-    if (pipe == NULL) {
-        return "";
-    }
+	if (pipe == NULL) {
+		return "";
+	}
 
-    if(fgets(line, 1024, pipe)){
-        strtok(line, "\n");
-        pclose(pipe);
-        return std::string(line);
-    }
-    return oss.str().c_str();
+	if (fgets(line, 1024, pipe)) {
+		strtok(line, "\n");
+		pclose(pipe);
+		return std::string(line);
+	}
+	return oss.str().c_str();
 }
 
 std::vector<std::string> ApiSystem::getAvailableAudioOutputDevices() {
 
-    std::vector<std::string> res;
-    std::ostringstream oss;
-    oss << "batocera-config" << " " << "lsaudio";
-    FILE *pipe = popen(oss.str().c_str(), "r");
-    char line[1024];
+	std::vector<std::string> res;
+	std::ostringstream oss;
+	oss << "batocera-config" << " " << "lsaudio";
+	FILE *pipe = popen(oss.str().c_str(), "r");
+	char line[1024];
 
-    if (pipe == NULL) {
-        return res;
-    }
+	if (pipe == NULL) {
+		return res;
+	}
 
-    while (fgets(line, 1024, pipe)) {
-        strtok(line, "\n");
-        res.push_back(std::string(line));
-    }
-    pclose(pipe);
+	while (fgets(line, 1024, pipe)) {
+		strtok(line, "\n");
+		res.push_back(std::string(line));
+	}
+	pclose(pipe);
 
-    return res;
+	return res;
 }
 
 std::vector<std::string> ApiSystem::getAvailableVideoOutputDevices() {
 
-    std::vector<std::string> res;
-    std::ostringstream oss;
-    oss << "batocera-config" << " " << "lsoutputs";
-    FILE *pipe = popen(oss.str().c_str(), "r");
-    char line[1024];
+	std::vector<std::string> res;
+	std::ostringstream oss;
+	oss << "batocera-config" << " " << "lsoutputs";
+	FILE *pipe = popen(oss.str().c_str(), "r");
+	char line[1024];
 
-    if (pipe == NULL) {
-        return res;
-    }
+	if (pipe == NULL) {
+		return res;
+	}
 
-    while (fgets(line, 1024, pipe)) {
-        strtok(line, "\n");
-        res.push_back(std::string(line));
-    }
-    pclose(pipe);
+	while (fgets(line, 1024, pipe)) {
+		strtok(line, "\n");
+		res.push_back(std::string(line));
+	}
+	pclose(pipe);
 
-    return res;
+	return res;
 }
 
 std::string ApiSystem::getCurrentAudioOutputDevice() {
 
-    std::ostringstream oss;
-    oss << "batocera-config" << " " << "getaudio";
-    FILE *pipe = popen(oss.str().c_str(), "r");
-    char line[1024];
+	std::ostringstream oss;
+	oss << "batocera-config" << " " << "getaudio";
+	FILE *pipe = popen(oss.str().c_str(), "r");
+	char line[1024];
 
-    if (pipe == NULL) {
-        return "";
-    }
+	if (pipe == NULL) {
+		return "";
+	}
 
-    if (fgets(line, 1024, pipe)) {
-        strtok(line, "\n");
-        pclose(pipe);
-        return std::string(line);
-    }
-    return "";
+	if (fgets(line, 1024, pipe)) {
+		strtok(line, "\n");
+		pclose(pipe);
+		return std::string(line);
+	}
+	return "";
 }
 
 bool ApiSystem::setAudioOutputDevice(std::string selected) {
-    std::ostringstream oss;
+	std::ostringstream oss;
 
-    AudioManager::getInstance()->deinit();
-    VolumeControl::getInstance()->deinit();
+	AudioManager::getInstance()->deinit();
+	VolumeControl::getInstance()->deinit();
 
-    oss << "batocera-config" << " " << "audio" << " '" << selected << "'";
-    int exitcode = system(oss.str().c_str());
+	oss << "batocera-config" << " " << "audio" << " '" << selected << "'";
+	int exitcode = system(oss.str().c_str());
 
-    VolumeControl::getInstance()->init();
-    AudioManager::getInstance()->init();
-    Sound::get("/usr/share/emulationstation/resources/checksound.ogg")->play();
+	VolumeControl::getInstance()->init();
+	AudioManager::getInstance()->init();
+	Sound::get("/usr/share/emulationstation/resources/checksound.ogg")->play();
 
-    return exitcode == 0;
+	return exitcode == 0;
 }
 
 // Batocera
 std::vector<std::string> ApiSystem::getRetroAchievements() {
 
-    std::vector<std::string> res;
-    std::ostringstream oss;
-    oss << "batocera-retroachievements-info" ;
-    FILE *pipe = popen(oss.str().c_str(), "r");
-    char line[1024];
+	std::vector<std::string> res;
+	std::ostringstream oss;
+	oss << "batocera-retroachievements-info";
+	FILE *pipe = popen(oss.str().c_str(), "r");
+	char line[1024];
 
-    if (pipe == NULL) {
-        return res;
-    }
+	if (pipe == NULL) {
+		return res;
+	}
 
-    while (fgets(line, 1024, pipe)) {
-        strtok(line, "\n");
-	res.push_back(std::string(line));
-    }
-    pclose(pipe);
-    return res;
+	while (fgets(line, 1024, pipe)) {
+		strtok(line, "\n");
+		res.push_back(std::string(line));
+	}
+	pclose(pipe);
+	return res;
 }
 
 std::vector<std::string> ApiSystem::getBatoceraThemesList() {
-    std::vector<std::string> res;
-    std::ostringstream oss;
-    oss << "batocera-es-theme" << " " << "list";
-    FILE *pipe = popen(oss.str().c_str(), "r");
-    char line[1024];
-    char *pch;
+	std::vector<std::string> res;
+	std::ostringstream oss;
+	oss << "batocera-es-theme" << " " << "list";
+	FILE *pipe = popen(oss.str().c_str(), "r");
+	char line[1024];
+	char *pch;
 
-    if (pipe == NULL) {
-        return res;
-    }
-    while (fgets(line, 1024, pipe)) {
-        strtok(line, "\n");
-        // provide only themes that are [A]vailable or [I]nstalled as a result
-        // (Eliminate [?] and other non-installable lines of text)
-        if ((strncmp(line,"[A]",3) == 0) || (strncmp(line,"[I]",3) == 0))
-                res.push_back(std::string(line));
-    }
-    pclose(pipe);
-    return res;
+	if (pipe == NULL) {
+		return res;
+	}
+	while (fgets(line, 1024, pipe)) {
+		strtok(line, "\n");
+		// provide only themes that are [A]vailable or [I]nstalled as a result
+		// (Eliminate [?] and other non-installable lines of text)
+		if ((strncmp(line, "[A]", 3) == 0) || (strncmp(line, "[I]", 3) == 0))
+			res.push_back(std::string(line));
+	}
+	pclose(pipe);
+	return res;
 }
 
-std::pair<std::string,int> ApiSystem::installBatoceraTheme(BusyComponent* ui, std::string thname) {
-    std::string updatecommand = std::string("batocera-es-theme install ") + thname;
-    LOG(LogWarning) << "Installing theme " << thname;
-    FILE *pipe = popen(updatecommand.c_str(), "r");
-    char line[1024] = "";
-    if (pipe == NULL) {
-        return std::pair<std::string,int>(std::string("Error starting `batocera-es-theme` command."),-1);
-    }
+std::pair<std::string, int> ApiSystem::installBatoceraTheme(BusyComponent* ui, std::string thname) {
+	std::string updatecommand = std::string("batocera-es-theme install ") + thname;
+	LOG(LogWarning) << "Installing theme " << thname;
+	FILE *pipe = popen(updatecommand.c_str(), "r");
+	char line[1024] = "";
+	if (pipe == NULL) {
+		return std::pair<std::string, int>(std::string("Error starting `batocera-es-theme` command."), -1);
+	}
 
-    while (fgets(line, 1024, pipe)) {
-        strtok(line, "\n");
-        LOG(LogWarning) << "Theme install: " << line;
-	// Long theme names/URL can crash the GUI MsgBox
-	// "48" found by trials and errors. Ideally should be fixed
-	// in es-core MsgBox -- FIXME
-	if (strlen(line)>48)
-		line[47]='\0';
-        ui->setText(std::string(line));
-    }
+	while (fgets(line, 1024, pipe)) {
+		strtok(line, "\n");
+		LOG(LogWarning) << "Theme install: " << line;
+		// Long theme names/URL can crash the GUI MsgBox
+		// "48" found by trials and errors. Ideally should be fixed
+		// in es-core MsgBox -- FIXME
+		if (strlen(line) > 48)
+			line[47] = '\0';
+		ui->setText(std::string(line));
+	}
 
-    int exitCode = pclose(pipe);
-    return std::pair<std::string,int>(std::string(line), exitCode);
+	int exitCode = pclose(pipe);
+	return std::pair<std::string, int>(std::string(line), exitCode);
 }
 
 
 std::vector<std::string> ApiSystem::getBatoceraBezelsList() {
-    std::vector<std::string> res;
-    std::ostringstream oss;
-    oss << "batocera-es-thebezelproject list";
-    FILE *pipe = popen(oss.str().c_str(), "r");
-    char line[1024];
-    char *pch;
+	std::vector<std::string> res;
+	std::ostringstream oss;
+	oss << "batocera-es-thebezelproject list";
+	FILE *pipe = popen(oss.str().c_str(), "r");
+	char line[1024];
+	char *pch;
 
-    if (pipe == NULL) {
-        return res;
-    }
-    while (fgets(line, 1024, pipe)) {
-        strtok(line, "\n");
-        // provide only themes that are [A]vailable or [I]nstalled as a result
-        // (Eliminate [?] and other non-installable lines of text)
-        if ((strncmp(line,"[A]",3) == 0) || (strncmp(line,"[I]",3) == 0))
-                res.push_back(std::string(line));
-    }
-    pclose(pipe);
-    return res;
+	if (pipe == NULL) {
+		return res;
+	}
+	while (fgets(line, 1024, pipe)) {
+		strtok(line, "\n");
+		// provide only themes that are [A]vailable or [I]nstalled as a result
+		// (Eliminate [?] and other non-installable lines of text)
+		if ((strncmp(line, "[A]", 3) == 0) || (strncmp(line, "[I]", 3) == 0))
+			res.push_back(std::string(line));
+	}
+	pclose(pipe);
+	return res;
 }
 
-std::pair<std::string,int> ApiSystem::installBatoceraBezel(BusyComponent* ui, std::string bezelsystem) {
-    std::string updatecommand = std::string("batocera-es-thebezelproject install ") + bezelsystem;
-    LOG(LogWarning) << "Installing bezels for " << bezelsystem;
-    FILE *pipe = popen(updatecommand.c_str(), "r");
-    char line[1024] = "";
-    if (pipe == NULL) {
-        return std::pair<std::string,int>(std::string("Error starting `batocera-es-thebezelproject install` command."),-1);
-    }
+std::pair<std::string, int> ApiSystem::installBatoceraBezel(BusyComponent* ui, std::string bezelsystem) {
+	std::string updatecommand = std::string("batocera-es-thebezelproject install ") + bezelsystem;
+	LOG(LogWarning) << "Installing bezels for " << bezelsystem;
+	FILE *pipe = popen(updatecommand.c_str(), "r");
+	char line[1024] = "";
+	if (pipe == NULL) {
+		return std::pair<std::string, int>(std::string("Error starting `batocera-es-thebezelproject install` command."), -1);
+	}
 
-    while (fgets(line, 1024, pipe)) {
-        strtok(line, "\n");
-        // Long theme names/URL can crash the GUI MsgBox
-        // "48" found by trials and errors. Ideally should be fixed
-        // in es-core MsgBox -- FIXME
-        if (strlen(line)>48)
-                line[47]='\0';
-        ui->setText(std::string(line));
-    }
+	while (fgets(line, 1024, pipe)) {
+		strtok(line, "\n");
+		// Long theme names/URL can crash the GUI MsgBox
+		// "48" found by trials and errors. Ideally should be fixed
+		// in es-core MsgBox -- FIXME
+		if (strlen(line) > 48)
+			line[47] = '\0';
+		ui->setText(std::string(line));
+	}
 
-    int exitCode = pclose(pipe);
-    return std::pair<std::string,int>(std::string(line), exitCode);
+	int exitCode = pclose(pipe);
+	return std::pair<std::string, int>(std::string(line), exitCode);
 }
 
-std::pair<std::string,int> ApiSystem::uninstallBatoceraBezel(BusyComponent* ui, std::string bezelsystem) {
-    std::string updatecommand = std::string("batocera-es-thebezelproject remove ") + bezelsystem;
-    LOG(LogWarning) << "Removing bezels for " << bezelsystem;
-    FILE *pipe = popen(updatecommand.c_str(), "r");
-    char line[1024] = "";
-    if (pipe == NULL) {
-        return std::pair<std::string,int>(std::string("Error starting `batocera-es-thebezelproject remove` command."),-1); 
-    }
+std::pair<std::string, int> ApiSystem::uninstallBatoceraBezel(BusyComponent* ui, std::string bezelsystem) {
+	std::string updatecommand = std::string("batocera-es-thebezelproject remove ") + bezelsystem;
+	LOG(LogWarning) << "Removing bezels for " << bezelsystem;
+	FILE *pipe = popen(updatecommand.c_str(), "r");
+	char line[1024] = "";
+	if (pipe == NULL) {
+		return std::pair<std::string, int>(std::string("Error starting `batocera-es-thebezelproject remove` command."), -1);
+	}
 
-    while (fgets(line, 1024, pipe)) {
-        strtok(line, "\n");
-        // Long theme names/URL can crash the GUI MsgBox
-        // "48" found by trials and errors. Ideally should be fixed
-        // in es-core MsgBox -- FIXME
-        if (strlen(line)>48)
-                line[47]='\0';
-        ui->setText(std::string(line));
-    }
+	while (fgets(line, 1024, pipe)) {
+		strtok(line, "\n");
+		// Long theme names/URL can crash the GUI MsgBox
+		// "48" found by trials and errors. Ideally should be fixed
+		// in es-core MsgBox -- FIXME
+		if (strlen(line) > 48)
+			line[47] = '\0';
+		ui->setText(std::string(line));
+	}
 
-    int exitCode = pclose(pipe);
-    return std::pair<std::string,int>(std::string(line), exitCode);
+	int exitCode = pclose(pipe);
+	return std::pair<std::string, int>(std::string(line), exitCode);
 }

--- a/es-app/src/CollectionSystemManager.cpp
+++ b/es-app/src/CollectionSystemManager.cpp
@@ -1045,7 +1045,6 @@ bool CollectionSystemManager::includeFileInAutoCollections(FileData* file)
 	return file->getName() != "kodi" && file->getSystem()->isGameSystem();
 }
 
-
 std::string getCustomCollectionConfigPath(std::string collectionName)
 {
 	return getCollectionsFolder() + "/custom-" + collectionName + ".cfg";
@@ -1053,7 +1052,7 @@ std::string getCustomCollectionConfigPath(std::string collectionName)
 
 std::string getCollectionsFolder()
 {
-	return Utils::FileSystem::getGenericPath("/userdata/system/configs/emulationstation/collections"); // batocera
+	return Utils::FileSystem::getGenericPath(Utils::FileSystem::getEsConfigPath() + "/collections");
 }
 
 bool systemSort(SystemData* sys1, SystemData* sys2)

--- a/es-app/src/NetworkThread.cpp
+++ b/es-app/src/NetworkThread.cpp
@@ -4,39 +4,49 @@
 #include "guis/GuiMsgBox.h"
 #include "LocaleES.h"
 
-NetworkThread::NetworkThread(Window* window) : mWindow(window){
-    
+#include <chrono>
+#include <thread>
+
+NetworkThread::NetworkThread(Window* window) : mWindow(window)
+{    
     // creer le thread
     mFirstRun = true;
     mRunning = true;
-    mThreadHandle = new boost::thread(boost::bind(&NetworkThread::run, this));
-
+	mThread = new std::thread(&NetworkThread::run, this);
 }
 
-NetworkThread::~NetworkThread() {
-    	mThreadHandle->join();
+NetworkThread::~NetworkThread() 
+{
+	mThread->join();
+	delete mThread;
 }
 
-void NetworkThread::run(){
-    while(mRunning){
-        if(mFirstRun){
-            boost::this_thread::sleep(boost::posix_time::seconds(15));
-            mFirstRun = false;
-        }else {
-            boost::this_thread::sleep(boost::posix_time::hours(1));
-        }
-	if(SystemConf::getInstance()->get("updates.enabled") == "1") {
-	  std::vector<std::string> msgtbl;
-	  if(ApiSystem::getInstance()->canUpdate(msgtbl)){
-	    std::string msg = "";
-	    for(int i=0; i<msgtbl.size(); i++) {
-	      if(i != 0) msg += "\n";
-	      msg += msgtbl[i];
-	    }
-	    mWindow->displayMessage(_("UPDATE AVAILABLE") + std::string(": ") + msg);
-	    mRunning = false;
-	  }
+void NetworkThread::run() 
+{
+	while (mRunning) 
+	{
+		if (mFirstRun) 
+		{
+			std::this_thread::sleep_for(std::chrono::seconds(15));
+			mFirstRun = false;
+		}
+		else
+			std::this_thread::sleep_for(std::chrono::hours(1));		
+
+		if (SystemConf::getInstance()->get("updates.enabled") == "1") 
+		{
+			std::vector<std::string> msgtbl;
+			if (ApiSystem::getInstance()->canUpdate(msgtbl)) 
+			{
+				std::string msg = "";
+				for (int i = 0; i < msgtbl.size(); i++)
+				{
+					if (i != 0) msg += "\n";
+					msg += msgtbl[i];
+				}
+				mWindow->displayMessage(_("UPDATE AVAILABLE") + std::string(": ") + msg);
+				mRunning = false;
+			}
+		}
 	}
-    }
 }
-

--- a/es-app/src/NetworkThread.h
+++ b/es-app/src/NetworkThread.h
@@ -1,17 +1,20 @@
 #pragma once
 
 #include "Window.h"
-#include <boost/thread.hpp>
+#include <thread>
 
-class NetworkThread {
+class NetworkThread 
+{
 public:
     NetworkThread(Window * window);
     virtual ~NetworkThread();
+
 private:
-    Window* mWindow;
-    bool mRunning;
-    bool mFirstRun;
-    boost::thread * mThreadHandle;
+    Window*			mWindow;
+    bool			mRunning;
+    bool			mFirstRun;
+	std::thread*	mThread;
+
     void run();
 };
 

--- a/es-app/src/SystemData.cpp
+++ b/es-app/src/SystemData.cpp
@@ -355,7 +355,7 @@ void SystemData::deleteSystems()
 
 std::string SystemData::getConfigPath(bool forWrite)
 {
-	std::string path = "/userdata/system/configs/emulationstation/es_systems.cfg"; // batocera
+	std::string path = Utils::FileSystem::getEsConfigPath() + "/es_systems.cfg"; // batocera
 	if(forWrite || Utils::FileSystem::exists(path))
 		return path;
 

--- a/es-app/src/components/AsyncReqComponent.cpp
+++ b/es-app/src/components/AsyncReqComponent.cpp
@@ -13,7 +13,7 @@ AsyncReqComponent::AsyncReqComponent(Window* window, std::shared_ptr<HttpReq> re
 
 bool AsyncReqComponent::input(InputConfig* config, Input input)
 {
-	if(input.value != 0 && config->isMappedTo("a", input)) // batocera
+	if(input.value != 0 && config->isMappedTo(BUTTON_BACK, input))
 	{
 		if(mCancelFunc)
 			mCancelFunc();
@@ -49,6 +49,6 @@ void AsyncReqComponent::render(const Transform4x4f& /*parentTrans*/)
 std::vector<HelpPrompt> AsyncReqComponent::getHelpPrompts()
 {
 	std::vector<HelpPrompt> prompts;
-	prompts.push_back(HelpPrompt("a", _("CANCEL"))); // batocera
+	prompts.push_back(HelpPrompt(BUTTON_BACK, _("CANCEL")));
 	return prompts;
 }

--- a/es-app/src/components/RatingComponent.cpp
+++ b/es-app/src/components/RatingComponent.cpp
@@ -146,7 +146,7 @@ void RatingComponent::render(const Transform4x4f& parentTrans)
 
 bool RatingComponent::input(InputConfig* config, Input input)
 {
-	if(config->isMappedTo("b", input) && input.value != 0) // batocera
+	if(config->isMappedTo(BUTTON_OK, input) && input.value != 0)
 	{
 		mValue += 1.f / NUM_RATING_STARS;
 		if(mValue > 1.0f)
@@ -191,6 +191,6 @@ void RatingComponent::applyTheme(const std::shared_ptr<ThemeData>& theme, const 
 std::vector<HelpPrompt> RatingComponent::getHelpPrompts()
 {
 	std::vector<HelpPrompt> prompts;
-	prompts.push_back(HelpPrompt("b", "add star"));  // batocera
+	prompts.push_back(HelpPrompt(BUTTON_OK, "add star"));
 	return prompts;
 }

--- a/es-app/src/components/ScraperSearchComponent.cpp
+++ b/es-app/src/components/ScraperSearchComponent.cpp
@@ -343,7 +343,7 @@ void ScraperSearchComponent::updateInfoPane()
 
 bool ScraperSearchComponent::input(InputConfig* config, Input input)
 {
-	if(config->isMappedTo("b", input) && input.value != 0) // batocera
+	if(config->isMappedTo(BUTTON_OK, input) && input.value != 0)
 	{
 		if(mBlockAccept)
 			return true;
@@ -476,7 +476,7 @@ std::vector<HelpPrompt> ScraperSearchComponent::getHelpPrompts()
 {
 	std::vector<HelpPrompt> prompts = mGrid.getHelpPrompts();
 	if(getSelectedIndex() != -1)
-		prompts.push_back(HelpPrompt("b", _("ACCEPT RESULT"))); // batocera
+		prompts.push_back(HelpPrompt(BUTTON_OK, _("ACCEPT RESULT")));
 	
 	return prompts;
 }

--- a/es-app/src/guis/GuiAutoScrape.cpp
+++ b/es-app/src/guis/GuiAutoScrape.cpp
@@ -6,7 +6,6 @@
 #include "SystemData.h"
 
 #include "Window.h"
-#include <boost/thread.hpp>
 #include <string>
 #include "Log.h"
 #include "Settings.h"
@@ -62,7 +61,7 @@ void GuiAutoScrape::update(int deltaTime) {
 
         if(mState == 1){
 	  mLoading = true;
-	  mHandle = new boost::thread(boost::bind(&GuiAutoScrape::threadAutoScrape, this));
+	  mHandle = new std::thread(&GuiAutoScrape::threadAutoScrape, this);
 	  mState = 0;
         }
 	

--- a/es-app/src/guis/GuiAutoScrape.h
+++ b/es-app/src/guis/GuiAutoScrape.h
@@ -4,8 +4,7 @@
 #include "components/MenuComponent.h"
 #include "components/BusyComponent.h"
 
-
-#include <boost/thread.hpp>
+#include <thread>
 
 class GuiAutoScrape : public GuiComponent {
 public:
@@ -27,7 +26,7 @@ private:
     int mState;
     std::pair<std::string, int> mResult;
 
-    boost::thread *mHandle;
+    std::thread *mHandle;
 
     void onAutoScrapeError(std::pair<std::string, int>);
 

--- a/es-app/src/guis/GuiBackup.cpp
+++ b/es-app/src/guis/GuiBackup.cpp
@@ -2,7 +2,6 @@
 #include "guis/GuiMsgBox.h"
 
 #include "Window.h"
-#include <boost/thread.hpp>
 #include <string>
 #include "Log.h"
 #include "Settings.h"
@@ -53,7 +52,7 @@ void GuiBackup::update(int deltaTime) {
         Window* window = mWindow;
         if(mState == 1){
 	  mLoading = true;
-	  mHandle = new boost::thread(boost::bind(&GuiBackup::threadBackup, this));
+	  mHandle = new std::thread(&GuiBackup::threadBackup, this);
 	  mState = 0;
         }
 

--- a/es-app/src/guis/GuiBackup.h
+++ b/es-app/src/guis/GuiBackup.h
@@ -4,8 +4,7 @@
 #include "components/MenuComponent.h"
 #include "components/BusyComponent.h"
 
-
-#include <boost/thread.hpp>
+#include <thread>
 
 class GuiBackup : public GuiComponent {
 public:
@@ -29,7 +28,7 @@ private:
 
     std::string mstorageDevice;
     
-    boost::thread *mHandle;
+    std::thread *mHandle;
 
     void onBackupError(std::pair<std::string, int>);
 

--- a/es-app/src/guis/GuiBezelInstall.cpp
+++ b/es-app/src/guis/GuiBezelInstall.cpp
@@ -1,7 +1,6 @@
 #include "guis/GuiBackup.h"
 #include "guis/GuiMsgBox.h"
 #include "Window.h"
-#include <boost/thread.hpp>
 #include <string>
 #include "Log.h"
 #include "Settings.h"
@@ -54,7 +53,7 @@ void GuiBezelInstall::update(int deltaTime) {
         Window* window = mWindow;
         if(mState == 1){
 	  mLoading = true;
-	  mHandle = new boost::thread(boost::bind(&GuiBezelInstall::threadBezel, this));
+	  mHandle = new std::thread(&GuiBezelInstall::threadBezel, this);
 	  mState = 0;
         }
 
@@ -156,7 +155,7 @@ void GuiBezelUninstall::update(int deltaTime) {
         Window* window = mWindow;
         if(mState == 1){
 	  mLoading = true;
-	  mHandle = new boost::thread(boost::bind(&GuiBezelUninstall::threadBezel, this));
+	  mHandle = new std::thread(&GuiBezelUninstall::threadBezel, this);
 	  mState = 0;
         }
 

--- a/es-app/src/guis/GuiBezelInstall.h
+++ b/es-app/src/guis/GuiBezelInstall.h
@@ -4,7 +4,7 @@
 #include "components/MenuComponent.h"
 #include "components/BusyComponent.h"
 
-#include <boost/thread.hpp>
+#include <thread>
 
 class GuiBezelInstall : public GuiComponent {
 public:
@@ -28,7 +28,7 @@ private:
 
     std::string mBezelName;
     
-    boost::thread *mHandle;
+    std::thread *mHandle;
 
     void onInstallError(std::pair<std::string, int>);
 
@@ -60,7 +60,7 @@ private:
 
     std::string mBezelName;
     
-    boost::thread *mHandle;
+    std::thread *mHandle;
 
     void onInstallError(std::pair<std::string, int>);
 

--- a/es-app/src/guis/GuiBezelInstallStart.cpp
+++ b/es-app/src/guis/GuiBezelInstallStart.cpp
@@ -4,9 +4,6 @@
 #include "components/OptionListComponent.h"
 #include "guis/GuiBezelInstall.h"
 #include "guis/GuiSettings.h"
-#include <boost/algorithm/string/predicate.hpp>
-#include <boost/algorithm/string/split.hpp>
-#include <boost/algorithm/string/classification.hpp>
 #include "views/ViewController.h"
 #include "SystemData.h"
 
@@ -51,7 +48,7 @@ bool GuiBezelInstallMenu::input(InputConfig* config, Input input)
 	if(consumed)
 		return true;
 	
-	if(input.value != 0 && config->isMappedTo("a", input))
+	if(input.value != 0 && config->isMappedTo(BUTTON_BACK, input))
 	{
 		delete this;
 		return true;
@@ -69,7 +66,7 @@ bool GuiBezelInstallMenu::input(InputConfig* config, Input input)
 std::vector<HelpPrompt> GuiBezelInstallMenu::getHelpPrompts()
 {
         std::vector<HelpPrompt> prompts = mMenu.getHelpPrompts();
-        prompts.push_back(HelpPrompt("a", _("BACK")));
+        prompts.push_back(HelpPrompt(BUTTON_BACK, _("BACK")));
         prompts.push_back(HelpPrompt("start", _("CLOSE")));
         return prompts;
 }
@@ -133,7 +130,7 @@ bool GuiBezelInstallStart::input(InputConfig* config, Input input)
 	if(consumed)
 		return true;
 	
-	if(input.value != 0 && config->isMappedTo("a", input))
+	if(input.value != 0 && config->isMappedTo(BUTTON_BACK, input))
 	{
 		delete this;
 		return true;
@@ -151,7 +148,7 @@ bool GuiBezelInstallStart::input(InputConfig* config, Input input)
 std::vector<HelpPrompt> GuiBezelInstallStart::getHelpPrompts()
 {
         std::vector<HelpPrompt> prompts = mMenu.getHelpPrompts();
-        prompts.push_back(HelpPrompt("a", _("BACK")));
+        prompts.push_back(HelpPrompt(BUTTON_BACK, _("BACK")));
         prompts.push_back(HelpPrompt("start", _("CLOSE")));
 	return prompts;
 }
@@ -227,7 +224,7 @@ bool GuiBezelUninstallStart::input(InputConfig* config, Input input)
 	if(consumed)
 		return true;
 	
-	if(input.value != 0 && config->isMappedTo("a", input))
+	if(input.value != 0 && config->isMappedTo(BUTTON_BACK, input))
 	{
 		delete this;
 		return true;
@@ -245,7 +242,7 @@ bool GuiBezelUninstallStart::input(InputConfig* config, Input input)
 std::vector<HelpPrompt> GuiBezelUninstallStart::getHelpPrompts()
 {
         std::vector<HelpPrompt> prompts = mMenu.getHelpPrompts();
-        prompts.push_back(HelpPrompt("a", _("BACK")));
+        prompts.push_back(HelpPrompt(BUTTON_BACK, _("BACK")));
         prompts.push_back(HelpPrompt("start", _("CLOSE")));
 	return prompts;
 }

--- a/es-app/src/guis/GuiCollectionSystemsOptions.cpp
+++ b/es-app/src/guis/GuiCollectionSystemsOptions.cpp
@@ -202,11 +202,8 @@ bool GuiCollectionSystemsOptions::input(InputConfig* config, Input input)
 	if(consumed)
 		return true;
 
-	if(config->isMappedTo("a", input) && input.value != 0) // batocera
-	{
+	if(config->isMappedTo(BUTTON_BACK, input) && input.value != 0)
 		applySettings();
-	}
-
 
 	return false;
 }
@@ -214,6 +211,6 @@ bool GuiCollectionSystemsOptions::input(InputConfig* config, Input input)
 std::vector<HelpPrompt> GuiCollectionSystemsOptions::getHelpPrompts()
 {
 	std::vector<HelpPrompt> prompts = mMenu.getHelpPrompts();
-	prompts.push_back(HelpPrompt("a", _("BACK"))); // batocera
+	prompts.push_back(HelpPrompt(BUTTON_BACK, _("BACK")));
 	return prompts;
 }

--- a/es-app/src/guis/GuiGameScraper.cpp
+++ b/es-app/src/guis/GuiGameScraper.cpp
@@ -95,7 +95,7 @@ void GuiGameScraper::onSizeChanged()
 
 bool GuiGameScraper::input(InputConfig* config, Input input)
 {
-	if(config->isMappedTo("a", input) && input.value) // batocera
+	if(config->isMappedTo(BUTTON_BACK, input) && input.value)
 	{
 		PowerSaver::resume();
 		delete this;

--- a/es-app/src/guis/GuiGamelistFilter.cpp
+++ b/es-app/src/guis/GuiGamelistFilter.cpp
@@ -100,11 +100,8 @@ bool GuiGamelistFilter::input(InputConfig* config, Input input)
 	if(consumed)
 		return true;
 
-	if(config->isMappedTo("a", input) && input.value != 0) // batocera
-	{
+	if(config->isMappedTo(BUTTON_BACK, input) && input.value != 0)
 		applyFilters();
-	}
-
 
 	return false;
 }
@@ -112,6 +109,6 @@ bool GuiGamelistFilter::input(InputConfig* config, Input input)
 std::vector<HelpPrompt> GuiGamelistFilter::getHelpPrompts()
 {
 	std::vector<HelpPrompt> prompts = mMenu.getHelpPrompts();
-	prompts.push_back(HelpPrompt("a", _("BACK"))); // batocera
+	prompts.push_back(HelpPrompt(BUTTON_BACK, _("BACK")));
 	return prompts;
 }

--- a/es-app/src/guis/GuiGamelistOptions.cpp
+++ b/es-app/src/guis/GuiGamelistOptions.cpp
@@ -54,8 +54,9 @@ GuiGamelistOptions::GuiGamelistOptions(Window* window, SystemData* system) : Gui
 
 		row.addElement(std::make_shared<TextComponent>(mWindow, _("JUMP TO..."), Font::get(FONT_SIZE_MEDIUM), 0x777777FF), true); // batocera
 		row.addElement(mJumpToLetterList, false);
-		row.input_handler = [&](InputConfig* config, Input input) {
-		  if(config->isMappedTo("b", input) && input.value) // batocera
+		row.input_handler = [&](InputConfig* config, Input input) 
+		{
+		  if(config->isMappedTo(BUTTON_OK, input) && input.value)
 			{
 				jumpToLetter();
 				return true;
@@ -250,7 +251,7 @@ void GuiGamelistOptions::jumpToLetter()
 
 bool GuiGamelistOptions::input(InputConfig* config, Input input)
 {
-  if((config->isMappedTo("a", input) || config->isMappedTo("select", input)) && input.value) // batocera
+	if ((config->isMappedTo(BUTTON_BACK, input) || config->isMappedTo("select", input)) && input.value)
 	{
 		delete this;
 		return true;
@@ -269,7 +270,7 @@ HelpStyle GuiGamelistOptions::getHelpStyle()
 std::vector<HelpPrompt> GuiGamelistOptions::getHelpPrompts()
 {
 	auto prompts = mMenu.getHelpPrompts();
-	prompts.push_back(HelpPrompt("b", _("CLOSE"))); // batocera
+	prompts.push_back(HelpPrompt(BUTTON_BACK, _("CLOSE")));
 	return prompts;
 }
 

--- a/es-app/src/guis/GuiInstall.cpp
+++ b/es-app/src/guis/GuiInstall.cpp
@@ -2,7 +2,6 @@
 #include "guis/GuiMsgBox.h"
 
 #include "Window.h"
-#include <boost/thread.hpp>
 #include <string>
 #include "Log.h"
 #include "Settings.h"
@@ -54,7 +53,7 @@ void GuiInstall::update(int deltaTime) {
         Window* window = mWindow;
         if(mState == 1){
 	  mLoading = true;
-	  mHandle = new boost::thread(boost::bind(&GuiInstall::threadInstall, this));
+	  mHandle = new std::thread(&GuiInstall::threadInstall, this);
 	  mState = 0;
         }
 

--- a/es-app/src/guis/GuiInstall.h
+++ b/es-app/src/guis/GuiInstall.h
@@ -5,7 +5,7 @@
 #include "components/BusyComponent.h"
 
 
-#include <boost/thread.hpp>
+#include <thread>
 
 class GuiInstall : public GuiComponent {
 public:
@@ -30,7 +30,7 @@ private:
     std::string mstorageDevice;
     std::string marchitecture;
     
-    boost::thread *mHandle;
+    std::thread *mHandle;
 
     void onInstallError(std::pair<std::string, int>);
 

--- a/es-app/src/guis/GuiInstallStart.cpp
+++ b/es-app/src/guis/GuiInstallStart.cpp
@@ -3,77 +3,77 @@
 #include "ApiSystem.h"
 #include "components/OptionListComponent.h"
 #include "guis/GuiInstall.h"
-#include <boost/algorithm/string/predicate.hpp>
-#include <boost/algorithm/string/split.hpp>
-#include <boost/algorithm/string/classification.hpp>
 #include "views/ViewController.h"
-
+#include "utils/StringUtil.h"
 #include "LocaleES.h"
 
 GuiInstallStart::GuiInstallStart(Window* window) : GuiComponent(window),
-  mMenu(window, _("INSTALL BATOCERA").c_str())
+mMenu(window, _("INSTALL BATOCERA").c_str())
 {
 	addChild(&mMenu);
 
 	std::vector<std::string> availableStorage = ApiSystem::getInstance()->getAvailableInstallDevices();
 	std::vector<std::string> availableArchitecture = ApiSystem::getInstance()->getAvailableInstallArchitectures();
 	bool installationPossible = true;
-	if(availableArchitecture.size() == 0) {
-	  installationPossible = false;
+	if (availableArchitecture.size() == 0) {
+		installationPossible = false;
 	}
-	
+
 	// available install storage
-	if(installationPossible) {
-	  moptionsStorage = std::make_shared<OptionListComponent<std::string> >(window, _("TARGET DEVICE"),
-										false);
-	  for(auto it = availableStorage.begin(); it != availableStorage.end(); it++){
-	    std::vector<std::string> tokens;
-	    boost::split( tokens, (*it), boost::is_any_of(" ") );
-	    if(tokens.size()>= 2){
-	      // concatenat the ending words
-	      std::string vname = "";
-	      for(unsigned int i=1; i<tokens.size(); i++) {
-		if(i > 1) vname += " ";
-		vname += tokens.at(i);
-	      }
-	      moptionsStorage->add(vname, tokens.at(0), false);
-	    }
-	  }
-	  mMenu.addWithLabel(_("TARGET DEVICE"), moptionsStorage);
+	if (installationPossible) 
+	{
+		moptionsStorage = std::make_shared<OptionListComponent<std::string> >(window, _("TARGET DEVICE"), false);
+		for (auto it = availableStorage.begin(); it != availableStorage.end(); it++) 
+		{
+			std::vector<std::string> tokens = Utils::String::split(*it, ' ');
+
+			if (tokens.size() >= 2) {
+				// concatenat the ending words
+				std::string vname = "";
+				for (unsigned int i = 1; i < tokens.size(); i++) {
+					if (i > 1) vname += " ";
+					vname += tokens.at(i);
+				}
+				moptionsStorage->add(vname, tokens.at(0), false);
+			}
+		}
+		mMenu.addWithLabel(_("TARGET DEVICE"), moptionsStorage);
 	}
 
 	// available install architecture
-	if(installationPossible) {
-	  moptionsArchitecture = std::make_shared<OptionListComponent<std::string> >(window, _("TARGET ARCHITECTURE"),
-										     false);
-	  for(auto it = availableArchitecture.begin(); it != availableArchitecture.end(); it++){
-	    moptionsArchitecture->add((*it), (*it), false);
-	  }
-	  mMenu.addWithLabel(_("TARGET ARCHITECTURE"), moptionsArchitecture);
+	if (installationPossible) 
+	{
+		moptionsArchitecture = std::make_shared<OptionListComponent<std::string> >(window, _("TARGET ARCHITECTURE"), false);
+		for (auto it = availableArchitecture.begin(); it != availableArchitecture.end(); it++) {
+			moptionsArchitecture->add((*it), (*it), false);
+		}
+		mMenu.addWithLabel(_("TARGET ARCHITECTURE"), moptionsArchitecture);
 	}
-	
+
 	// validation
-	if(installationPossible) {
-	  moptionsValidation = std::make_shared<OptionListComponent<std::string> >(window, _("VALIDATION"),
-										   false);
-	  for(int i=0; i<6; i++){
-	    if(i == 4) {
-	      moptionsValidation->add(_("YES, I'M SURE"), _("YES, I'M SURE"), false);
-	    } else {
-	      moptionsValidation->add("", "", false);
-	    }
-	  }
-	  mMenu.addWithLabel(_("VALIDATION"), moptionsValidation);
+	if (installationPossible) {
+		moptionsValidation = std::make_shared<OptionListComponent<std::string> >(window, _("VALIDATION"),
+			false);
+		for (int i = 0; i < 6; i++) {
+			if (i == 4) {
+				moptionsValidation->add(_("YES, I'M SURE"), _("YES, I'M SURE"), false);
+			}
+			else {
+				moptionsValidation->add("", "", false);
+			}
+		}
+		mMenu.addWithLabel(_("VALIDATION"), moptionsValidation);
 	}
 
-	if(installationPossible) {
-	  mMenu.addButton(_("INSTALL"), "install", std::bind(&GuiInstallStart::start, this));
+	if (installationPossible) {
+		mMenu.addButton(_("INSTALL"), "install", std::bind(&GuiInstallStart::start, this));
 	}
 
-	if(installationPossible) {
-	  mMenu.addButton(_("BACK"), "back", [&] { delete this; });
-	} else {
-	  mMenu.addButton(_("NETWORK REQUIRED"), "back", [&] { delete this; });
+	if (installationPossible) {
+		mMenu.addButton(_("BACK"), "back", [&] { delete this; });
+	}
+	else {
+		mMenu.addButton(_("NETWORK REQUIRED"), "back", [&] { delete this; });
 	}
 
 	mMenu.setPosition((Renderer::getScreenWidth() - mMenu.getSize().x()) / 2, Renderer::getScreenHeight() * 0.1f);
@@ -93,7 +93,7 @@ bool GuiInstallStart::input(InputConfig* config, Input input)
 	if(consumed)
 		return true;
 	
-	if(input.value != 0 && config->isMappedTo("a", input))
+	if(input.value != 0 && config->isMappedTo(BUTTON_BACK, input))
 	{
 		delete this;
 		return true;
@@ -114,7 +114,7 @@ bool GuiInstallStart::input(InputConfig* config, Input input)
 std::vector<HelpPrompt> GuiInstallStart::getHelpPrompts()
 {
 	std::vector<HelpPrompt> prompts = mMenu.getHelpPrompts();
-	prompts.push_back(HelpPrompt("a", _("BACK")));
+	prompts.push_back(HelpPrompt(BUTTON_BACK, _("BACK")));
 	prompts.push_back(HelpPrompt("start", _("CLOSE")));
 	return prompts;
 }

--- a/es-app/src/guis/GuiLoading.cpp
+++ b/es-app/src/guis/GuiLoading.cpp
@@ -2,7 +2,6 @@
 #include "guis/GuiMsgBox.h"
 
 #include "Window.h"
-#include <boost/thread.hpp>
 #include <string>
 #include "Log.h"
 #include "Settings.h"
@@ -11,14 +10,14 @@
 GuiLoading::GuiLoading(Window *window, const std::function<void*()> &mFunc) : GuiComponent(window), mBusyAnim(window), mFunc(mFunc),mFunc2(NULL) {
     setSize((float) Renderer::getScreenWidth(), (float) Renderer::getScreenHeight());
     mRunning = true;
-    mHandle = new boost::thread(boost::bind(&GuiLoading::threadLoading, this));
+    mHandle = new std::thread(&GuiLoading::threadLoading, this);
     mBusyAnim.setSize(mSize);
 }
 
 GuiLoading::GuiLoading(Window *window, const std::function<void*()> &mFunc, const std::function<void(void *)> &mFunc2) : GuiComponent(window), mBusyAnim(window), mFunc(mFunc),mFunc2(mFunc2) {
     setSize((float) Renderer::getScreenWidth(), (float) Renderer::getScreenHeight());
     mRunning = true;
-    mHandle = new boost::thread(boost::bind(&GuiLoading::threadLoading, this));
+    mHandle = new std::thread(&GuiLoading::threadLoading, this);
     mBusyAnim.setSize(mSize);
 }
 

--- a/es-app/src/guis/GuiLoading.h
+++ b/es-app/src/guis/GuiLoading.h
@@ -10,8 +10,7 @@
 #include "components/MenuComponent.h"
 #include "components/BusyComponent.h"
 
-
-#include <boost/thread.hpp>
+#include <thread>
 
 class GuiLoading  : public GuiComponent {
 public:
@@ -30,7 +29,7 @@ public:
 
 private:
     BusyComponent mBusyAnim;
-    boost::thread *mHandle;
+    std::thread *mHandle;
     bool mRunning;
     const std::function<void*()> mFunc;
     const std::function<void(void *)> mFunc2;

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -24,9 +24,6 @@
 #include <SDL_events.h>
 #include <algorithm>
 
-#include <boost/algorithm/string/split.hpp>
-#include <boost/algorithm/string/predicate.hpp>
-#include <boost/algorithm/string/classification.hpp>
 #include "SystemConf.h"
 #include "ApiSystem.h"
 #include "InputManager.h"
@@ -42,84 +39,83 @@
 
 GuiMenu::GuiMenu(Window *window) : GuiComponent(window), mMenu(window, _("MAIN MENU").c_str()), mVersion(window)
 {
-  // MAIN MENU
-  bool isFullUI = UIModeController::getInstance()->isUIModeFull();
+	// MAIN MENU
+	bool isFullUI = UIModeController::getInstance()->isUIModeFull();
 
-  // KODI >
-  // GAMES SETTINGS >
-  // CONTROLLERS >
-  // UI SETTINGS >
-  // SOUND SETTINGS >
-  // NETWORK >
-  // SCRAPER >
-  // SYSTEM SETTINGS >
-  // QUIT >
-  
-  // KODI
+	// KODI >
+	// GAMES SETTINGS >
+	// CONTROLLERS >
+	// UI SETTINGS >
+	// SOUND SETTINGS >
+	// NETWORK >
+	// SCRAPER >
+	// SYSTEM SETTINGS >
+	// QUIT >
+
+	// KODI
 #ifdef _ENABLE_KODI_
-  if (SystemConf::getInstance()->get("kodi.enabled") != "0") {
-    addEntry(_("KODI MEDIA CENTER").c_str(), 0x777777FF, true, [this] { openKodiLauncher_batocera(); });
-  }
+	if (SystemConf::getInstance()->get("kodi.enabled") != "0") {
+		addEntry(_("KODI MEDIA CENTER").c_str(), 0x777777FF, true, [this] { openKodiLauncher_batocera(); });
+	}
 #endif
 
-  if (isFullUI &&
-      SystemConf::getInstance()->get("global.retroachievements") == "1" &&
-      SystemConf::getInstance()->get("global.retroachievements.username") != "")
-    addEntry(_("RETROACHIEVEMENTS").c_str(), 0x777777FF, true, [this] { openRetroAchievements_batocera(); });
+	if (isFullUI &&
+		SystemConf::getInstance()->get("global.retroachievements") == "1" &&
+		SystemConf::getInstance()->get("global.retroachievements.username") != "")
+		addEntry(_("RETROACHIEVEMENTS").c_str(), 0x777777FF, true, [this] { openRetroAchievements_batocera(); });
 
-  // GAMES SETTINGS
-  if (isFullUI)
-    addEntry(_("GAMES SETTINGS").c_str(), 0x777777FF, true, [this] { openGamesSettings_batocera(); });
+	// GAMES SETTINGS
+	if (isFullUI)
+		addEntry(_("GAMES SETTINGS").c_str(), 0x777777FF, true, [this] { openGamesSettings_batocera(); });
 
-  // CONTROLLERS SETTINGS
-  if (isFullUI)
-    addEntry(_("CONTROLLERS SETTINGS").c_str(), 0x777777FF, true, [this] { openControllersSettings_batocera(); });
-  
-  if (isFullUI)
-    addEntry(_("UI SETTINGS").c_str(), 0x777777FF, true, [this] { openUISettings_batocera(); });
+	// CONTROLLERS SETTINGS
+	if (isFullUI)
+		addEntry(_("CONTROLLERS SETTINGS").c_str(), 0x777777FF, true, [this] { openControllersSettings_batocera(); });
 
-  // batocera
-  if (isFullUI)
-    addEntry(_("GAME COLLECTION SETTINGS").c_str(), 0x777777FF, true, [this] { openCollectionSystemSettings(); });
+	if (isFullUI)
+		addEntry(_("UI SETTINGS").c_str(), 0x777777FF, true, [this] { openUISettings_batocera(); });
 
-  if (isFullUI)
-    addEntry(_("SOUND SETTINGS").c_str(), 0x777777FF, true, [this] { openSoundSettings_batocera(); });
+	// batocera
+	if (isFullUI)
+		addEntry(_("GAME COLLECTION SETTINGS").c_str(), 0x777777FF, true, [this] { openCollectionSystemSettings(); });
 
-  if (isFullUI)
-    addEntry(_("NETWORK SETTINGS").c_str(), 0x777777FF, true, [this] { openNetworkSettings_batocera(); });
+	if (isFullUI)
+		addEntry(_("SOUND SETTINGS").c_str(), 0x777777FF, true, [this] { openSoundSettings_batocera(); });
 
-  if (isFullUI)
-    addEntry(_("SCRAPE").c_str(), 0x777777FF, true, [this] { openScraperSettings_batocera(); });
+	if (isFullUI)
+		addEntry(_("NETWORK SETTINGS").c_str(), 0x777777FF, true, [this] { openNetworkSettings_batocera(); });
 
-  // SYSTEM
-  if (isFullUI) {
-    addEntry(_("SYSTEM SETTINGS").c_str(), 0x777777FF, true, [this] { openSystemSettings_batocera(); });
-  } else {
-    addEntry(_("INFORMATIONS").c_str(), 0x777777FF, true, [this] { openSystemInformations_batocera(); });
-  }
+	if (isFullUI)
+		addEntry(_("SCRAPE").c_str(), 0x777777FF, true, [this] { openScraperSettings_batocera(); });
 
-  addEntry(_("QUIT").c_str(), 0x777777FF, true, [this] { openQuitMenu_batocera(); });
+	// SYSTEM
+	if (isFullUI)
+		addEntry(_("SYSTEM SETTINGS").c_str(), 0x777777FF, true, [this] { openSystemSettings_batocera(); });	
+	else
+		addEntry(_("INFORMATIONS").c_str(), 0x777777FF, true, [this] { openSystemInformations_batocera(); });	
+
+	addEntry(_("QUIT").c_str(), 0x777777FF, true, [this] { openQuitMenu_batocera(); });
 
 
-  //addEntry("SOUND SETTINGS", 0x777777FF, true, [this] { openSoundSettings(); });
+	//addEntry("SOUND SETTINGS", 0x777777FF, true, [this] { openSoundSettings(); });
 
-  //if (isFullUI)
-  //addEntry("UI SETTINGS", 0x777777FF, true, [this] { openUISettings(); });
+	//if (isFullUI)
+	//addEntry("UI SETTINGS", 0x777777FF, true, [this] { openUISettings(); });
 
-  //if (isFullUI)
-  //addEntry("OTHER SETTINGS", 0x777777FF, true, [this] { openOtherSettings(); });
+	//if (isFullUI)
+	//addEntry("OTHER SETTINGS", 0x777777FF, true, [this] { openOtherSettings(); });
 
-  // batocera
-  //if (isFullUI)
-  //	addEntry("CONFIGURE INPUT", 0x777777FF, true, [this] { openConfigInput(); });
-  
-  // batocera
-  //addEntry("QUIT", 0x777777FF, true, [this] {openQuitMenu(); });
+	// batocera
+	//if (isFullUI)
+	//	addEntry("CONFIGURE INPUT", 0x777777FF, true, [this] { openConfigInput(); });
 
-  addChild(&mMenu);
-  //addVersionInfo(); // batocera
-  setSize(mMenu.getSize());
-  setPosition((Renderer::getScreenWidth() - mSize.x()) / 2, Renderer::getScreenHeight() * 0.15f);
+	// batocera
+	//addEntry("QUIT", 0x777777FF, true, [this] {openQuitMenu(); });
+
+	addChild(&mMenu);
+	//addVersionInfo(); // batocera
+	setSize(mMenu.getSize());
+	setPosition((Renderer::getScreenWidth() - mSize.x()) / 2, Renderer::getScreenHeight() * 0.15f);
 }
 
 void GuiMenu::openScraperSettings()
@@ -661,7 +657,7 @@ bool GuiMenu::input(InputConfig* config, Input input)
 	if(GuiComponent::input(config, input))
 		return true;
 
-	if((config->isMappedTo("a", input) || config->isMappedTo("start", input)) && input.value != 0) // batocera
+	if((config->isMappedTo(BUTTON_BACK, input) || config->isMappedTo("start", input)) && input.value != 0)
 	{
 		delete this;
 		return true;
@@ -681,7 +677,7 @@ std::vector<HelpPrompt> GuiMenu::getHelpPrompts()
 {
 	std::vector<HelpPrompt> prompts;
 	prompts.push_back(HelpPrompt("up/down", _("CHOOSE"))); // batocera
-	prompts.push_back(HelpPrompt("b", _("SELECT"))); // batocera
+	prompts.push_back(HelpPrompt(BUTTON_OK, _("SELECT"))); // batocera
 	prompts.push_back(HelpPrompt("start", _("CLOSE"))); // batocera
 	return prompts;
 }
@@ -713,8 +709,8 @@ void GuiMenu::openSystemInformations_batocera() {
   // various informations
   std::vector<std::string> infos = ApiSystem::getInstance()->getSystemInformations();
   for(auto it = infos.begin(); it != infos.end(); it++) {
-    std::vector<std::string> tokens;
-    boost::split( tokens, (*it), boost::is_any_of(":") );
+	  std::vector<std::string> tokens = Utils::String::split(*it, ':');
+    
     if(tokens.size()>= 2){
       // concatenat the ending words
       std::string vname = "";
@@ -753,310 +749,320 @@ void GuiMenu::openSystemInformations_batocera() {
   window->pushGui(informationsGui);
 }
 
-void GuiMenu::openSystemSettings_batocera() {
-  Window *window = mWindow;
+void GuiMenu::openSystemSettings_batocera() 
+{
+	Window *window = mWindow;
 
-  auto s = new GuiSettings(mWindow, _("SYSTEM SETTINGS").c_str());
-  bool isFullUI = UIModeController::getInstance()->isUIModeFull();
-  
-  // system informations
-  {
-    ComponentListRow row;
-    std::function<void()> openGui = [this] {
-      openSystemInformations_batocera();
-    };
-    row.makeAcceptInputHandler(openGui);
-    auto informationsSettings = std::make_shared<TextComponent>(mWindow, _("INFORMATION"), Font::get(FONT_SIZE_MEDIUM), 0x777777FF);
-    auto bracket = makeArrow(mWindow);
-    row.addElement(informationsSettings, true);
-    row.addElement(bracket, false);
-    s->addRow(row);
-  }
-  
-  std::vector<std::string> availableStorage = ApiSystem::getInstance()->getAvailableStorageDevices();
-  std::string selectedStorage = ApiSystem::getInstance()->getCurrentStorage();
-  
-  // Storage device
-  auto optionsStorage = std::make_shared<OptionListComponent<std::string> >(window, _("STORAGE DEVICE"),
-									    false);
-  for(auto it = availableStorage.begin(); it != availableStorage.end(); it++){
-    if((*it) != "RAM"){
-      if (boost::starts_with((*it), "DEV")){
-	std::vector<std::string> tokens;
-	boost::split( tokens, (*it), boost::is_any_of(" ") );
-	if(tokens.size()>= 3){
-	  // concatenat the ending words
-	  std::string vname = "";
-	  for(unsigned int i=2; i<tokens.size(); i++) {
-	    if(i > 2) vname += " ";
-	    vname += tokens.at(i);
-	  }
-	  optionsStorage->add(vname, (*it), selectedStorage == std::string("DEV "+tokens.at(1)));
+	auto s = new GuiSettings(mWindow, _("SYSTEM SETTINGS").c_str());
+	bool isFullUI = UIModeController::getInstance()->isUIModeFull();
+
+	// system informations
+	{
+		ComponentListRow row;
+		std::function<void()> openGui = [this] {
+			openSystemInformations_batocera();
+		};
+		row.makeAcceptInputHandler(openGui);
+		auto informationsSettings = std::make_shared<TextComponent>(mWindow, _("INFORMATION"), Font::get(FONT_SIZE_MEDIUM), 0x777777FF);
+		auto bracket = makeArrow(mWindow);
+		row.addElement(informationsSettings, true);
+		row.addElement(bracket, false);
+		s->addRow(row);
 	}
-      } else {
-	optionsStorage->add((*it), (*it), selectedStorage == (*it));
-      }
-    }
-  }
-  s->addWithLabel(_("STORAGE DEVICE"), optionsStorage);
-  
-  
-  // language choice
-  auto language_choice = std::make_shared<OptionListComponent<std::string> >(window, _("LANGUAGE"),
-									     false);
-  std::string language = SystemConf::getInstance()->get("system.language");
-  if (language.empty()) language = "en_US";
-  language_choice->add("BASQUE",              "eu_ES", language == "eu_ES");
-  language_choice->add("正體中文",             "zh_TW", language == "zh_TW");
-  language_choice->add("简体中文",             "zh_CN", language == "zh_CN");
-  language_choice->add("DEUTSCH",             "de_DE", language == "de_DE");
-  language_choice->add("ENGLISH",             "en_US", language == "en_US");
-  language_choice->add("ESPAÑOL",             "es_ES", language == "es_ES");
-  language_choice->add("FRANÇAIS",            "fr_FR", language == "fr_FR");
-  language_choice->add("ITALIANO",            "it_IT", language == "it_IT");
-  language_choice->add("PORTUGUES BRASILEIRO", "pt_BR", language == "pt_BR");
-  language_choice->add("PORTUGUES PORTUGAL",  "pt_PT", language == "pt_PT");
-  language_choice->add("SVENSKA",             "sv_SE", language == "sv_SE");
-  language_choice->add("TÜRKÇE",              "tr_TR", language == "tr_TR");
-  language_choice->add("CATALÀ",              "ca_ES", language == "ca_ES");
-  language_choice->add("ARABIC",              "ar_YE", language == "ar_YE");
-  language_choice->add("DUTCH",               "nl_NL", language == "nl_NL");
-  language_choice->add("GREEK",               "el_GR", language == "el_GR");
-  language_choice->add("KOREAN",              "ko_KR", language == "ko_KR");
-  language_choice->add("NORWEGIAN",           "nn_NO", language == "nn_NO");
-  language_choice->add("NORWEGIAN BOKMAL",    "nb_NO", language == "nb_NO");
-  language_choice->add("POLISH",              "pl_PL", language == "pl_PL");
-  language_choice->add("JAPANESE",            "ja_JP", language == "ja_JP");
-  language_choice->add("RUSSIAN",             "ru_RU", language == "ru_RU");
-  language_choice->add("HUNGARIAN",           "hu_HU", language == "hu_HU");
-  
-  s->addWithLabel(_("LANGUAGE"), language_choice);
-  
-  // Overclock choice
-  auto overclock_choice = std::make_shared<OptionListComponent<std::string> >(window, _("OVERCLOCK"),
-									      false);
-  std::string currentOverclock = Settings::getInstance()->getString("Overclock");
-  if(currentOverclock == "") currentOverclock = "none";
-  std::vector<std::string> availableOverclocking = ApiSystem::getInstance()->getAvailableOverclocking();
-  
-  // Overclocking device
-  bool isOneSet = false;
-  for(auto it = availableOverclocking.begin(); it != availableOverclocking.end(); it++){
-    std::vector<std::string> tokens;
-    boost::split( tokens, (*it), boost::is_any_of(" ") );
-    if(tokens.size()>= 2){
-      // concatenat the ending words
-      std::string vname = "";
-      for(unsigned int i=1; i<tokens.size(); i++) {
-	if(i > 1) vname += " ";
-	vname += tokens.at(i);
-      }
-      bool isSet = currentOverclock == std::string(tokens.at(0));
-      if(isSet) {
-	isOneSet = true;
-      }
-      overclock_choice->add(vname, tokens.at(0), isSet);
-    }
-  }
-  if(isOneSet == false) {
-    overclock_choice->add(currentOverclock, currentOverclock, true);
-  }
-  s->addWithLabel(_("OVERCLOCK"), overclock_choice);
-  
-  // Updates
-  {
-    ComponentListRow row;
-    std::function<void()> openGuiD = [this] {
-      GuiSettings *updateGui = new GuiSettings(mWindow, _("UPDATES").c_str());
 
-      // Batocera themes installer/browser
-      {
-	auto openThemesInstallNow = [this] { mWindow->pushGui(new GuiThemeInstallStart(mWindow)); };
-	ComponentListRow row;
-	row.makeAcceptInputHandler(openThemesInstallNow);
-	auto ThemeInstallSettings = std::make_shared<TextComponent>(mWindow, _("THEMES"),
- 							  Font::get(FONT_SIZE_MEDIUM), 0x777777FF);
-	auto bracket = makeArrow(mWindow);
-	row.addElement(ThemeInstallSettings, true);
-	row.addElement(bracket, false);
-	updateGui->addRow(row);
-      }
+	std::vector<std::string> availableStorage = ApiSystem::getInstance()->getAvailableStorageDevices();
+	std::string selectedStorage = ApiSystem::getInstance()->getCurrentStorage();
 
-      // Batocera integration with theBezelProject
-      {
-	auto openBezelMenuNow = [this] { mWindow->pushGui(new GuiBezelInstallMenu(mWindow)); };
-	ComponentListRow row;
-	row.makeAcceptInputHandler(openBezelMenuNow);
-	auto BezelInstallMenuSettings = std::make_shared<TextComponent>(mWindow, _("THE BEZEL PROJECT"),
-			Font::get(FONT_SIZE_MEDIUM), 0x777777FF);
-	auto bracket = makeArrow(mWindow);
-	row.addElement(BezelInstallMenuSettings, true);
-	row.addElement(bracket, false);
-	updateGui->addRow(row);
-      }
+	// Storage device
+	auto optionsStorage = std::make_shared<OptionListComponent<std::string> >(window, _("STORAGE DEVICE"), false);
+	for (auto it = availableStorage.begin(); it != availableStorage.end(); it++) 
+	{
+		if ((*it) != "RAM")
+		{
+			if (Utils::String::startsWith(*it, "DEV"))
+			{
+				std::vector<std::string> tokens = Utils::String::split(*it, ' ');
 
-      // Enable updates
-      auto updates_enabled = std::make_shared<SwitchComponent>(mWindow);
-      updates_enabled->setState(
+				if (tokens.size() >= 3) {
+					// concatenat the ending words
+					std::string vname = "";
+					for (unsigned int i = 2; i < tokens.size(); i++) {
+						if (i > 2) vname += " ";
+						vname += tokens.at(i);
+					}
+					optionsStorage->add(vname, (*it), selectedStorage == std::string("DEV " + tokens.at(1)));
+				}
+			}
+			else {
+				optionsStorage->add((*it), (*it), selectedStorage == (*it));
+			}
+		}
+	}
+	s->addWithLabel(_("STORAGE DEVICE"), optionsStorage);
+	
+	// language choice
+	auto language_choice = std::make_shared<OptionListComponent<std::string> >(window, _("LANGUAGE"), false);
+
+	std::string language = SystemConf::getInstance()->get("system.language");
+	if (language.empty()) 
+		language = "en_US";
+
+	language_choice->add("BASQUE", "eu_ES", language == "eu_ES");
+	language_choice->add("正體中文", "zh_TW", language == "zh_TW");
+	language_choice->add("简体中文", "zh_CN", language == "zh_CN");
+	language_choice->add("DEUTSCH", "de_DE", language == "de_DE");
+	language_choice->add("ENGLISH", "en_US", language == "en_US");
+	language_choice->add("ESPAÑOL", "es_ES", language == "es_ES");
+	language_choice->add("FRANÇAIS", "fr_FR", language == "fr_FR");
+	language_choice->add("ITALIANO", "it_IT", language == "it_IT");
+	language_choice->add("PORTUGUES BRASILEIRO", "pt_BR", language == "pt_BR");
+	language_choice->add("PORTUGUES PORTUGAL", "pt_PT", language == "pt_PT");
+	language_choice->add("SVENSKA", "sv_SE", language == "sv_SE");
+	language_choice->add("TÜRKÇE", "tr_TR", language == "tr_TR");
+	language_choice->add("CATALÀ", "ca_ES", language == "ca_ES");
+	language_choice->add("ARABIC", "ar_YE", language == "ar_YE");
+	language_choice->add("DUTCH", "nl_NL", language == "nl_NL");
+	language_choice->add("GREEK", "el_GR", language == "el_GR");
+	language_choice->add("KOREAN", "ko_KR", language == "ko_KR");
+	language_choice->add("NORWEGIAN", "nn_NO", language == "nn_NO");
+	language_choice->add("NORWEGIAN BOKMAL", "nb_NO", language == "nb_NO");
+	language_choice->add("POLISH", "pl_PL", language == "pl_PL");
+	language_choice->add("JAPANESE", "ja_JP", language == "ja_JP");
+	language_choice->add("RUSSIAN", "ru_RU", language == "ru_RU");
+	language_choice->add("HUNGARIAN", "hu_HU", language == "hu_HU");
+
+	s->addWithLabel(_("LANGUAGE"), language_choice);
+
+	// Overclock choice
+	auto overclock_choice = std::make_shared<OptionListComponent<std::string> >(window, _("OVERCLOCK"), false);
+
+	std::string currentOverclock = Settings::getInstance()->getString("Overclock");
+	if (currentOverclock == "") 
+		currentOverclock = "none";
+
+	std::vector<std::string> availableOverclocking = ApiSystem::getInstance()->getAvailableOverclocking();
+
+	// Overclocking device
+	bool isOneSet = false;
+	for (auto it = availableOverclocking.begin(); it != availableOverclocking.end(); it++) 
+	{
+		std::vector<std::string> tokens = Utils::String::split(*it, ' ');		
+		if (tokens.size() >= 2) 
+		{
+			// concatenat the ending words
+			std::string vname;
+			for (unsigned int i = 1; i < tokens.size(); i++) 
+			{
+				if (i > 1) vname += " ";
+				vname += tokens.at(i);
+			}
+			bool isSet = currentOverclock == std::string(tokens.at(0));
+			if (isSet) 
+				isOneSet = true;
+			
+			overclock_choice->add(vname, tokens.at(0), isSet);
+		}
+	}
+	if (isOneSet == false) {
+		overclock_choice->add(currentOverclock, currentOverclock, true);
+	}
+	s->addWithLabel(_("OVERCLOCK"), overclock_choice);
+
+	// Updates
+	{
+		ComponentListRow row;
+		std::function<void()> openGuiD = [this] {
+			GuiSettings *updateGui = new GuiSettings(mWindow, _("UPDATES").c_str());
+
+			// Batocera themes installer/browser
+			{
+				auto openThemesInstallNow = [this] { mWindow->pushGui(new GuiThemeInstallStart(mWindow)); };
+				ComponentListRow row;
+				row.makeAcceptInputHandler(openThemesInstallNow);
+				auto ThemeInstallSettings = std::make_shared<TextComponent>(mWindow, _("THEMES"),
+					Font::get(FONT_SIZE_MEDIUM), 0x777777FF);
+				auto bracket = makeArrow(mWindow);
+				row.addElement(ThemeInstallSettings, true);
+				row.addElement(bracket, false);
+				updateGui->addRow(row);
+			}
+
+			// Batocera integration with theBezelProject
+			{
+				auto openBezelMenuNow = [this] { mWindow->pushGui(new GuiBezelInstallMenu(mWindow)); };
+				ComponentListRow row;
+				row.makeAcceptInputHandler(openBezelMenuNow);
+				auto BezelInstallMenuSettings = std::make_shared<TextComponent>(mWindow, _("THE BEZEL PROJECT"),
+					Font::get(FONT_SIZE_MEDIUM), 0x777777FF);
+				auto bracket = makeArrow(mWindow);
+				row.addElement(BezelInstallMenuSettings, true);
+				row.addElement(bracket, false);
+				updateGui->addRow(row);
+			}
+
+#ifndef WIN32
+			// Enable updates
+			auto updates_enabled = std::make_shared<SwitchComponent>(mWindow);
+			updates_enabled->setState(
 				SystemConf::getInstance()->get("updates.enabled") == "1");
-      updateGui->addWithLabel(_("AUTO UPDATES"), updates_enabled);
-      
-      // Start update
-      {
-	ComponentListRow updateRow;
-	std::function<void()> openGui = [this] { mWindow->pushGui(new GuiUpdate(mWindow)); };
-	updateRow.makeAcceptInputHandler(openGui);
-	auto update = std::make_shared<TextComponent>(mWindow, _("START UPDATE"),
-						      Font::get(FONT_SIZE_MEDIUM),
-						      0x777777FF);
-	auto bracket = makeArrow(mWindow);
-	updateRow.addElement(update, true);
-	updateRow.addElement(bracket, false);
-	updateGui->addRow(updateRow);
-      }
-      updateGui->addSaveFunc([updates_enabled] {
-	  SystemConf::getInstance()->set("updates.enabled",
-					 updates_enabled->getState() ? "1" : "0");
-	  SystemConf::getInstance()->saveSystemConf();
-	});
-      mWindow->pushGui(updateGui);
-      
-    };
-    row.makeAcceptInputHandler(openGuiD);
-    auto update = std::make_shared<TextComponent>(mWindow, _("UPDATES"), Font::get(FONT_SIZE_MEDIUM),
-						  0x777777FF);
-    auto bracket = makeArrow(mWindow);
-    row.addElement(update, true);
-    row.addElement(bracket, false);
-    s->addRow(row);
-  }
-  
-  // backup
-  {
-    ComponentListRow row;
-    auto openBackupNow = [this] { mWindow->pushGui(new GuiBackupStart(mWindow)); };
-    row.makeAcceptInputHandler(openBackupNow);
-    auto backupSettings = std::make_shared<TextComponent>(mWindow, _("BACKUP USER DATA"),
-							  Font::get(FONT_SIZE_MEDIUM), 0x777777FF);
-    auto bracket = makeArrow(mWindow);
-    row.addElement(backupSettings, true);
-    row.addElement(bracket, false);
-    s->addRow(row);
-  }
-  
-#ifdef _ENABLE_KODI_
-  //Kodi
-  {
-    ComponentListRow row;
-    std::function<void()> openGui = [this] {
-      GuiSettings *kodiGui = new GuiSettings(mWindow, _("KODI SETTINGS").c_str());
-      auto kodiEnabled = std::make_shared<SwitchComponent>(mWindow);
-      kodiEnabled->setState(SystemConf::getInstance()->get("kodi.enabled") == "1");
-      kodiGui->addWithLabel(_("ENABLE KODI"), kodiEnabled);
-      auto kodiAtStart = std::make_shared<SwitchComponent>(mWindow);
-      kodiAtStart->setState(
-			    SystemConf::getInstance()->get("kodi.atstartup") == "1");
-      kodiGui->addWithLabel(_("KODI AT START"), kodiAtStart);
-      auto kodiX = std::make_shared<SwitchComponent>(mWindow);
-      kodiX->setState(SystemConf::getInstance()->get("kodi.xbutton") == "1");
-      kodiGui->addWithLabel(_("START KODI WITH X"), kodiX);
-      kodiGui->addSaveFunc([kodiEnabled, kodiAtStart, kodiX] {
-	  SystemConf::getInstance()->set("kodi.enabled",
-					 kodiEnabled->getState() ? "1" : "0");
-	  SystemConf::getInstance()->set("kodi.atstartup",
-					 kodiAtStart->getState() ? "1" : "0");
-	  SystemConf::getInstance()->set("kodi.xbutton",
-					 kodiX->getState() ? "1" : "0");
-	  SystemConf::getInstance()->saveSystemConf();
-	});
-      mWindow->pushGui(kodiGui);
-    };
-    row.makeAcceptInputHandler(openGui);
-    auto kodiSettings = std::make_shared<TextComponent>(mWindow, _("KODI SETTINGS"),
-							Font::get(FONT_SIZE_MEDIUM), 0x777777FF);
-    auto bracket = makeArrow(mWindow);
-    row.addElement(kodiSettings, true);
-    row.addElement(bracket, false);
-    s->addRow(row);
-  }
+			updateGui->addWithLabel(_("AUTO UPDATES"), updates_enabled);
+
+			// Start update
+			{
+				ComponentListRow updateRow;
+				std::function<void()> openGui = [this] { mWindow->pushGui(new GuiUpdate(mWindow)); };
+				updateRow.makeAcceptInputHandler(openGui);
+				auto update = std::make_shared<TextComponent>(mWindow, _("START UPDATE"),
+					Font::get(FONT_SIZE_MEDIUM),
+					0x777777FF);
+				auto bracket = makeArrow(mWindow);
+				updateRow.addElement(update, true);
+				updateRow.addElement(bracket, false);
+				updateGui->addRow(updateRow);
+			}
+			updateGui->addSaveFunc([updates_enabled] {
+				SystemConf::getInstance()->set("updates.enabled",
+					updates_enabled->getState() ? "1" : "0");
+				SystemConf::getInstance()->saveSystemConf();
+			});
 #endif
-  // install
-  {
-    ComponentListRow row;
-    auto openInstallNow = [this] { mWindow->pushGui(new GuiInstallStart(mWindow)); };
-    row.makeAcceptInputHandler(openInstallNow);
-    auto installSettings = std::make_shared<TextComponent>(mWindow, _("INSTALL BATOCERA ON A NEW DISK"),
-							   Font::get(FONT_SIZE_MEDIUM), 0x777777FF);
-    auto bracket = makeArrow(mWindow);
-    row.addElement(installSettings, true);
-    row.addElement(bracket, false);
-    s->addRow(row);
-  }
-  
-  //Security
-  {
-    ComponentListRow row;
-    std::function<void()> openGui = [this] {
-      GuiSettings *securityGui = new GuiSettings(mWindow, _("SECURITY").c_str());
-      auto securityEnabled = std::make_shared<SwitchComponent>(mWindow);
-      securityEnabled->setState(SystemConf::getInstance()->get("system.security.enabled") == "1");
-      securityGui->addWithLabel(_("ENFORCE SECURITY"), securityEnabled);
-      
-      auto rootpassword = std::make_shared<TextComponent>(mWindow,
-							  ApiSystem::getInstance()->getRootPassword(),
-							  Font::get(FONT_SIZE_MEDIUM), 0x777777FF);
-      securityGui->addWithLabel(_("ROOT PASSWORD"), rootpassword);
-      
-      securityGui->addSaveFunc([this, securityEnabled] {
-	  Window* window = this->mWindow;
-	  bool reboot = false;
-	  
-	  if (securityEnabled->changed()) {
-	    SystemConf::getInstance()->set("system.security.enabled",
-					   securityEnabled->getState() ? "1" : "0");
-	    SystemConf::getInstance()->saveSystemConf();
-	    reboot = true;
-	  }
-	  
-	  if (reboot) {
-	    window->displayMessage(_("A REBOOT OF THE SYSTEM IS REQUIRED TO APPLY THE NEW CONFIGURATION"));
-	  }
+			mWindow->pushGui(updateGui);
+		};
+		row.makeAcceptInputHandler(openGuiD);
+		auto update = std::make_shared<TextComponent>(mWindow, _("UPDATES"), Font::get(FONT_SIZE_MEDIUM),
+			0x777777FF);
+		auto bracket = makeArrow(mWindow);
+		row.addElement(update, true);
+		row.addElement(bracket, false);
+		s->addRow(row);
+	}
+
+	// backup
+	{
+		ComponentListRow row;
+		auto openBackupNow = [this] { mWindow->pushGui(new GuiBackupStart(mWindow)); };
+		row.makeAcceptInputHandler(openBackupNow);
+		auto backupSettings = std::make_shared<TextComponent>(mWindow, _("BACKUP USER DATA"),
+			Font::get(FONT_SIZE_MEDIUM), 0x777777FF);
+		auto bracket = makeArrow(mWindow);
+		row.addElement(backupSettings, true);
+		row.addElement(bracket, false);
+		s->addRow(row);
+	}
+
+#ifdef _ENABLE_KODI_
+	//Kodi
+	{
+		ComponentListRow row;
+		std::function<void()> openGui = [this] {
+			GuiSettings *kodiGui = new GuiSettings(mWindow, _("KODI SETTINGS").c_str());
+			auto kodiEnabled = std::make_shared<SwitchComponent>(mWindow);
+			kodiEnabled->setState(SystemConf::getInstance()->get("kodi.enabled") == "1");
+			kodiGui->addWithLabel(_("ENABLE KODI"), kodiEnabled);
+			auto kodiAtStart = std::make_shared<SwitchComponent>(mWindow);
+			kodiAtStart->setState(
+				SystemConf::getInstance()->get("kodi.atstartup") == "1");
+			kodiGui->addWithLabel(_("KODI AT START"), kodiAtStart);
+			auto kodiX = std::make_shared<SwitchComponent>(mWindow);
+			kodiX->setState(SystemConf::getInstance()->get("kodi.xbutton") == "1");
+			kodiGui->addWithLabel(_("START KODI WITH X"), kodiX);
+			kodiGui->addSaveFunc([kodiEnabled, kodiAtStart, kodiX] {
+				SystemConf::getInstance()->set("kodi.enabled",
+					kodiEnabled->getState() ? "1" : "0");
+				SystemConf::getInstance()->set("kodi.atstartup",
+					kodiAtStart->getState() ? "1" : "0");
+				SystemConf::getInstance()->set("kodi.xbutton",
+					kodiX->getState() ? "1" : "0");
+				SystemConf::getInstance()->saveSystemConf();
+			});
+			mWindow->pushGui(kodiGui);
+		};
+		row.makeAcceptInputHandler(openGui);
+		auto kodiSettings = std::make_shared<TextComponent>(mWindow, _("KODI SETTINGS"),
+			Font::get(FONT_SIZE_MEDIUM), 0x777777FF);
+		auto bracket = makeArrow(mWindow);
+		row.addElement(kodiSettings, true);
+		row.addElement(bracket, false);
+		s->addRow(row);
+	}
+#endif
+	// install
+	{
+		ComponentListRow row;
+		auto openInstallNow = [this] { mWindow->pushGui(new GuiInstallStart(mWindow)); };
+		row.makeAcceptInputHandler(openInstallNow);
+		auto installSettings = std::make_shared<TextComponent>(mWindow, _("INSTALL BATOCERA ON A NEW DISK"),
+			Font::get(FONT_SIZE_MEDIUM), 0x777777FF);
+		auto bracket = makeArrow(mWindow);
+		row.addElement(installSettings, true);
+		row.addElement(bracket, false);
+		s->addRow(row);
+	}
+
+	//Security
+	{
+		ComponentListRow row;
+		std::function<void()> openGui = [this] {
+			GuiSettings *securityGui = new GuiSettings(mWindow, _("SECURITY").c_str());
+			auto securityEnabled = std::make_shared<SwitchComponent>(mWindow);
+			securityEnabled->setState(SystemConf::getInstance()->get("system.security.enabled") == "1");
+			securityGui->addWithLabel(_("ENFORCE SECURITY"), securityEnabled);
+
+			auto rootpassword = std::make_shared<TextComponent>(mWindow,
+				ApiSystem::getInstance()->getRootPassword(),
+				Font::get(FONT_SIZE_MEDIUM), 0x777777FF);
+			securityGui->addWithLabel(_("ROOT PASSWORD"), rootpassword);
+
+			securityGui->addSaveFunc([this, securityEnabled] {
+				Window* window = this->mWindow;
+				bool reboot = false;
+
+				if (securityEnabled->changed()) {
+					SystemConf::getInstance()->set("system.security.enabled",
+						securityEnabled->getState() ? "1" : "0");
+					SystemConf::getInstance()->saveSystemConf();
+					reboot = true;
+				}
+
+				if (reboot) {
+					window->displayMessage(_("A REBOOT OF THE SYSTEM IS REQUIRED TO APPLY THE NEW CONFIGURATION"));
+				}
+			});
+			mWindow->pushGui(securityGui);
+		};
+		row.makeAcceptInputHandler(openGui);
+		auto securitySettings = std::make_shared<TextComponent>(mWindow, _("SECURITY"),
+			Font::get(FONT_SIZE_MEDIUM), 0x777777FF);
+		auto bracket = makeArrow(mWindow);
+		row.addElement(securitySettings, true);
+		row.addElement(bracket, false);
+		s->addRow(row);
+	}
+
+	s->addSaveFunc([overclock_choice, window, language_choice, language, optionsStorage, selectedStorage] {
+		bool reboot = false;
+		if (optionsStorage->changed()) {
+			ApiSystem::getInstance()->setStorage(optionsStorage->getSelected());
+			reboot = true;
+		}
+
+		if (overclock_choice->changed()) {
+			Settings::getInstance()->setString("Overclock", overclock_choice->getSelected());
+			ApiSystem::getInstance()->setOverclock(overclock_choice->getSelected());
+			reboot = true;
+		}
+		if (language_choice->changed()) {
+			SystemConf::getInstance()->set("system.language",
+				language_choice->getSelected());
+			SystemConf::getInstance()->saveSystemConf();
+			reboot = true;
+		}
+		if (reboot) {
+			window->displayMessage(_("A REBOOT OF THE SYSTEM IS REQUIRED TO APPLY THE NEW CONFIGURATION"));
+		}
+
 	});
-      mWindow->pushGui(securityGui);
-    };
-    row.makeAcceptInputHandler(openGui);
-    auto securitySettings = std::make_shared<TextComponent>(mWindow, _("SECURITY"),
-							    Font::get(FONT_SIZE_MEDIUM), 0x777777FF);
-    auto bracket = makeArrow(mWindow);
-    row.addElement(securitySettings, true);
-    row.addElement(bracket, false);
-    s->addRow(row);
-  }
-  
-  s->addSaveFunc([overclock_choice, window, language_choice, language, optionsStorage, selectedStorage] {
-      bool reboot = false;
-      if (optionsStorage->changed()) {
-	ApiSystem::getInstance()->setStorage(optionsStorage->getSelected());
-	reboot = true;
-      }
-      
-      if(overclock_choice->changed()) {
-	Settings::getInstance()->setString("Overclock", overclock_choice->getSelected());
-	ApiSystem::getInstance()->setOverclock(overclock_choice->getSelected());
-	reboot = true;
-      }
-      if(language_choice->changed()) {
-	SystemConf::getInstance()->set("system.language",
-				       language_choice->getSelected());
-	SystemConf::getInstance()->saveSystemConf();
-	reboot = true;
-      }
-      if (reboot) {
-	window->displayMessage(_("A REBOOT OF THE SYSTEM IS REQUIRED TO APPLY THE NEW CONFIGURATION"));
-      }
-      
-    });
-  mWindow->pushGui(s);
+	mWindow->pushGui(s);
 }
 
 void GuiMenu::openGamesSettings_batocera() {
@@ -1551,487 +1557,502 @@ void GuiMenu::openControllersSettings_batocera() {
   window->pushGui(s);
 }
 
-void GuiMenu::openUISettings_batocera() {
-  auto s = new GuiSettings(mWindow, _("UI SETTINGS").c_str());
+void GuiMenu::openUISettings_batocera() 
+{
+	auto s = new GuiSettings(mWindow, _("UI SETTINGS").c_str());
 
-  //UI mode
-  auto UImodeSelection = std::make_shared< OptionListComponent<std::string> >(mWindow, _("UI MODE"), false);
-  std::vector<std::string> UImodes = UIModeController::getInstance()->getUIModes();
-  for (auto it = UImodes.cbegin(); it != UImodes.cend(); it++)
-    UImodeSelection->add(*it, *it, Settings::getInstance()->getString("UIMode") == *it);
-  s->addWithLabel(_("UI MODE"), UImodeSelection);
-  Window* window = mWindow;
-  s->addSaveFunc([ UImodeSelection, window]
-		 {
-		   std::string selectedMode = UImodeSelection->getSelected();
-		   if (selectedMode != "Full")
-		     {
-		       std::string msg = _("You are changing the UI to a restricted mode:\nThis will hide most menu-options to prevent changes to the system.\nTo unlock and return to the full UI, enter this code:") + "\n";
-		       msg += "\"" + UIModeController::getInstance()->getFormattedPassKeyStr() + "\"\n\n";
-		       msg += _("Do you want to proceed ?");
-		       window->pushGui(new GuiMsgBox(window, msg, 
-						     _("YES"), [selectedMode] {
-						       LOG(LogDebug) << "Setting UI mode to " << selectedMode;
-						       Settings::getInstance()->setString("UIMode", selectedMode);
-						       Settings::getInstance()->saveFile();
-						     }, _("NO") ,nullptr));
-		     }
-		 });
-
-  // video device
-  auto optionsVideo = std::make_shared<OptionListComponent<std::string> >(mWindow, _("VIDEO OUTPUT"), false);
-  std::string currentDevice = SystemConf::getInstance()->get("global.videooutput");
-  if (currentDevice.empty()) currentDevice = "auto";
-
-  std::vector<std::string> availableVideo = ApiSystem::getInstance()->getAvailableVideoOutputDevices();
-
-  bool vfound=false;
-  for(auto it = availableVideo.begin(); it != availableVideo.end(); it++){
-    optionsVideo->add((*it), (*it), currentDevice == (*it));
-    if(currentDevice == (*it)) {
-      vfound = true;
-    }
-  }
-  if(vfound == false) {
-    optionsVideo->add(currentDevice, currentDevice, true);
-  }
-  s->addWithLabel(_("VIDEO OUTPUT"), optionsVideo);
-
-  s->addSaveFunc([this, optionsVideo, currentDevice] {
-      if (optionsVideo->changed()) {
-	SystemConf::getInstance()->set("global.videooutput", optionsVideo->getSelected());
-	SystemConf::getInstance()->saveSystemConf();
-	mWindow->displayMessage(_("A REBOOT OF THE SYSTEM IS REQUIRED TO APPLY THE NEW CONFIGURATION"));
-      }
-    });
-
-  // theme set
-  auto themeSets = ThemeData::getThemeSets();
-
-  if (!themeSets.empty()) {
-    auto selectedSet = themeSets.find(Settings::getInstance()->getString("ThemeSet"));
-    if (selectedSet == themeSets.end())
-      selectedSet = themeSets.begin();
-
-    auto theme_set = std::make_shared<OptionListComponent<std::string> >(mWindow, _("THEME SET"),
-									 false);
-    for (auto it = themeSets.begin(); it != themeSets.end(); it++)
-      theme_set->add(it->first, it->first, it == selectedSet);
-    s->addWithLabel(_("THEME SET"), theme_set);
-
-    Window *window = mWindow;
-    s->addSaveFunc([window, theme_set] {
-	bool needReload = false;
-	if (theme_set->changed()) {
-	  needReload = true;
-	  Settings::getInstance()->setString("ThemeSet", theme_set->getSelected());
-	}
-
-	if (needReload)
-	  ViewController::get()->reloadAll(); // TODO - replace this with some sort of signal-based implementation
-      });
-  }
-
-  // GameList view style
-  auto gamelist_style = std::make_shared< OptionListComponent<std::string> >(mWindow, _("GAMELIST VIEW STYLE"), false);
-  std::vector<std::string> styles;
-  styles.push_back("automatic");
-  styles.push_back("basic");
-  styles.push_back("detailed");
-  styles.push_back("video");
-  styles.push_back("grid");
-
-  for (auto it = styles.cbegin(); it != styles.cend(); it++)
-    gamelist_style->add(*it, *it, Settings::getInstance()->getString("GamelistViewStyle") == *it);
-  s->addWithLabel(_("GAMELIST VIEW STYLE"), gamelist_style);
-  s->addSaveFunc([gamelist_style] {
-      bool needReload = false;
-      if (Settings::getInstance()->getString("GamelistViewStyle") != gamelist_style->getSelected())
-	needReload = true;
-      Settings::getInstance()->setString("GamelistViewStyle", gamelist_style->getSelected());
-      if (needReload)
-	ViewController::get()->reloadAll();
-    });
-
-  // Optionally start in selected system
-  auto systemfocus_list = std::make_shared< OptionListComponent<std::string> >(mWindow, _("START ON SYSTEM"), false);
-  systemfocus_list->add("NONE", "", Settings::getInstance()->getString("StartupSystem") == "");
-  for (auto it = SystemData::sSystemVector.cbegin(); it != SystemData::sSystemVector.cend(); it++)
-    {
-      if ("retropie" != (*it)->getName())
+	//UI mode
+	auto UImodeSelection = std::make_shared< OptionListComponent<std::string> >(mWindow, _("UI MODE"), false);
+	std::vector<std::string> UImodes = UIModeController::getInstance()->getUIModes();
+	for (auto it = UImodes.cbegin(); it != UImodes.cend(); it++)
+		UImodeSelection->add(*it, *it, Settings::getInstance()->getString("UIMode") == *it);
+	s->addWithLabel(_("UI MODE"), UImodeSelection);
+	Window* window = mWindow;
+	s->addSaveFunc([UImodeSelection, window]
 	{
-	  systemfocus_list->add((*it)->getName(), (*it)->getName(), Settings::getInstance()->getString("StartupSystem") == (*it)->getName());
+		std::string selectedMode = UImodeSelection->getSelected();
+		if (selectedMode != "Full")
+		{
+			std::string msg = _("You are changing the UI to a restricted mode:\nThis will hide most menu-options to prevent changes to the system.\nTo unlock and return to the full UI, enter this code:") + "\n";
+			msg += "\"" + UIModeController::getInstance()->getFormattedPassKeyStr() + "\"\n\n";
+			msg += _("Do you want to proceed ?");
+			window->pushGui(new GuiMsgBox(window, msg,
+				_("YES"), [selectedMode] {
+				LOG(LogDebug) << "Setting UI mode to " << selectedMode;
+				Settings::getInstance()->setString("UIMode", selectedMode);
+				Settings::getInstance()->saveFile();
+			}, _("NO"), nullptr));
+		}
+	});
+
+#ifndef WIN32
+	// video device
+	auto optionsVideo = std::make_shared<OptionListComponent<std::string> >(mWindow, _("VIDEO OUTPUT"), false);
+	std::string currentDevice = SystemConf::getInstance()->get("global.videooutput");
+	if (currentDevice.empty()) currentDevice = "auto";
+
+	std::vector<std::string> availableVideo = ApiSystem::getInstance()->getAvailableVideoOutputDevices();
+
+	bool vfound = false;
+	for (auto it = availableVideo.begin(); it != availableVideo.end(); it++) {
+		optionsVideo->add((*it), (*it), currentDevice == (*it));
+		if (currentDevice == (*it)) {
+			vfound = true;
+		}
 	}
-    }
-  s->addWithLabel(_("START ON SYSTEM"), systemfocus_list);
-  s->addSaveFunc([systemfocus_list] {
-      Settings::getInstance()->setString("StartupSystem", systemfocus_list->getSelected());
-    });
+	if (vfound == false) {
+		optionsVideo->add(currentDevice, currentDevice, true);
+	}
+	s->addWithLabel(_("VIDEO OUTPUT"), optionsVideo);
 
-  // Batocera: select systems to hide
-  auto openSystemsHideNow = [this] { mWindow->pushGui(new GuiSystemsHide(mWindow)); };
-  ComponentListRow rowHide;
-  rowHide.makeAcceptInputHandler(openSystemsHideNow);
-  auto SystemsHideSettings = std::make_shared<TextComponent>(mWindow, _("DISPLAY / HIDE SYSTEMS"),
-		  Font::get(FONT_SIZE_MEDIUM), 0x777777FF);
-  auto bracket = makeArrow(mWindow);
-  rowHide.addElement(SystemsHideSettings, true);
-  rowHide.addElement(bracket, false);
-  s->addRow(rowHide);
+	s->addSaveFunc([this, optionsVideo, currentDevice] {
+		if (optionsVideo->changed()) {
+			SystemConf::getInstance()->set("global.videooutput", optionsVideo->getSelected());
+			SystemConf::getInstance()->saveSystemConf();
+			mWindow->displayMessage(_("A REBOOT OF THE SYSTEM IS REQUIRED TO APPLY THE NEW CONFIGURATION"));
+		}
+	});
+#endif
 
-  // transition style
-  auto transition_style = std::make_shared<OptionListComponent<std::string> >(mWindow,
-									      _("TRANSITION STYLE"),
-									      false);
-  std::vector<std::string> transitions;
-  transitions.push_back("fade");
-  transitions.push_back("slide");
-  transitions.push_back("instant");
-  for (auto it = transitions.begin(); it != transitions.end(); it++)
-    transition_style->add(*it, *it, Settings::getInstance()->getString("TransitionStyle") == *it);
-  s->addWithLabel(_("TRANSITION STYLE"), transition_style);
-  s->addSaveFunc([transition_style] {
-      if(transition_style->changed()) {
-	Settings::getInstance()->setString("TransitionStyle", transition_style->getSelected());
-      }
-    });
+	// theme set
+	auto themeSets = ThemeData::getThemeSets();
 
-  // screensaver time
-  auto screensaver_time = std::make_shared<SliderComponent>(mWindow, 0.f, 30.f, 1.f, "m");
-  screensaver_time->setValue(
-                             (float) (Settings::getInstance()->getInt("ScreenSaverTime") / (1000 * 60)));
-  s->addWithLabel(_("SCREENSAVER AFTER"), screensaver_time);
-  s->addSaveFunc([screensaver_time] {
-      Settings::getInstance()->setInt("ScreenSaverTime",
-				      (int) round(screensaver_time->getValue()) * (1000 * 60));
-    });
+	if (!themeSets.empty()) {
+		auto selectedSet = themeSets.find(Settings::getInstance()->getString("ThemeSet"));
+		if (selectedSet == themeSets.end())
+			selectedSet = themeSets.begin();
 
-  // Batocera screensavers: added "random video" (aka "demo mode") and slideshow at the same time,
-  // for those who don't scrape videos and stick with pictures
-  auto screensaver_behavior = std::make_shared<OptionListComponent<std::string> >(mWindow,
-								_("TRANSITION STYLE"), false);
-  std::vector<std::string> screensavers;
-  screensavers.push_back("dim");
-  screensavers.push_back("black");
-  screensavers.push_back("random video");
-  screensavers.push_back("slideshow");
-  for(auto it = screensavers.cbegin(); it != screensavers.cend(); it++)
-	  screensaver_behavior->add(*it, *it, Settings::getInstance()->getString("ScreenSaverBehavior") == *it);
-  s->addWithLabel(_("SCREENSAVER BEHAVIOR"), screensaver_behavior);
-  s->addSaveFunc([this, screensaver_behavior] {
-		  if (Settings::getInstance()->getString("ScreenSaverBehavior") != "random video" 
-						&& screensaver_behavior->getSelected() == "random video") {
+		auto theme_set = std::make_shared<OptionListComponent<std::string> >(mWindow, _("THEME SET"),
+			false);
+		for (auto it = themeSets.begin(); it != themeSets.end(); it++)
+			theme_set->add(it->first, it->first, it == selectedSet);
+		s->addWithLabel(_("THEME SET"), theme_set);
+
+		Window *window = mWindow;
+		s->addSaveFunc([window, theme_set] {
+			bool needReload = false;
+			if (theme_set->changed()) {
+				needReload = true;
+				Settings::getInstance()->setString("ThemeSet", theme_set->getSelected());
+			}
+
+
+			if (needReload)
+				ViewController::get()->reloadAll(); // TODO - replace this with some sort of signal-based implementation	
+		});
+	}
+
+	// GameList view style
+	auto gamelist_style = std::make_shared< OptionListComponent<std::string> >(mWindow, _("GAMELIST VIEW STYLE"), false);
+	std::vector<std::string> styles;
+	styles.push_back("automatic");
+	styles.push_back("basic");
+	styles.push_back("detailed");
+	styles.push_back("video");
+	styles.push_back("grid");
+
+	for (auto it = styles.cbegin(); it != styles.cend(); it++)
+		gamelist_style->add(*it, *it, Settings::getInstance()->getString("GamelistViewStyle") == *it);
+	s->addWithLabel(_("GAMELIST VIEW STYLE"), gamelist_style);
+	s->addSaveFunc([gamelist_style] {
+		bool needReload = false;
+		if (Settings::getInstance()->getString("GamelistViewStyle") != gamelist_style->getSelected())
+			needReload = true;
+		Settings::getInstance()->setString("GamelistViewStyle", gamelist_style->getSelected());
+		if (needReload)
+			ViewController::get()->reloadAll();
+	});
+
+	// Optionally start in selected system
+	auto systemfocus_list = std::make_shared< OptionListComponent<std::string> >(mWindow, _("START ON SYSTEM"), false);
+	systemfocus_list->add("NONE", "", Settings::getInstance()->getString("StartupSystem") == "");
+	for (auto it = SystemData::sSystemVector.cbegin(); it != SystemData::sSystemVector.cend(); it++)
+	{
+		if ("retropie" != (*it)->getName())
+		{
+			systemfocus_list->add((*it)->getName(), (*it)->getName(), Settings::getInstance()->getString("StartupSystem") == (*it)->getName());
+		}
+	}
+	s->addWithLabel(_("START ON SYSTEM"), systemfocus_list);
+	s->addSaveFunc([systemfocus_list] {
+		Settings::getInstance()->setString("StartupSystem", systemfocus_list->getSelected());
+	});
+
+	// Batocera: select systems to hide
+	auto openSystemsHideNow = [this] { mWindow->pushGui(new GuiSystemsHide(mWindow)); };
+	ComponentListRow rowHide;
+	rowHide.makeAcceptInputHandler(openSystemsHideNow);
+	auto SystemsHideSettings = std::make_shared<TextComponent>(mWindow, _("DISPLAY / HIDE SYSTEMS"),
+		Font::get(FONT_SIZE_MEDIUM), 0x777777FF);
+	auto bracket = makeArrow(mWindow);
+	rowHide.addElement(SystemsHideSettings, true);
+	rowHide.addElement(bracket, false);
+	s->addRow(rowHide);
+
+	// transition style
+	auto transition_style = std::make_shared<OptionListComponent<std::string> >(mWindow,
+		_("TRANSITION STYLE"),
+		false);
+	std::vector<std::string> transitions;
+	transitions.push_back("fade");
+	transitions.push_back("slide");
+	transitions.push_back("instant");
+	for (auto it = transitions.begin(); it != transitions.end(); it++)
+		transition_style->add(*it, *it, Settings::getInstance()->getString("TransitionStyle") == *it);
+	s->addWithLabel(_("TRANSITION STYLE"), transition_style);
+	s->addSaveFunc([transition_style] {
+		if (transition_style->changed()) {
+			Settings::getInstance()->setString("TransitionStyle", transition_style->getSelected());
+		}
+	});
+
+	// screensaver time
+	auto screensaver_time = std::make_shared<SliderComponent>(mWindow, 0.f, 30.f, 1.f, "m");
+	screensaver_time->setValue(
+		(float)(Settings::getInstance()->getInt("ScreenSaverTime") / (1000 * 60)));
+	s->addWithLabel(_("SCREENSAVER AFTER"), screensaver_time);
+	s->addSaveFunc([screensaver_time] {
+		Settings::getInstance()->setInt("ScreenSaverTime",
+			(int)round(screensaver_time->getValue()) * (1000 * 60));
+	});
+
+	// Batocera screensavers: added "random video" (aka "demo mode") and slideshow at the same time,
+	// for those who don't scrape videos and stick with pictures
+	auto screensaver_behavior = std::make_shared<OptionListComponent<std::string> >(mWindow,
+		_("TRANSITION STYLE"), false);
+	std::vector<std::string> screensavers;
+	screensavers.push_back("dim");
+	screensavers.push_back("black");
+	screensavers.push_back("random video");
+	screensavers.push_back("slideshow");
+	for (auto it = screensavers.cbegin(); it != screensavers.cend(); it++)
+		screensaver_behavior->add(*it, *it, Settings::getInstance()->getString("ScreenSaverBehavior") == *it);
+	s->addWithLabel(_("SCREENSAVER BEHAVIOR"), screensaver_behavior);
+	s->addSaveFunc([this, screensaver_behavior] {
+		if (Settings::getInstance()->getString("ScreenSaverBehavior") != "random video"
+			&& screensaver_behavior->getSelected() == "random video") {
 			// if before it wasn't risky but now there's a risk of problems, show warning
 			mWindow->pushGui(new GuiMsgBox(mWindow,
-			_("THE \"RANDOM VIDEO\" SCREENSAVER SHOWS VIDEOS FROM YOUR GAMELIST.\nIF YOU DON'T HAVE VIDEOS, OR IF NONE OF THEM CAN BE PLAYED AFTER A FEW ATTEMPTS, IT WILL DEFAULT TO \"BLACK\".\nMORE OPTIONS IN THE \"UI SETTINGS\" -> \"RANDOM VIDEO SCREENSAVER SETTINGS\" MENU."),
+				_("THE \"RANDOM VIDEO\" SCREENSAVER SHOWS VIDEOS FROM YOUR GAMELIST.\nIF YOU DON'T HAVE VIDEOS, OR IF NONE OF THEM CAN BE PLAYED AFTER A FEW ATTEMPTS, IT WILL DEFAULT TO \"BLACK\".\nMORE OPTIONS IN THE \"UI SETTINGS\" -> \"RANDOM VIDEO SCREENSAVER SETTINGS\" MENU."),
 				_("OK"), [] { return; }));
 		}
 		Settings::getInstance()->setString("ScreenSaverBehavior", screensaver_behavior->getSelected());
 		PowerSaver::updateTimeouts();
-		});
+	});
 
-  ComponentListRow row;
-  // show filtered menu
-  row.elements.clear();
-  row.addElement(std::make_shared<TextComponent>(mWindow, _("RANDOM VIDEO SCREENSAVER SETTINGS"), Font::get(FONT_SIZE_MEDIUM), 0x777777FF), true);
-  row.addElement(makeArrow(mWindow), false);
-  row.makeAcceptInputHandler(std::bind(&GuiMenu::openVideoScreensaverOptions, this));
-  s->addRow(row);
+	ComponentListRow row;
+	// show filtered menu
+	row.elements.clear();
+	row.addElement(std::make_shared<TextComponent>(mWindow, _("RANDOM VIDEO SCREENSAVER SETTINGS"), Font::get(FONT_SIZE_MEDIUM), 0x777777FF), true);
+	row.addElement(makeArrow(mWindow), false);
+	row.makeAcceptInputHandler(std::bind(&GuiMenu::openVideoScreensaverOptions, this));
+	s->addRow(row);
 
-  row.elements.clear();
-  row.addElement(std::make_shared<TextComponent>(mWindow, _("SLIDESHOW SCREENSAVER SETTINGS"), Font::get(FONT_SIZE_MEDIUM), 0x777777FF), true);
-  row.addElement(makeArrow(mWindow), false);
-  row.makeAcceptInputHandler(std::bind(&GuiMenu::openSlideshowScreensaverOptions, this));
-  s->addRow(row);
+	row.elements.clear();
+	row.addElement(std::make_shared<TextComponent>(mWindow, _("SLIDESHOW SCREENSAVER SETTINGS"), Font::get(FONT_SIZE_MEDIUM), 0x777777FF), true);
+	row.addElement(makeArrow(mWindow), false);
+	row.makeAcceptInputHandler(std::bind(&GuiMenu::openSlideshowScreensaverOptions, this));
+	s->addRow(row);
 
-  // clock
-  auto clock = std::make_shared<SwitchComponent>(mWindow);
-  clock->setState(Settings::getInstance()->getBool("DrawClock"));
-  s->addWithLabel(_("SHOW CLOCK"), clock);
-  s->addSaveFunc(
-		 [clock] { Settings::getInstance()->setBool("DrawClock", clock->getState()); });
+	// clock
+	auto clock = std::make_shared<SwitchComponent>(mWindow);
+	clock->setState(Settings::getInstance()->getBool("DrawClock"));
+	s->addWithLabel(_("SHOW CLOCK"), clock);
+	s->addSaveFunc(
+		[clock] { Settings::getInstance()->setBool("DrawClock", clock->getState()); });
 
-  // show help
-  auto show_help = std::make_shared<SwitchComponent>(mWindow);
-  show_help->setState(Settings::getInstance()->getBool("ShowHelpPrompts"));
-  s->addWithLabel(_("ON-SCREEN HELP"), show_help);
-  s->addSaveFunc(
-		 [show_help] {
-		   Settings::getInstance()->setBool("ShowHelpPrompts", show_help->getState());
-		 });
+	// show help
+	auto show_help = std::make_shared<SwitchComponent>(mWindow);
+	show_help->setState(Settings::getInstance()->getBool("ShowHelpPrompts"));
+	s->addWithLabel(_("ON-SCREEN HELP"), show_help);
+	s->addSaveFunc(
+		[show_help] {
+		Settings::getInstance()->setBool("ShowHelpPrompts", show_help->getState());
+	});
 
-  // quick system select (left/right in game list view)
-  auto quick_sys_select = std::make_shared<SwitchComponent>(mWindow);
-  quick_sys_select->setState(Settings::getInstance()->getBool("QuickSystemSelect"));
-  s->addWithLabel(_("QUICK SYSTEM SELECT"), quick_sys_select);
-  s->addSaveFunc([quick_sys_select] {
-      Settings::getInstance()->setBool("QuickSystemSelect", quick_sys_select->getState());
-    });
+	// quick system select (left/right in game list view)
+	auto quick_sys_select = std::make_shared<SwitchComponent>(mWindow);
+	quick_sys_select->setState(Settings::getInstance()->getBool("QuickSystemSelect"));
+	s->addWithLabel(_("QUICK SYSTEM SELECT"), quick_sys_select);
+	s->addSaveFunc([quick_sys_select] {
+		Settings::getInstance()->setBool("QuickSystemSelect", quick_sys_select->getState());
+	});
 
-  // Enable OSK (On-Screen-Keyboard)
-  auto osk_enable = std::make_shared<SwitchComponent>(mWindow);
-  osk_enable->setState(Settings::getInstance()->getBool("UseOSK"));
-  s->addWithLabel(_("ON SCREEN KEYBOARD"), osk_enable);
-  s->addSaveFunc([osk_enable] {
-      Settings::getInstance()->setBool("UseOSK", osk_enable->getState()); } );
+	// Enable OSK (On-Screen-Keyboard)
+	auto osk_enable = std::make_shared<SwitchComponent>(mWindow);
+	osk_enable->setState(Settings::getInstance()->getBool("UseOSK"));
+	s->addWithLabel(_("ON SCREEN KEYBOARD"), osk_enable);
+	s->addSaveFunc([osk_enable] {
+		Settings::getInstance()->setBool("UseOSK", osk_enable->getState()); });
 
-  // carousel transition option
-  auto move_carousel = std::make_shared<SwitchComponent>(mWindow);
-  move_carousel->setState(Settings::getInstance()->getBool("MoveCarousel"));
-  s->addWithLabel(_("CAROUSEL TRANSITIONS"), move_carousel);
-  s->addSaveFunc([move_carousel] {
-      if (move_carousel->getState()
-	  && !Settings::getInstance()->getBool("MoveCarousel")
-	  && PowerSaver::getMode() == PowerSaver::INSTANT)
+	// carousel transition option
+	auto move_carousel = std::make_shared<SwitchComponent>(mWindow);
+	move_carousel->setState(Settings::getInstance()->getBool("MoveCarousel"));
+	s->addWithLabel(_("CAROUSEL TRANSITIONS"), move_carousel);
+	s->addSaveFunc([move_carousel] {
+		if (move_carousel->getState()
+			&& !Settings::getInstance()->getBool("MoveCarousel")
+			&& PowerSaver::getMode() == PowerSaver::INSTANT)
+		{
+			Settings::getInstance()->setString("PowerSaverMode", "default");
+			PowerSaver::init();
+		}
+		Settings::getInstance()->setBool("MoveCarousel", move_carousel->getState());
+	});
+
+	// enable filters (ForceDisableFilters)
+	auto enable_filter = std::make_shared<SwitchComponent>(mWindow);
+	enable_filter->setState(!Settings::getInstance()->getBool("ForceDisableFilters"));
+	s->addWithLabel(_("ENABLE FILTERS"), enable_filter);
+	s->addSaveFunc([enable_filter] {
+		bool filter_is_enabled = !Settings::getInstance()->getBool("ForceDisableFilters");
+		Settings::getInstance()->setBool("ForceDisableFilters", !enable_filter->getState());
+		if (enable_filter->getState() != filter_is_enabled) ViewController::get()->ReloadAndGoToStart();
+	});
+
+	// framerate
+	auto framerate = std::make_shared<SwitchComponent>(mWindow);
+	framerate->setState(Settings::getInstance()->getBool("DrawFramerate"));
+	s->addWithLabel(_("SHOW FRAMERATE"), framerate);
+	s->addSaveFunc(
+		[framerate] { Settings::getInstance()->setBool("DrawFramerate", framerate->getState()); });
+
+	// overscan
+	auto overscan_enabled = std::make_shared<SwitchComponent>(mWindow);
+	overscan_enabled->setState(Settings::getInstance()->getBool("Overscan"));
+	s->addWithLabel(_("OVERSCAN"), overscan_enabled);
+	s->addSaveFunc([overscan_enabled] {
+		if (Settings::getInstance()->getBool("Overscan") != overscan_enabled->getState()) {
+			Settings::getInstance()->setBool("Overscan", overscan_enabled->getState());
+			ApiSystem::getInstance()->setOverscan(overscan_enabled->getState());
+		}
+	});
+
+	// gamelists
+	auto save_gamelists = std::make_shared<SwitchComponent>(mWindow);
+	save_gamelists->setState(Settings::getInstance()->getBool("SaveGamelistsOnExit"));
+	s->addWithLabel(_("SAVE METADATA ON EXIT"), save_gamelists);
+	s->addSaveFunc([save_gamelists] { Settings::getInstance()->setBool("SaveGamelistsOnExit", save_gamelists->getState()); });
+
+	auto parse_gamelists = std::make_shared<SwitchComponent>(mWindow);
+	parse_gamelists->setState(Settings::getInstance()->getBool("ParseGamelistOnly"));
+	s->addWithLabel(_("PARSE GAMESLISTS ONLY"), parse_gamelists);
+	s->addSaveFunc([parse_gamelists] { Settings::getInstance()->setBool("ParseGamelistOnly", parse_gamelists->getState()); });
+
+	auto local_art = std::make_shared<SwitchComponent>(mWindow);
+	local_art->setState(Settings::getInstance()->getBool("LocalArt"));
+	s->addWithLabel(_("SEARCH FOR LOCAL ART"), local_art);
+	s->addSaveFunc([local_art] { Settings::getInstance()->setBool("LocalArt", local_art->getState()); });
+
+	// hidden files
+	auto hidden_files = std::make_shared<SwitchComponent>(mWindow);
+	hidden_files->setState(Settings::getInstance()->getBool("ShowHiddenFiles"));
+	s->addWithLabel(_("SHOW HIDDEN FILES"), hidden_files);
+	s->addSaveFunc([hidden_files] { Settings::getInstance()->setBool("ShowHiddenFiles", hidden_files->getState()); });
+
+	// maximum vram
+	auto max_vram = std::make_shared<SliderComponent>(mWindow, 0.f, 1000.f, 10.f, "Mb");
+	max_vram->setValue((float)(Settings::getInstance()->getInt("MaxVRAM")));
+	s->addWithLabel(_("VRAM LIMIT"), max_vram);
+	s->addSaveFunc([max_vram] { Settings::getInstance()->setInt("MaxVRAM", (int)round(max_vram->getValue())); });
+
+	// power saver
+	auto power_saver = std::make_shared< OptionListComponent<std::string> >(mWindow, _("POWER SAVER MODES"), false);
+	std::vector<std::string> modes;
+	modes.push_back("disabled");
+	modes.push_back("default");
+	modes.push_back("enhanced");
+	modes.push_back("instant");
+	for (auto it = modes.cbegin(); it != modes.cend(); it++)
+		power_saver->add(*it, *it, Settings::getInstance()->getString("PowerSaverMode") == *it);
+	s->addWithLabel(_("POWER SAVER MODES"), power_saver);
+	s->addSaveFunc([this, power_saver] {
+		if (Settings::getInstance()->getString("PowerSaverMode") != "instant" && power_saver->getSelected() == "instant") {
+			Settings::getInstance()->setString("TransitionStyle", "instant");
+			Settings::getInstance()->setBool("MoveCarousel", false);
+			Settings::getInstance()->setBool("EnableSounds", false);
+		}
+		Settings::getInstance()->setString("PowerSaverMode", power_saver->getSelected());
+		PowerSaver::init();
+	});
+
+	mWindow->pushGui(s);
+}
+
+void GuiMenu::openSoundSettings_batocera() 
+{
+	auto s = new GuiSettings(mWindow, _("SOUND SETTINGS").c_str());
+
+	// volume
+	auto volume = std::make_shared<SliderComponent>(mWindow, 0.f, 100.f, 1.f, "%");
+	volume->setValue((float)VolumeControl::getInstance()->getVolume());
+	s->addWithLabel(_("SYSTEM VOLUME"), volume);
+
+	// disable sounds
+	auto music_enabled = std::make_shared<SwitchComponent>(mWindow);
+	music_enabled->setState(!(SystemConf::getInstance()->get("audio.bgmusic") == "0"));
+	s->addWithLabel(_("FRONTEND MUSIC"), music_enabled);
+	s->addSaveFunc([music_enabled] {
+		SystemConf::getInstance()->set("audio.bgmusic", music_enabled->getState() ? "1" : "0");
+		if (music_enabled->getState())
+			AudioManager::getInstance()->playRandomMusic();
+		else
+			AudioManager::getInstance()->stopMusic();
+	});
+
+	// batocera - display music titles
+	auto display_titles = std::make_shared<SwitchComponent>(mWindow);
+	display_titles->setState((SystemConf::getInstance()->get("audio.display_titles") == "1"));
+	s->addWithLabel(_("DISPLAY SONG TITLES"), display_titles);
+	s->addSaveFunc([display_titles] {
+		SystemConf::getInstance()->set("audio.display_titles", display_titles->getState() ? "1" : "0");
+	});
+
+	// batocera - music per system
+	auto music_per_system = std::make_shared<SwitchComponent>(mWindow);
+	music_per_system->setState(!(SystemConf::getInstance()->get("audio.persystem") == "0"));
+	s->addWithLabel(_("ONLY PLAY SYSTEM-SPECIFIC MUSIC FOLDER"), music_per_system);
+	s->addSaveFunc([music_per_system] {
+		SystemConf::getInstance()->set("audio.persystem", music_per_system->getState() ? "1" : "0");
+	});
+
+	// disable sounds
+	//auto sounds_enabled = std::make_shared<SwitchComponent>(mWindow);
+	//sounds_enabled->setState(Settings::getInstance()->getBool("EnableSounds"));
+	//s->addWithLabel(_("ENABLE NAVIGATION SOUNDS"), sounds_enabled);
+	//s->addSaveFunc([sounds_enabled] {
+	//    if (sounds_enabled->getState()
+	//	  && !Settings::getInstance()->getBool("EnableSounds")
+	//	  && PowerSaver::getMode() == PowerSaver::INSTANT)
+	//	{
+	//	  Settings::getInstance()->setString("PowerSaverMode", "default");
+	//	  PowerSaver::init();
+	//	}
+	//    Settings::getInstance()->setBool("EnableSounds", sounds_enabled->getState());
+	//  });
+
+	auto video_audio = std::make_shared<SwitchComponent>(mWindow);
+	video_audio->setState(Settings::getInstance()->getBool("VideoAudio"));
+	s->addWithLabel(_("ENABLE VIDEO AUDIO"), video_audio);
+	s->addSaveFunc([video_audio] { Settings::getInstance()->setBool("VideoAudio", video_audio->getState()); });
+
+#ifndef WIN32
+	// audio device
+	auto optionsAudio = std::make_shared<OptionListComponent<std::string> >(mWindow, _("OUTPUT DEVICE"), false);
+
+	std::vector<std::string> availableAudio = ApiSystem::getInstance()->getAvailableAudioOutputDevices();
+	std::string selectedAudio = ApiSystem::getInstance()->getCurrentAudioOutputDevice();
+	if (selectedAudio.empty()) 
+		selectedAudio = "auto";
+
+	if (SystemConf::getInstance()->get("system.es.menu") != "bartop") 
 	{
-	  Settings::getInstance()->setString("PowerSaverMode", "default");
-	  PowerSaver::init();
+		bool vfound = false;
+		for (auto it = availableAudio.begin(); it != availableAudio.end(); it++)
+		{
+			std::vector<std::string> tokens = Utils::String::split(*it, ' ');
+
+			if (selectedAudio == (*it))
+				vfound = true;
+
+			if (tokens.size() >= 2) 
+			{
+				// concatenat the ending words
+				std::string vname = "";
+				for (unsigned int i = 1; i < tokens.size(); i++) 
+				{
+					if (i > 2) vname += " ";
+					vname += tokens.at(i);
+				}
+				optionsAudio->add(vname, (*it), selectedAudio == (*it));
+			}
+			else
+				optionsAudio->add((*it), (*it), selectedAudio == (*it));			
+		}
+
+		if (vfound == false)
+			optionsAudio->add(selectedAudio, selectedAudio, true);
+
+		s->addWithLabel(_("OUTPUT DEVICE"), optionsAudio);
 	}
-      Settings::getInstance()->setBool("MoveCarousel", move_carousel->getState());
-    });
 
-  // enable filters (ForceDisableFilters)
-  auto enable_filter = std::make_shared<SwitchComponent>(mWindow);
-  enable_filter->setState(!Settings::getInstance()->getBool("ForceDisableFilters"));
-  s->addWithLabel(_("ENABLE FILTERS"), enable_filter);
-  s->addSaveFunc([enable_filter] { 
-      bool filter_is_enabled = !Settings::getInstance()->getBool("ForceDisableFilters");
-      Settings::getInstance()->setBool("ForceDisableFilters", !enable_filter->getState()); 
-      if (enable_filter->getState() != filter_is_enabled) ViewController::get()->ReloadAndGoToStart();
-    });
+	s->addSaveFunc([this, optionsAudio, selectedAudio, volume] {
+		bool v_need_reboot = false;
 
-  // framerate
-  auto framerate = std::make_shared<SwitchComponent>(mWindow);
-  framerate->setState(Settings::getInstance()->getBool("DrawFramerate"));
-  s->addWithLabel(_("SHOW FRAMERATE"), framerate);
-  s->addSaveFunc(
-		 [framerate] { Settings::getInstance()->setBool("DrawFramerate", framerate->getState()); });
+		VolumeControl::getInstance()->setVolume((int)round(volume->getValue()));
+		SystemConf::getInstance()->set("audio.volume",
+			std::to_string((int)round(volume->getValue())));
 
-  // overscan
-  auto overscan_enabled = std::make_shared<SwitchComponent>(mWindow);
-  overscan_enabled->setState(Settings::getInstance()->getBool("Overscan"));
-  s->addWithLabel(_("OVERSCAN"), overscan_enabled);
-  s->addSaveFunc([overscan_enabled] {
-      if (Settings::getInstance()->getBool("Overscan") != overscan_enabled->getState()) {
-	Settings::getInstance()->setBool("Overscan", overscan_enabled->getState());
-	ApiSystem::getInstance()->setOverscan(overscan_enabled->getState());
-      }
-    });
-  
-  // gamelists
-  auto save_gamelists = std::make_shared<SwitchComponent>(mWindow);
-  save_gamelists->setState(Settings::getInstance()->getBool("SaveGamelistsOnExit"));
-  s->addWithLabel(_("SAVE METADATA ON EXIT"), save_gamelists);
-  s->addSaveFunc([save_gamelists] { Settings::getInstance()->setBool("SaveGamelistsOnExit", save_gamelists->getState()); });
+		if (optionsAudio->changed()) {
+			SystemConf::getInstance()->set("audio.device", optionsAudio->getSelected());
+			ApiSystem::getInstance()->setAudioOutputDevice(optionsAudio->getSelected());
+			v_need_reboot = true;
+		}
+		SystemConf::getInstance()->saveSystemConf();
+		if (v_need_reboot)
+			mWindow->displayMessage(_("A REBOOT OF THE SYSTEM IS REQUIRED TO APPLY THE NEW CONFIGURATION"));
+	});
+#endif
 
-  auto parse_gamelists = std::make_shared<SwitchComponent>(mWindow);
-  parse_gamelists->setState(Settings::getInstance()->getBool("ParseGamelistOnly"));
-  s->addWithLabel(_("PARSE GAMESLISTS ONLY"), parse_gamelists);
-  s->addSaveFunc([parse_gamelists] { Settings::getInstance()->setBool("ParseGamelistOnly", parse_gamelists->getState()); });
-
-  auto local_art = std::make_shared<SwitchComponent>(mWindow);
-  local_art->setState(Settings::getInstance()->getBool("LocalArt"));
-  s->addWithLabel(_("SEARCH FOR LOCAL ART"), local_art);
-  s->addSaveFunc([local_art] { Settings::getInstance()->setBool("LocalArt", local_art->getState()); });
-
-  // hidden files
-  auto hidden_files = std::make_shared<SwitchComponent>(mWindow);
-  hidden_files->setState(Settings::getInstance()->getBool("ShowHiddenFiles"));
-  s->addWithLabel(_("SHOW HIDDEN FILES"), hidden_files);
-  s->addSaveFunc([hidden_files] { Settings::getInstance()->setBool("ShowHiddenFiles", hidden_files->getState()); });
-
-  // maximum vram
-  auto max_vram = std::make_shared<SliderComponent>(mWindow, 0.f, 1000.f, 10.f, "Mb");
-  max_vram->setValue((float)(Settings::getInstance()->getInt("MaxVRAM")));
-  s->addWithLabel(_("VRAM LIMIT"), max_vram);
-  s->addSaveFunc([max_vram] { Settings::getInstance()->setInt("MaxVRAM", (int)round(max_vram->getValue())); });
-
-  // power saver
-  auto power_saver = std::make_shared< OptionListComponent<std::string> >(mWindow, _("POWER SAVER MODES"), false);
-  std::vector<std::string> modes;
-  modes.push_back("disabled");
-  modes.push_back("default");
-  modes.push_back("enhanced");
-  modes.push_back("instant");
-  for (auto it = modes.cbegin(); it != modes.cend(); it++)
-    power_saver->add(*it, *it, Settings::getInstance()->getString("PowerSaverMode") == *it);
-  s->addWithLabel(_("POWER SAVER MODES"), power_saver);
-  s->addSaveFunc([this, power_saver] {
-      if (Settings::getInstance()->getString("PowerSaverMode") != "instant" && power_saver->getSelected() == "instant") {
-	Settings::getInstance()->setString("TransitionStyle", "instant");
-	Settings::getInstance()->setBool("MoveCarousel", false);
-	Settings::getInstance()->setBool("EnableSounds", false);
-      }
-      Settings::getInstance()->setString("PowerSaverMode", power_saver->getSelected());
-      PowerSaver::init();
-    });
-  
-  mWindow->pushGui(s);
+	mWindow->pushGui(s);
 }
 
-void GuiMenu::openSoundSettings_batocera() {
-  auto s = new GuiSettings(mWindow, _("SOUND SETTINGS").c_str());
+void GuiMenu::openNetworkSettings_batocera()
+{
+	Window *window = mWindow;
 
-  // volume
-  auto volume = std::make_shared<SliderComponent>(mWindow, 0.f, 100.f, 1.f, "%");
-  volume->setValue((float) VolumeControl::getInstance()->getVolume());
-  s->addWithLabel(_("SYSTEM VOLUME"), volume);
+	auto s = new GuiSettings(mWindow, _("NETWORK SETTINGS").c_str());
+	auto status = std::make_shared<TextComponent>(mWindow,
+		ApiSystem::getInstance()->ping() ? _("CONNECTED")
+		: _("NOT CONNECTED"),
+		Font::get(FONT_SIZE_MEDIUM), 0x777777FF);
+	s->addWithLabel(_("STATUS"), status);
+	auto ip = std::make_shared<TextComponent>(mWindow, ApiSystem::getInstance()->getIpAdress(),
+		Font::get(FONT_SIZE_MEDIUM), 0x777777FF);
+	s->addWithLabel(_("IP ADDRESS"), ip);
+	// Hostname
+	createInputTextRow(s, _("HOSTNAME"), "system.hostname", false);
 
-  // disable sounds
-  auto music_enabled = std::make_shared<SwitchComponent>(mWindow);
-  music_enabled->setState(!(SystemConf::getInstance()->get("audio.bgmusic") == "0"));
-  s->addWithLabel(_("FRONTEND MUSIC"), music_enabled);
-  s->addSaveFunc([music_enabled] {
-      SystemConf::getInstance()->set("audio.bgmusic", music_enabled->getState() ? "1" : "0");
-      if (music_enabled->getState())
-	AudioManager::getInstance()->playRandomMusic();
-      else
-	AudioManager::getInstance()->stopMusic();
-    });
+	// Wifi enable
+	auto enable_wifi = std::make_shared<SwitchComponent>(mWindow);
+	bool baseEnabled = SystemConf::getInstance()->get("wifi.enabled") == "1";
+	enable_wifi->setState(baseEnabled);
+	s->addWithLabel(_("ENABLE WIFI"), enable_wifi);
 
-  // batocera - display music titles
-  auto display_titles = std::make_shared<SwitchComponent>(mWindow);
-  display_titles->setState((SystemConf::getInstance()->get("audio.display_titles") == "1"));
-  s->addWithLabel(_("DISPLAY SONG TITLES"), display_titles);
-  s->addSaveFunc([display_titles] {
-      SystemConf::getInstance()->set("audio.display_titles", display_titles->getState() ? "1" : "0");
-    });
+	// window, title, settingstring,
+	const std::string baseSSID = SystemConf::getInstance()->get("wifi.ssid");
+	createInputTextRow(s, _("WIFI SSID"), "wifi.ssid", false);
+	const std::string baseKEY = SystemConf::getInstance()->get("wifi.key");
+	createInputTextRow(s, _("WIFI KEY"), "wifi.key", true);
 
-  // batocera - music per system
-  auto music_per_system = std::make_shared<SwitchComponent>(mWindow);
-  music_per_system->setState(!(SystemConf::getInstance()->get("audio.persystem") == "0"));
-  s->addWithLabel(_("ONLY PLAY SYSTEM-SPECIFIC MUSIC FOLDER"), music_per_system);
-  s->addSaveFunc([music_per_system] {
-      SystemConf::getInstance()->set("audio.persystem", music_per_system->getState() ? "1" : "0");
-    });
+	s->addSaveFunc([baseEnabled, baseSSID, baseKEY, enable_wifi, window] {
+		bool wifienabled = enable_wifi->getState();
+		SystemConf::getInstance()->set("wifi.enabled", wifienabled ? "1" : "0");
+		std::string newSSID = SystemConf::getInstance()->get("wifi.ssid");
+		std::string newKey = SystemConf::getInstance()->get("wifi.key");
+		SystemConf::getInstance()->saveSystemConf();
+		if (wifienabled) {
+			if (baseSSID != newSSID
+				|| baseKEY != newKey
+				|| !baseEnabled) {
+				if (ApiSystem::getInstance()->enableWifi(newSSID, newKey)) {
+					window->pushGui(
+						new GuiMsgBox(window, _("WIFI ENABLED"))
+					);
+				}
+				else {
+					window->pushGui(
+						new GuiMsgBox(window, _("WIFI CONFIGURATION ERROR"))
+					);
+				}
+			}
+		}
+		else if (baseEnabled) {
+			ApiSystem::getInstance()->disableWifi();
+		}
+	});
 
-  // disable sounds
-  //auto sounds_enabled = std::make_shared<SwitchComponent>(mWindow);
-  //sounds_enabled->setState(Settings::getInstance()->getBool("EnableSounds"));
-  //s->addWithLabel(_("ENABLE NAVIGATION SOUNDS"), sounds_enabled);
-  //s->addSaveFunc([sounds_enabled] {
-  //    if (sounds_enabled->getState()
-  //	  && !Settings::getInstance()->getBool("EnableSounds")
-  //	  && PowerSaver::getMode() == PowerSaver::INSTANT)
-  //	{
-  //	  Settings::getInstance()->setString("PowerSaverMode", "default");
-  //	  PowerSaver::init();
-  //	}
-  //    Settings::getInstance()->setBool("EnableSounds", sounds_enabled->getState());
-  //  });
-
-  auto video_audio = std::make_shared<SwitchComponent>(mWindow);
-  video_audio->setState(Settings::getInstance()->getBool("VideoAudio"));
-  s->addWithLabel(_("ENABLE VIDEO AUDIO"), video_audio);
-  s->addSaveFunc([video_audio] { Settings::getInstance()->setBool("VideoAudio", video_audio->getState()); });
-  
-  // audio device
-  auto optionsAudio = std::make_shared<OptionListComponent<std::string> >(mWindow, _("OUTPUT DEVICE"),
-									  false);
-  std::vector<std::string> availableAudio = ApiSystem::getInstance()->getAvailableAudioOutputDevices();
-  std::string selectedAudio = ApiSystem::getInstance()->getCurrentAudioOutputDevice();
-  if (selectedAudio.empty()) selectedAudio = "auto";
-
-  if (SystemConf::getInstance()->get("system.es.menu") != "bartop") {
-    bool vfound=false;
-    for(auto it = availableAudio.begin(); it != availableAudio.end(); it++){
-      std::vector<std::string> tokens;
-      boost::split( tokens, (*it), boost::is_any_of(" ") );
-      if(selectedAudio == (*it)) {
-	vfound = true;
-      }
-      if(tokens.size()>= 2){
-	// concatenat the ending words
-	std::string vname = "";
-	for(unsigned int i=1; i<tokens.size(); i++) {
-	  if(i > 2) vname += " ";
-	  vname += tokens.at(i);
-	}
-	optionsAudio->add(vname, (*it), selectedAudio == (*it));
-      } else {
-	optionsAudio->add((*it), (*it), selectedAudio == (*it));
-      }
-    }
-
-    if(vfound == false) {
-      optionsAudio->add(selectedAudio, selectedAudio, true);
-    }
-    s->addWithLabel(_("OUTPUT DEVICE"), optionsAudio);
-  }
-
-  s->addSaveFunc([this, optionsAudio, selectedAudio, volume] {
-      bool v_need_reboot = false;
-
-      VolumeControl::getInstance()->setVolume((int) round(volume->getValue()));
-      SystemConf::getInstance()->set("audio.volume",
-				     std::to_string((int) round(volume->getValue())));
-
-      if (optionsAudio->changed()) {
-	SystemConf::getInstance()->set("audio.device", optionsAudio->getSelected());
-	ApiSystem::getInstance()->setAudioOutputDevice(optionsAudio->getSelected());
-	v_need_reboot = true;
-      }
-      SystemConf::getInstance()->saveSystemConf();
-      if(v_need_reboot) {
-	mWindow->displayMessage(_("A REBOOT OF THE SYSTEM IS REQUIRED TO APPLY THE NEW CONFIGURATION"));
-      }
-    });
-
-  mWindow->pushGui(s);
-}
-
-void GuiMenu::openNetworkSettings_batocera() {
-  Window *window = mWindow;
-
-  auto s = new GuiSettings(mWindow, _("NETWORK SETTINGS").c_str());
-  auto status = std::make_shared<TextComponent>(mWindow,
-						ApiSystem::getInstance()->ping() ? _("CONNECTED")
-						: _("NOT CONNECTED"),
-						Font::get(FONT_SIZE_MEDIUM), 0x777777FF);
-  s->addWithLabel(_("STATUS"), status);
-  auto ip = std::make_shared<TextComponent>(mWindow, ApiSystem::getInstance()->getIpAdress(),
-					    Font::get(FONT_SIZE_MEDIUM), 0x777777FF);
-  s->addWithLabel(_("IP ADDRESS"), ip);
-  // Hostname
-  createInputTextRow(s, _("HOSTNAME"), "system.hostname", false);
-
-  // Wifi enable
-  auto enable_wifi = std::make_shared<SwitchComponent>(mWindow);
-  bool baseEnabled = SystemConf::getInstance()->get("wifi.enabled") == "1";
-  enable_wifi->setState(baseEnabled);
-  s->addWithLabel(_("ENABLE WIFI"), enable_wifi);
-
-  // window, title, settingstring,
-  const std::string baseSSID = SystemConf::getInstance()->get("wifi.ssid");
-  createInputTextRow(s, _("WIFI SSID"), "wifi.ssid", false);
-  const std::string baseKEY = SystemConf::getInstance()->get("wifi.key");
-  createInputTextRow(s, _("WIFI KEY"), "wifi.key", true);
-
-  s->addSaveFunc([baseEnabled, baseSSID, baseKEY, enable_wifi, window] {
-      bool wifienabled = enable_wifi->getState();
-      SystemConf::getInstance()->set("wifi.enabled", wifienabled ? "1" : "0");
-      std::string newSSID = SystemConf::getInstance()->get("wifi.ssid");
-      std::string newKey = SystemConf::getInstance()->get("wifi.key");
-      SystemConf::getInstance()->saveSystemConf();
-      if (wifienabled) {
-	if (baseSSID != newSSID
-	    || baseKEY != newKey
-	    || !baseEnabled) {
-	  if (ApiSystem::getInstance()->enableWifi(newSSID, newKey)) {
-	    window->pushGui(
-			    new GuiMsgBox(window, _("WIFI ENABLED"))
-			    );
-	  } else {
-	    window->pushGui(
-			    new GuiMsgBox(window, _("WIFI CONFIGURATION ERROR"))
-			    );
-	  }
-	}
-      } else if (baseEnabled) {
-	ApiSystem::getInstance()->disableWifi();
-      }
-    });
-  mWindow->pushGui(s);
+	mWindow->pushGui(s);
 }
 
 void GuiMenu::openRetroAchievements_batocera() {
@@ -2116,6 +2137,12 @@ void GuiMenu::openQuitMenu_batocera()
 
 void GuiMenu::openQuitMenu_batocera_static(Window *window)
 {
+#ifdef WIN32
+	Scripting::fireEvent("quit");
+	quitES("");
+	return;
+#endif
+
   auto s = new GuiSettings(window, _("QUIT").c_str());
 
   ComponentListRow row;
@@ -2544,29 +2571,34 @@ std::shared_ptr<OptionListComponent<std::string>> GuiMenu::createRatioOptionList
   return ratio_choice;
 }
 
-std::shared_ptr<OptionListComponent<std::string>> GuiMenu::createVideoResolutionModeOptionList(Window *window,
-											       std::string configname) {
-  auto videoResolutionMode_choice = std::make_shared<OptionListComponent<std::string> >(window, _("VIDEO MODE"), false);
-  std::string currentVideoMode = SystemConf::getInstance()->get(configname + ".videomode");
-  if (currentVideoMode.empty()) {
-    currentVideoMode = std::string("auto");
-  }
+std::shared_ptr<OptionListComponent<std::string>> GuiMenu::createVideoResolutionModeOptionList(Window *window, std::string configname) 
+{
+	auto videoResolutionMode_choice = std::make_shared<OptionListComponent<std::string> >(window, _("VIDEO MODE"), false);
 
-  std::vector<std::string> videoResolutionModeMap = ApiSystem::getInstance()->getVideoModes();
-  videoResolutionMode_choice->add(_("AUTO"), "auto", currentVideoMode == "auto");
-  for (auto videoMode = videoResolutionModeMap.begin(); videoMode != videoResolutionModeMap.end(); videoMode++) {
-    std::vector<std::string> tokens;
-    boost::split( tokens, (*videoMode), boost::is_any_of(":") );
-    // concatenat the ending words
-    std::string vname = "";
-    for(unsigned int i=1; i<tokens.size(); i++) {
-      if(i > 1) vname += ":";
-      vname += tokens.at(i);
-    }
-    videoResolutionMode_choice->add(vname, tokens.at(0), currentVideoMode == tokens.at(0));
-  }
+	std::string currentVideoMode = SystemConf::getInstance()->get(configname + ".videomode");
+	if (currentVideoMode.empty())
+		currentVideoMode = std::string("auto");
+	
+	std::vector<std::string> videoResolutionModeMap = ApiSystem::getInstance()->getVideoModes();
+	videoResolutionMode_choice->add(_("AUTO"), "auto", currentVideoMode == "auto");
+	for (auto videoMode = videoResolutionModeMap.begin(); videoMode != videoResolutionModeMap.end(); videoMode++)
+	{
+		std::vector<std::string> tokens = Utils::String::split(*videoMode, ':');
 
-  return videoResolutionMode_choice;
+		// concatenat the ending words
+		std::string vname;
+		for (unsigned int i = 1; i < tokens.size(); i++) 
+		{
+			if (i > 1) 
+				vname += ":";
+
+			vname += tokens.at(i);
+		}
+
+		videoResolutionMode_choice->add(vname, tokens.at(0), currentVideoMode == tokens.at(0));
+	}
+
+	return videoResolutionMode_choice;
 }
 
 void GuiMenu::clearLoadedInput() {

--- a/es-app/src/guis/GuiMetaDataEd.cpp
+++ b/es-app/src/guis/GuiMetaDataEd.cpp
@@ -272,7 +272,7 @@ bool GuiMetaDataEd::input(InputConfig* config, Input input)
 		return true;
 
 	const bool isStart = config->isMappedTo("start", input);
-	if(input.value != 0 && (config->isMappedTo("a", input) || isStart)) // batocera
+	if(input.value != 0 && (config->isMappedTo(BUTTON_BACK, input) || isStart))
 	{
 		close(isStart);
 		return true;
@@ -284,7 +284,7 @@ bool GuiMetaDataEd::input(InputConfig* config, Input input)
 std::vector<HelpPrompt> GuiMetaDataEd::getHelpPrompts()
 {
 	std::vector<HelpPrompt> prompts = mGrid.getHelpPrompts();
-	prompts.push_back(HelpPrompt("a", _("BACK"))); // batocera
+	prompts.push_back(HelpPrompt(BUTTON_BACK, _("BACK")));
 	prompts.push_back(HelpPrompt("start", _("CLOSE"))); // batocera
 	return prompts;
 }

--- a/es-app/src/guis/GuiScraperStart.cpp
+++ b/es-app/src/guis/GuiScraperStart.cpp
@@ -102,7 +102,7 @@ bool GuiScraperStart::input(InputConfig* config, Input input)
 	if(consumed)
 		return true;
 	
-	if(input.value != 0 && config->isMappedTo("a", input)) // batocera
+	if(input.value != 0 && config->isMappedTo(BUTTON_BACK, input))
 	{
 		delete this;
 		return true;
@@ -123,7 +123,7 @@ bool GuiScraperStart::input(InputConfig* config, Input input)
 std::vector<HelpPrompt> GuiScraperStart::getHelpPrompts()
 {
 	std::vector<HelpPrompt> prompts = mMenu.getHelpPrompts();
-	prompts.push_back(HelpPrompt("a", _("BACK"))); // batocera
+	prompts.push_back(HelpPrompt(BUTTON_BACK, _("BACK")));
 	prompts.push_back(HelpPrompt("start", _("CLOSE"))); // batocera
 	return prompts;
 }

--- a/es-app/src/guis/GuiScreensaverOptions.cpp
+++ b/es-app/src/guis/GuiScreensaverOptions.cpp
@@ -34,7 +34,7 @@ void GuiScreensaverOptions::save()
 
 bool GuiScreensaverOptions::input(InputConfig* config, Input input)
 {
-	if(config->isMappedTo("a", input) && input.value != 0) // batocera "a" instead of "b"
+	if(config->isMappedTo(BUTTON_BACK, input) && input.value != 0)
 	{
 		delete this;
 		return true;
@@ -63,7 +63,7 @@ std::vector<HelpPrompt> GuiScreensaverOptions::getHelpPrompts()
 {
 	std::vector<HelpPrompt> prompts = mMenu.getHelpPrompts();
 
-	prompts.push_back(HelpPrompt("b", "back"));
+	prompts.push_back(HelpPrompt(BUTTON_BACK, "back"));
 	prompts.push_back(HelpPrompt("start", "close"));
 
 	return prompts;

--- a/es-app/src/guis/GuiSettings.cpp
+++ b/es-app/src/guis/GuiSettings.cpp
@@ -34,7 +34,7 @@ void GuiSettings::save()
 
 bool GuiSettings::input(InputConfig* config, Input input)
 {
-	if(config->isMappedTo("a", input) && input.value != 0) // batocera
+	if(config->isMappedTo(BUTTON_BACK, input) && input.value != 0)
 	{
 		delete this;
 		return true;
@@ -63,7 +63,7 @@ std::vector<HelpPrompt> GuiSettings::getHelpPrompts()
 {
 	std::vector<HelpPrompt> prompts = mMenu.getHelpPrompts();
 
-	prompts.push_back(HelpPrompt("a", _("BACK"))); // batocera
+	prompts.push_back(HelpPrompt(BUTTON_BACK, _("BACK")));
 	prompts.push_back(HelpPrompt("start", _("CLOSE"))); // batocera
 
 	return prompts;

--- a/es-app/src/guis/GuiSystemsHide.cpp
+++ b/es-app/src/guis/GuiSystemsHide.cpp
@@ -52,23 +52,23 @@ void GuiSystemsHide::Apply()
 
 bool GuiSystemsHide::input(InputConfig* config, Input input)
 {
-        if(GuiComponent::input(config, input))
-                return true;
+	if (GuiComponent::input(config, input))
+		return true;
 
-        if((config->isMappedTo("a", input) || config->isMappedTo("start", input)) && input.value != 0) 
-        {
-                delete this;
-                return true;
-        }
+	if ((config->isMappedTo(BUTTON_BACK, input) || config->isMappedTo("start", input)) && input.value != 0)
+	{
+		delete this;
+		return true;
+	}
 
-        return false;
+	return false;
 }
 
 std::vector<HelpPrompt> GuiSystemsHide::getHelpPrompts()
 {
 	std::vector<HelpPrompt> prompts = mMenu.getHelpPrompts();
-	prompts.push_back(HelpPrompt("a", _("BACK"))); 
-	prompts.push_back(HelpPrompt("b", _("VALIDATE"))); 
+	prompts.push_back(HelpPrompt(BUTTON_BACK, _("BACK")));
+	prompts.push_back(HelpPrompt(BUTTON_OK, _("VALIDATE")));
 	prompts.push_back(HelpPrompt("start", _("CLOSE"))); 
 	return prompts;
 }

--- a/es-app/src/guis/GuiThemeInstall.cpp
+++ b/es-app/src/guis/GuiThemeInstall.cpp
@@ -1,7 +1,6 @@
 #include "guis/GuiBackup.h"
 #include "guis/GuiMsgBox.h"
 #include "Window.h"
-#include <boost/thread.hpp>
 #include <string>
 #include "Log.h"
 #include "Settings.h"
@@ -54,7 +53,7 @@ void GuiThemeInstall::update(int deltaTime) {
         Window* window = mWindow;
         if(mState == 1){
 	  mLoading = true;
-	  mHandle = new boost::thread(boost::bind(&GuiThemeInstall::threadTheme, this));
+	  mHandle = new std::thread(&GuiThemeInstall::threadTheme, this);
 	  mState = 0;
         }
 

--- a/es-app/src/guis/GuiThemeInstall.h
+++ b/es-app/src/guis/GuiThemeInstall.h
@@ -4,7 +4,7 @@
 #include "components/MenuComponent.h"
 #include "components/BusyComponent.h"
 
-#include <boost/thread.hpp>
+#include <thread>
 
 class GuiThemeInstall : public GuiComponent {
 public:
@@ -29,7 +29,7 @@ private:
 
     std::string mThemeName;
     
-    boost::thread *mHandle;
+    std::thread *mHandle;
 
     void onInstallError(std::pair<std::string, int>);
 

--- a/es-app/src/guis/GuiThemeInstallStart.cpp
+++ b/es-app/src/guis/GuiThemeInstallStart.cpp
@@ -4,9 +4,6 @@
 #include "components/OptionListComponent.h"
 #include "guis/GuiThemeInstall.h"
 #include "guis/GuiSettings.h"
-#include <boost/algorithm/string/predicate.hpp>
-#include <boost/algorithm/string/split.hpp>
-#include <boost/algorithm/string/classification.hpp>
 #include "views/ViewController.h"
 
 #include "LocaleES.h"
@@ -58,7 +55,7 @@ bool GuiThemeInstallStart::input(InputConfig* config, Input input)
 	if(consumed)
 		return true;
 	
-	if(input.value != 0 && config->isMappedTo("a", input))
+	if(input.value != 0 && config->isMappedTo(BUTTON_BACK, input))
 	{
 		delete this;
 		return true;
@@ -76,7 +73,7 @@ bool GuiThemeInstallStart::input(InputConfig* config, Input input)
 std::vector<HelpPrompt> GuiThemeInstallStart::getHelpPrompts()
 {
 	std::vector<HelpPrompt> prompts = mMenu.getHelpPrompts();
-	prompts.push_back(HelpPrompt("a", _("BACK")));
+	prompts.push_back(HelpPrompt(BUTTON_BACK, _("BACK")));
 	prompts.push_back(HelpPrompt("start", _("CLOSE")));
 	return prompts;
 }

--- a/es-app/src/guis/GuiUpdate.cpp
+++ b/es-app/src/guis/GuiUpdate.cpp
@@ -2,7 +2,6 @@
 #include "guis/GuiMsgBox.h"
 
 #include "Window.h"
-#include <boost/thread.hpp>
 #include <string>
 #include "Log.h"
 #include "Settings.h"
@@ -13,7 +12,7 @@ GuiUpdate::GuiUpdate(Window* window) : GuiComponent(window), mBusyAnim(window)
 {
 	setSize((float)Renderer::getScreenWidth(), (float)Renderer::getScreenHeight());
         mLoading = true;
-        mPingHandle = new boost::thread(boost::bind(&GuiUpdate::threadPing, this));
+        mPingHandle = new std::thread(&GuiUpdate::threadPing, this);
         mBusyAnim.setSize(mSize);
 }
 
@@ -57,7 +56,7 @@ void GuiUpdate::update(int deltaTime) {
                            [this] { 
                                mState = 2;
                                mLoading = true;
-                               mHandle = new boost::thread(boost::bind(&GuiUpdate::threadUpdate, this));
+                               mHandle = new std::thread(&GuiUpdate::threadUpdate, this);
 
 					  }, _("NO"), [this] {
                                mState = -1;

--- a/es-app/src/guis/GuiUpdate.h
+++ b/es-app/src/guis/GuiUpdate.h
@@ -4,8 +4,7 @@
 #include "components/MenuComponent.h"
 #include "components/BusyComponent.h"
 
-
-#include <boost/thread.hpp>
+#include <thread>
 
 class GuiUpdate : public GuiComponent {
 public:
@@ -27,8 +26,8 @@ private:
     int mState;
     std::pair<std::string, int> mResult;
 
-    boost::thread *mHandle;
-    boost::thread *mPingHandle;
+	std::thread *mHandle;
+	std::thread *mPingHandle;
 
     void onUpdateError(std::pair<std::string, int>);
 

--- a/es-app/src/scrapers/GamesDBJSONScraperResources.cpp
+++ b/es-app/src/scrapers/GamesDBJSONScraperResources.cpp
@@ -49,8 +49,7 @@ void ensureScrapersResourcesDir()
 
 std::string getScrapersResouceDir()
 {
-	return Utils::FileSystem::getGenericPath(
-						 std::string("/userdata/system/configs/emulationstation/") + SCRAPER_RESOURCES_DIR); // batocera
+	return Utils::FileSystem::getGenericPath(Utils::FileSystem::getEsConfigPath() + std::string("/") + SCRAPER_RESOURCES_DIR); // batocera
 }
 
 std::string TheGamesDBJSONRequestResources::getApiKey() const { return GamesDBAPIKey; }

--- a/es-app/src/views/SystemView.cpp
+++ b/es-app/src/views/SystemView.cpp
@@ -221,7 +221,7 @@ bool SystemView::input(InputConfig* config, Input input)
 			break;
 		}
 
-		if(config->isMappedTo("b", input))
+		if(config->isMappedTo(BUTTON_OK, input))
 		{
 			stopScrolling();
 			ViewController::get()->goToGameList(getSelected());
@@ -442,7 +442,7 @@ std::vector<HelpPrompt> SystemView::getHelpPrompts()
 	  prompts.push_back(HelpPrompt("up/down", _("CHOOSE"))); // batocera
 	else
 	  prompts.push_back(HelpPrompt("left/right", _("CHOOSE"))); // batocera
-	prompts.push_back(HelpPrompt("b", _("SELECT"))); // batocera
+	prompts.push_back(HelpPrompt(BUTTON_OK, _("SELECT")));
 #ifdef _ENABLE_KODI_
 	if(SystemConf::getInstance()->get("kodi.enabled") == "1" && SystemConf::getInstance()->get("kodi.xbutton") == "1" && !UIModeController::getInstance()->isUIModeKid()) {
 	  prompts.push_back(HelpPrompt("x", _("KODI"))); // batocera

--- a/es-app/src/views/ViewController.cpp
+++ b/es-app/src/views/ViewController.cpp
@@ -452,6 +452,7 @@ void ViewController::preload()
 	uint32_t i = 0;
 	for(auto it = SystemData::sSystemVector.cbegin(); it != SystemData::sSystemVector.cend(); it++)
 	{
+		/*
 		if(Settings::getInstance()->getBool("SplashScreen") &&
 			Settings::getInstance()->getBool("SplashScreenProgress"))
 		{
@@ -461,9 +462,9 @@ void ViewController::preload()
 				(*it)->getFullName().c_str(), i, (int)SystemData::sSystemVector.size());
 			mWindow->renderLoadingScreen(std::string(buffer));
 		}
-
+		*/
 		(*it)->getIndex()->resetFilters();
-		//getGameListView(*it); // batocera - performances
+		// getGameListView(*it); // batocera - performances
 	}
 }
 
@@ -508,20 +509,20 @@ void ViewController::reloadAll()
 		cursorMap[it->first] = it->second->getCursor();
 	}
 	mGameListViews.clear();
-
+	
 	// If preloaded is disabled
 	for (auto it = SystemData::sSystemVector.cbegin(); it != SystemData::sSystemVector.cend(); it++)
 	{
 		if (cursorMap.find((*it)) == cursorMap.end())
 			cursorMap[(*it)] = NULL;
 	}
-	
+
 	// load themes, create gamelistviews and reset filters
 	for(auto it = cursorMap.cbegin(); it != cursorMap.cend(); it++)
 	{
 		it->first->loadTheme();
 		it->first->getIndex()->resetFilters();
-		
+
 		if (it->second != NULL)
 			getGameListView(it->first)->setCursor(it->second);
 	}

--- a/es-app/src/views/gamelist/BasicGameListView.cpp
+++ b/es-app/src/views/gamelist/BasicGameListView.cpp
@@ -160,8 +160,8 @@ std::vector<HelpPrompt> BasicGameListView::getHelpPrompts()
 	if(Settings::getInstance()->getBool("QuickSystemSelect"))
 	  prompts.push_back(HelpPrompt("left/right", _("SYSTEM"))); // batocera
 	prompts.push_back(HelpPrompt("up/down", _("CHOOSE"))); // batocera
-	prompts.push_back(HelpPrompt("b", _("LAUNCH"))); // batocera
-	prompts.push_back(HelpPrompt("a", _("BACK"))); // batocera
+	prompts.push_back(HelpPrompt(BUTTON_OK, _("LAUNCH")));
+	prompts.push_back(HelpPrompt(BUTTON_BACK, _("BACK")));
 	if(!UIModeController::getInstance()->isUIModeKid())
 	  prompts.push_back(HelpPrompt("select", _("OPTIONS"))); // batocera
 	if(mRoot->getSystem()->isGameSystem())

--- a/es-app/src/views/gamelist/GridGameListView.cpp
+++ b/es-app/src/views/gamelist/GridGameListView.cpp
@@ -377,8 +377,8 @@ std::vector<HelpPrompt> GridGameListView::getHelpPrompts()
 	if(Settings::getInstance()->getBool("QuickSystemSelect"))
 	  prompts.push_back(HelpPrompt("lr", _("SYSTEM"))); // batocera
 	prompts.push_back(HelpPrompt("up/down/left/right", _("CHOOSE"))); // batocera
-	prompts.push_back(HelpPrompt("b", _("LAUNCH"))); // batocera
-	prompts.push_back(HelpPrompt("a", _("BACK"))); // batocera
+	prompts.push_back(HelpPrompt(BUTTON_OK, _("LAUNCH")));
+	prompts.push_back(HelpPrompt(BUTTON_BACK, _("BACK")));
 	if(!UIModeController::getInstance()->isUIModeKid())
 	  prompts.push_back(HelpPrompt("select", _("OPTIONS"))); // batocera
 	if(mRoot->getSystem()->isGameSystem())

--- a/es-app/src/views/gamelist/ISimpleGameListView.cpp
+++ b/es-app/src/views/gamelist/ISimpleGameListView.cpp
@@ -80,7 +80,7 @@ bool ISimpleGameListView::input(InputConfig* config, Input input)
 {
 	if(input.value != 0)
 	{
-		if(config->isMappedTo("b", input)) // batocera
+		if(config->isMappedTo(BUTTON_OK, input))
 		{
 			FileData* cursor = getCursor();
 			if(cursor->getType() == GAME)
@@ -99,7 +99,7 @@ bool ISimpleGameListView::input(InputConfig* config, Input input)
 			}
 
 			return true;
-		}else if(config->isMappedTo("a", input)) // batocera
+		}else if(config->isMappedTo(BUTTON_BACK, input))
 		{
 			if(mCursorStack.size())
 			{

--- a/es-core/CMakeLists.txt
+++ b/es-core/CMakeLists.txt
@@ -13,7 +13,7 @@ set(CORE_HEADERS
 	${CMAKE_CURRENT_SOURCE_DIR}/src/Log.h
 	${CMAKE_CURRENT_SOURCE_DIR}/src/MameNames.h
 	${CMAKE_CURRENT_SOURCE_DIR}/src/LocaleES.h # batocera
-        ${CMAKE_CURRENT_SOURCE_DIR}/src/SystemConf.h # batocera
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/SystemConf.h # batocera
 	${CMAKE_CURRENT_SOURCE_DIR}/src/platform.h
 	${CMAKE_CURRENT_SOURCE_DIR}/src/PowerSaver.h
 	${CMAKE_CURRENT_SOURCE_DIR}/src/Renderer.h
@@ -92,6 +92,7 @@ set(CORE_SOURCES
 	${CMAKE_CURRENT_SOURCE_DIR}/src/InputManager.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/Log.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/MameNames.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/src/LocaleES.cpp # batocera
 	${CMAKE_CURRENT_SOURCE_DIR}/src/platform.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/PowerSaver.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/Renderer_draw_gl.cpp

--- a/es-core/src/AudioManager.h
+++ b/es-core/src/AudioManager.h
@@ -22,8 +22,10 @@ class AudioManager
 	void getMusicIn(const std::string &path, std::vector<std::string>& all_matching_files); // batocera
 	void playMusic(std::string path);
 	static void musicEnd_callback(); // batocera
+
 	std::string mSystem = ""; // batocera (per system music folder)
 	std::string mCurrentSong = ""; // batocera (pop-up for SongName.cpp)
+
 	bool mInitialized;
 
 public:

--- a/es-core/src/InputConfig.cpp
+++ b/es-core/src/InputConfig.cpp
@@ -91,8 +91,9 @@ bool InputConfig::getInputByName(const std::string& name, Input* result)
 bool InputConfig::isMappedTo(const std::string& name, Input input, bool reversedAxis) // batocera
 {
 	Input comp;
-	if(!getInputByName(name, &comp))
+	if (!getInputByName(name, &comp))
 		return false;
+
 	if(reversedAxis) { // batocera
 	  comp.value *= -1;
 	}

--- a/es-core/src/InputConfig.h
+++ b/es-core/src/InputConfig.h
@@ -16,6 +16,14 @@ namespace pugi { class xml_node; }
 // batocera
 #define MAX_PLAYERS 5
 
+#ifdef WIN32
+#define BUTTON_OK	"a"
+#define BUTTON_BACK	"b"
+#else
+#define BUTTON_OK	"b"
+#define BUTTON_BACK	"a"
+#endif
+
 enum InputType
 {
 	TYPE_AXIS,

--- a/es-core/src/InputManager.cpp
+++ b/es-core/src/InputManager.cpp
@@ -249,9 +249,10 @@ bool InputManager::parseEvent(const SDL_Event& ev, Window* window)
 	    // in es, the trick is to minus this value to the value to do as if it started at 0
 	    int initialValue = 0;
 	    Sint16 x;
-	    if(SDL_JoystickGetAxisInitialState(mJoysticks[ev.jaxis.which], ev.jaxis.axis, &x)) {
-	      initialValue = x;
-	    }
+	    // SDL_JoystickGetAxisInitialState doesn't work with 8bitdo start+b
+	    //if(SDL_JoystickGetAxisInitialState(mJoysticks[ev.jaxis.which], ev.jaxis.axis, &x)) {
+	    //  initialValue = x;
+	    //}
 
 		//if it switched boundaries
 		if((abs(ev.jaxis.value-initialValue) > DEADZONE) != (abs(mPrevAxisValues[ev.jaxis.which][ev.jaxis.axis]) > DEADZONE)) // batocera
@@ -402,8 +403,8 @@ void InputManager::loadDefaultKBConfig()
 	cfg->mapInput("left", Input(DEVICE_KEYBOARD, TYPE_KEY, SDLK_LEFT, 1, true));
 	cfg->mapInput("right", Input(DEVICE_KEYBOARD, TYPE_KEY, SDLK_RIGHT, 1, true));
 
-	cfg->mapInput("a", Input(DEVICE_KEYBOARD, TYPE_KEY, SDLK_RETURN, 1, true));
-	cfg->mapInput("b", Input(DEVICE_KEYBOARD, TYPE_KEY, SDLK_ESCAPE, 1, true));
+	cfg->mapInput(BUTTON_OK, Input(DEVICE_KEYBOARD, TYPE_KEY, SDLK_RETURN, 1, true));
+	cfg->mapInput(BUTTON_BACK, Input(DEVICE_KEYBOARD, TYPE_KEY, SDLK_ESCAPE, 1, true));
 	cfg->mapInput("start", Input(DEVICE_KEYBOARD, TYPE_KEY, SDLK_F1, 1, true));
 	cfg->mapInput("select", Input(DEVICE_KEYBOARD, TYPE_KEY, SDLK_F2, 1, true));
 
@@ -515,14 +516,12 @@ void InputManager::doOnFinish()
 
 std::string InputManager::getConfigPath()
 {
-	std::string path = "/userdata/system/configs/emulationstation/es_input.cfg"; // batocera
-	return path;
+	return Utils::FileSystem::getEsConfigPath() + "/es_input.cfg";
 }
 
 std::string InputManager::getTemporaryConfigPath()
 {
-	std::string path = "/userdata/system/configs/emulationstation/es_last_input.log"; // batocera
-	return path;
+	return Utils::FileSystem::getEsConfigPath() + "/es_last_input.cfg";
 }
 
 bool InputManager::initialized() const

--- a/es-core/src/LocaleES.cpp
+++ b/es-core/src/LocaleES.cpp
@@ -1,0 +1,233 @@
+#include "LocaleES.h"
+
+#if defined(WIN32)
+
+// For WIN32 avoid using boost or libintl 
+
+#include "resources/ResourceManager.h"
+#include "Settings.h"
+#include "utils/FileSystemUtil.h"
+#include "SystemConf.h"
+#include <fstream>
+
+std::map<std::string, std::string> EsLocale::mItems;
+std::string EsLocale::mCurrentLanguage = "en_US";
+bool EsLocale::mCurrentLanguageLoaded = true; // By default, 'en' is considered loaded
+
+// List of all possible plural forms here
+// https://github.com/translate/l10n-guide/blob/master/docs/l10n/pluralforms.rst
+// Test rules without spaces & without parenthesis - there are 19 distinct rules
+
+PluralRule rules[] = {
+	{ "en", "n!=1", [](int n) { return n != 1 ? 1 : 0; } },
+	{ "fr", "n>1", [](int n) { return n > 1 ? 1 : 0; } },
+	{ "jp", "0", [](int n) { return 0; } },
+	{ "ru", "n%10==1&&n%100!=11?0:n%10>=2&&n%10<=4&&n%100<10||n%100>=20?1:2",  [](int n) { return n % 10 == 1 && n % 100 != 11 ? 0 : n % 10 >= 2 && n % 10 <= 4 && (n % 100 < 10 || n % 100 >= 20) ? 1 : 2; } },
+	{ "ar", "n==0?0:n==1?1:n==2?2:n%100>=3&&n%100<=10?3:n%100>=11?4:5", [](int n) { return n == 0 ? 0 : n == 1 ? 1 : n == 2 ? 2 : n % 100 >= 3 && n % 100 <= 10 ? 3 : n % 100 >= 11 ? 4 : 5; } },
+	{ "pl", "n==1?0:n%10>=2&&n%10<=4&&n%100<10||n%100>=20?1:2", [](int n) { return n == 1 ? 0 : n % 10 >= 2 && n % 10 <= 4 && (n % 100 < 10 || n % 100 >= 20) ? 1 : 2; } },
+	{ "ga", "n==1?0:n==2?1:n>2&&n<7?2:n>6&&n<11?3:4", [](int n) { return n == 1 ? 0 : n == 2 ? 1 : (n > 2 && n < 7) ? 2 : (n > 6 && n < 11) ? 3 : 4; } },
+	{ "gd", "n==1||n==11?0:n==2||n==12?1:n>2&&n<20?2:3", [](int n) { return (n == 1 || n == 11) ? 0 : (n == 2 || n == 12) ? 1 : (n > 2 && n < 20) ? 2 : 3; } },
+	{ "mk", "n==1||n%10==1?0:1", [](int n) { return n == 1 || n % 10 == 1 ? 0 : 1; } },
+	{ "is", "n%10!=1||n%100==11", [](int n) { return (n % 10 != 1 || n % 100 == 11) ? 1 : 0; } },
+	{ "lv", "n%10==1&&n%100!=11?0:n!=0?1:2", [](int n) { return n % 10 == 1 && n % 100 != 11 ? 0 : n != 0 ? 1 : 2; } },
+	{ "lt", "n%10==1&&n%100!=11?0:n%10>=2&&n%100<10||n%100>=20?1:2", [](int n) { return n % 10 == 1 && n % 100 != 11 ? 0 : n % 10 >= 2 && (n % 100 < 10 || n % 100 >= 20) ? 1 : 2; } },
+	{ "mn", "n==0?0:n==1?1:2", [](int n) { return n == 0 ? 0 : n == 1 ? 1 : 2; } },
+	{ "ro", "n==1?0:n==0||n%100>0&&n%100<20?1:2", [](int n) { return n == 1 ? 0 : (n == 0 || (n % 100 > 0 && n % 100 < 20)) ? 1 : 2; } },
+	{ "cs", "n==1?0:n>=2&&n<=4?1:2", [](int n) { return (n == 1) ? 0 : (n >= 2 && n <= 4) ? 1 : 2; } },
+	{ "sl", "n%100==1?0:n%100==2?1:n%100==3||n%100==4?2:3", [](int n) { return n % 100 == 1 ? 0 : n % 100 == 2 ? 1 : n % 100 == 3 || n % 100 == 4 ? 2 : 3; } },
+	{ "mt", "n==1?0:n==0||n%100>1&&n%100<11?1:n%100>10&&n%100<20?2:3", [](int n) { return n == 1 ? 0 : n == 0 || (n % 100 > 1 && n % 100 < 11) ? 1 : (n % 100 > 10 && n % 100 < 20) ? 2 : 3; } },
+	{ "cy", "n==1?0:n==2?1:n!=8&&n!=11?2:3", [](int n) { return (n == 1) ? 0 : (n == 2) ? 1 : (n != 8 && n != 11) ? 2 : 3; } },
+	{ "kw", "n==1?0:n==2?1:n==3?2:3", [](int n) { return (n == 1) ? 0 : (n == 2) ? 1 : (n == 3) ? 2 : 3; } }
+};
+
+PluralRule EsLocale::mPluralRule = rules[0];
+const std::vector<PluralRule> pluralRules(rules, rules + sizeof(rules) / sizeof(rules[0]));
+
+const std::string EsLocale::getText(const std::string text)
+{
+	checkLocalisationLoaded();
+
+	auto item = mItems.find(text);
+	if (item != mItems.cend())
+		return item->second;
+
+	return text;
+}
+
+const std::string EsLocale::nGetText(const std::string msgid, const std::string msgid_plural, int n)
+{
+	if (mCurrentLanguage.empty() || mCurrentLanguage == "en_US") // English default
+		return n != 1 ? msgid_plural : msgid;
+
+	if (mPluralRule.rule.empty())
+		return n != 1 ? getText(msgid_plural) : getText(msgid);
+
+	checkLocalisationLoaded();
+
+	int pluralId = mPluralRule.evaluate(n);
+	if (pluralId == 0)
+		return getText(msgid);
+
+	auto item = mItems.find(std::to_string(pluralId) + "@" + msgid_plural);
+	if (item != mItems.cend())
+		return item->second;
+
+	item = mItems.find(msgid_plural);
+	if (item != mItems.cend())
+		return item->second;
+
+	return msgid_plural;
+}
+
+
+void EsLocale::checkLocalisationLoaded()
+{
+	if (mCurrentLanguageLoaded)
+	{
+		std::string language = SystemConf::getInstance()->get("system.language");
+		if (language.empty()) 
+			language = "en_US";
+
+		if (language == mCurrentLanguage)
+			return;
+
+		mCurrentLanguage = language;
+	}
+
+	mCurrentLanguageLoaded = true;
+
+	mPluralRule = rules[0];
+
+	mItems.clear();
+
+	// batocera could be adapted using this path : "/usr/share/locale"
+	std::string xmlpath = ResourceManager::getInstance()->getResourcePath(":/locale/" + mCurrentLanguage + "/emulationstation2.po");
+	if (!Utils::FileSystem::exists(xmlpath))
+		xmlpath = ResourceManager::getInstance()->getResourcePath(":/locale/" + mCurrentLanguage + "/LC_MESSAGES/emulationstation2.po");
+	
+	if (!Utils::FileSystem::exists(xmlpath))
+	{
+		auto shortNameDivider = mCurrentLanguage.find("_");
+		if (shortNameDivider != std::string::npos)
+		{
+			auto shortName = mCurrentLanguage.substr(0, shortNameDivider);
+
+			xmlpath = ResourceManager::getInstance()->getResourcePath(":/locale/" + shortName + "/emulationstation2.po");
+			if (!Utils::FileSystem::exists(xmlpath))
+				xmlpath = ResourceManager::getInstance()->getResourcePath(":/locale/" + shortName + "/LC_MESSAGES/emulationstation2.po");
+		}
+	}
+
+	if (!Utils::FileSystem::exists(xmlpath))
+		return;
+
+	std::string	msgid;
+	std::string	msgid_plural;
+
+	std::string line;
+
+	std::ifstream file(xmlpath);
+	while (std::getline(file, line))
+	{
+		if (line.find("\"Plural-Forms:") == 0)
+		{
+			auto start = line.find("plural=");
+			if (start != std::string::npos)
+			{
+				std::string plural;
+
+				auto end = line.find(";", start + 1);
+				if (end == std::string::npos)
+				{
+					plural = line.substr(start + 7, line.size() - start - 7 - 1);
+
+					std::getline(file, line);
+					end = line.find(";", start + 1);
+					if (end != std::string::npos)
+						plural += line.substr(1, end - 1);
+				}
+				else
+					plural = line.substr(start + 7, end - start - 7);
+
+				plural = Utils::String::replace(plural, " ", "");
+
+				if (Utils::String::endsWith(plural, ";"))
+					plural = plural.substr(0, plural.size() - 1);
+
+				//	if (Utils::String::startsWith(plural, "(") && Utils::String::endsWith(plural, ")"))
+				//		plural = plural.substr(1, plural.size() - 2);			
+				plural = Utils::String::replace(plural, "(", "");
+				plural = Utils::String::replace(plural, ")", "");
+
+				for (auto iter = pluralRules.cbegin(); iter != pluralRules.cend(); iter++)
+				{
+					if (plural == iter->rule)
+					{
+						mPluralRule = *iter;
+						break;
+					}
+				}
+			}
+		}
+		else if (line.find("msgid_plural") == 0)
+		{
+			auto start = line.find("\"");
+			if (start != std::string::npos && !msgid.empty())
+			{
+				auto end = line.find("\"", start + 1);
+				if (end != std::string::npos)
+					msgid_plural = line.substr(start + 1, end - start - 1);
+			}
+		}
+		else if (line.find("msgid") == 0)
+		{
+			msgid = "";
+			msgid_plural = "";
+
+			auto start = line.find("\"");
+			if (start != std::string::npos)
+			{
+				auto end = line.find("\"", start + 1);
+				if (end != std::string::npos)
+					msgid = line.substr(start + 1, end - start - 1);
+			}
+		}
+		else if (line.find("msgstr") == 0)
+		{
+			std::string	idx;
+
+			if (!msgid_plural.empty())
+			{
+				auto idxStart = line.find("[");
+				if (idxStart != std::string::npos)
+				{
+					auto idxEnd = line.find("]", idxStart + 1);
+					if (idxEnd != std::string::npos)
+						idx = line.substr(idxStart + 1, idxEnd - idxStart - 1);
+				}
+			}
+
+			auto start = line.find("\"");
+			if (start != std::string::npos)
+			{
+				auto end = line.find("\"", start + 1);
+				if (end != std::string::npos)
+				{
+					std::string	msgstr = line.substr(start + 1, end - start - 1);
+					if (!msgid.empty() && !msgstr.empty())
+						mItems[msgid] = msgstr;
+
+					if (!msgid_plural.empty() && !msgstr.empty())
+					{
+						if (!idx.empty() && idx != "0")
+							mItems[idx + "@" + msgid_plural] = msgstr;
+						else
+							mItems[msgid_plural] = msgstr;
+					}
+				}
+			}
+		}
+	}
+}
+
+#endif

--- a/es-core/src/LocaleES.h
+++ b/es-core/src/LocaleES.h
@@ -1,9 +1,52 @@
 #ifndef _LOCALE_H_
 #define _LOCALE_H_
 
+#if !defined(WIN32)
+
 #include <boost/locale.hpp>
 
 #define _(A) boost::locale::gettext(A)
 #define ngettext(A, B, C) boost::locale::ngettext(A, B, C)
+
+#else // WIN32
+
+#include <string>
+#include <map>
+#include <functional>
+#include "utils/StringUtil.h"
+
+struct PluralRule
+{
+	std::string key;
+	std::string rule;
+	std::function<int(int n)> evaluate;
+};
+
+class EsLocale
+{
+public:
+	static const std::string getText(const std::string text);
+	static const std::string nGetText(const std::string msgid, const std::string msgid_plural, int n);
+
+	static const std::string getLanguage() { return mCurrentLanguage; }
+
+private:
+	static void checkLocalisationLoaded();
+	static std::map<std::string, std::string> mItems;
+	static std::string mCurrentLanguage;
+	static bool mCurrentLanguageLoaded;
+
+	static PluralRule mPluralRule;
+};
+
+
+#define UNICODE_CHARTYPE wchar_t*
+#define _L(x) L ## x
+#define _U(x) Utils::String::convertFromWideString(L ## x)
+
+#define _(x) EsLocale::getText(x)
+#define ngettext(A, B, C) EsLocale::nGetText(A, B, C)
+
+#endif // WIN32
 
 #endif

--- a/es-core/src/Log.cpp
+++ b/es-core/src/Log.cpp
@@ -14,8 +14,7 @@ LogLevel Log::getReportingLevel()
 
 std::string Log::getLogPath()
 {
-	std::string home = Utils::FileSystem::getHomePath();
-	return "/userdata/system/configs/emulationstation/es_log.txt"; // batocera
+	return Utils::FileSystem::getEsConfigPath() + "/es_log.txt";
 }
 
 void Log::setReportingLevel(LogLevel level)

--- a/es-core/src/Scripting.cpp
+++ b/es-core/src/Scripting.cpp
@@ -18,7 +18,7 @@ namespace Scripting
             scriptDirList.push_back(test);
 
         // check in homepath
-        test = "/userdata/system/configs/emulationstation/scripts/" + eventName; // batocera
+		test = Utils::FileSystem::getEsConfigPath() + "/scripts/" + eventName;
         if(Utils::FileSystem::exists(test))
             scriptDirList.push_back(test);
 

--- a/es-core/src/Settings.cpp
+++ b/es-core/src/Settings.cpp
@@ -33,8 +33,7 @@ std::vector<const char*> settings_dont_save {
 	{ "ScreenHeight" },
 	{ "ScreenOffsetX" },
 	{ "ScreenOffsetY" },
-	{ "ScreenRotate" },
-	{ "ExePath" }
+	{ "ScreenRotate" }
 };
 
 Settings::Settings()
@@ -175,8 +174,6 @@ void Settings::setDefaults()
 	mIntMap["ScreenOffsetX"] = 0;
 	mIntMap["ScreenOffsetY"] = 0;
 	mIntMap["ScreenRotate"]  = 0;
-
-	mStringMap["ExePath"] = "";
 }
 
 // batocera
@@ -199,7 +196,8 @@ void saveMap(pugi::xml_node &node, std::map<K, V>& map, const char* type)
 void Settings::saveFile()
 {
 	LOG(LogDebug) << "Settings::saveFile() : Saving Settings to file.";
-	const std::string path = "/userdata/system/configs/emulationstation/es_settings.cfg"; // batocera
+
+	const std::string path = Utils::FileSystem::getEsConfigPath() + "/es_settings.cfg";
 
 	pugi::xml_document doc;
 
@@ -225,8 +223,7 @@ void Settings::saveFile()
 
 void Settings::loadFile()
 {
-        const std::string path = "/userdata/system/configs/emulationstation/es_settings.cfg"; // batocera
-
+	const std::string path = Utils::FileSystem::getEsConfigPath() + "/es_settings.cfg";
 	if(!Utils::FileSystem::exists(path))
 		return;
 

--- a/es-core/src/Sound.cpp
+++ b/es-core/src/Sound.cpp
@@ -87,7 +87,7 @@ void Sound::play()
 }
 
 bool Sound::isPlaying() const
-{
+{	
 	return (mPlayingChannel >= 0);
 }
 

--- a/es-core/src/ThemeData.cpp
+++ b/es-core/src/ThemeData.cpp
@@ -487,7 +487,7 @@ const std::shared_ptr<ThemeData>& ThemeData::getDefault()
 	{
 		theme = std::shared_ptr<ThemeData>(new ThemeData());
 
-		const std::string path = "/userdata/system/configs/emulationstation/es_theme_default.xml"; // batocera
+		const std::string path = Utils::FileSystem::getEsConfigPath() + "/es_theme_default.xml";
 		if(Utils::FileSystem::exists(path))
 		{
 			try
@@ -538,11 +538,12 @@ std::map<std::string, ThemeSet> ThemeData::getThemeSets()
 {
 	std::map<std::string, ThemeSet> sets;
 
-	static const size_t pathCount = 2;
+	static const size_t pathCount = 3;
 	std::string paths[pathCount] =
 	{ 
-		"/etc/emulationstation/themes", 
-	        "/userdata/themes" // batocera
+		Utils::FileSystem::getHomePath() + "/.emulationstation/themes",
+		"/etc/emulationstation/themes",
+	    "/userdata/themes" // batocera
 	};
 
 	for(size_t i = 0; i < pathCount; i++)

--- a/es-core/src/Window.cpp
+++ b/es-core/src/Window.cpp
@@ -207,23 +207,23 @@ void Window::input(InputConfig* config, Input input)
 }
 
 void Window::update(int deltaTime)
-{
+{        
 	// batocera        
-	if (SystemConf::getInstance()->get("audio.display_titles") == "1")
+	if(SystemConf::getInstance()->get("audio.display_titles") == "1")
 	{
 		std::string songName = AudioManager::getInstance()->getSongName();
 		if (!songName.empty())
 		{
-			displayMessage(_("Now playing: ") + songName);
+			mMessages.push_back(_("Now playing: ") + songName);
 			AudioManager::getInstance()->setSongName("");
 		}
 	}
 
-    if(!mMessages.empty())
+	if(!mMessages.empty())
 	{
 		std::string message = mMessages.back();
 		mMessages.pop_back();
-		this->setInfoPopup(new GuiInfoPopup(this, message, 4000)); // batocera
+		setInfoPopup(new GuiInfoPopup(this, message, 4000)); // batocera
 	}
 
 	if(mNormalizeNextUpdate)

--- a/es-core/src/components/ButtonComponent.cpp
+++ b/es-core/src/components/ButtonComponent.cpp
@@ -28,7 +28,7 @@ void ButtonComponent::setPressedFunc(std::function<void()> f)
 
 bool ButtonComponent::input(InputConfig* config, Input input)
 {
-	if(config->isMappedTo("b", input) && input.value != 0) // batocera
+	if(config->isMappedTo(BUTTON_OK, input) && input.value != 0)
 	{
 		if(mPressedFunc && mEnabled)
 			mPressedFunc();
@@ -126,6 +126,6 @@ unsigned int ButtonComponent::getCurTextColor() const
 std::vector<HelpPrompt> ButtonComponent::getHelpPrompts()
 {
 	std::vector<HelpPrompt> prompts;
-	prompts.push_back(HelpPrompt("b", mHelpText.empty() ? mText.c_str() : mHelpText.c_str())); // batocera
+	prompts.push_back(HelpPrompt(BUTTON_OK, mHelpText.empty() ? mText.c_str() : mHelpText.c_str())); // batocera
 	return prompts;
 }

--- a/es-core/src/components/ComponentList.h
+++ b/es-core/src/components/ComponentList.h
@@ -33,7 +33,7 @@ struct ComponentListRow
 	inline void makeAcceptInputHandler(const std::function<void()>& func)
 	{
 		input_handler = [func](InputConfig* config, Input input) -> bool {
-			if(config->isMappedTo("b", input) && input.value != 0) // batocera
+			if(config->isMappedTo(BUTTON_OK, input) && input.value != 0) // batocera
 			{
 				func();
 				return true;

--- a/es-core/src/components/DateTimeEditComponent.cpp
+++ b/es-core/src/components/DateTimeEditComponent.cpp
@@ -22,7 +22,7 @@ bool DateTimeEditComponent::input(InputConfig* config, Input input)
 	if(input.value == 0)
 		return false;
 
-	if(config->isMappedTo("a", input))
+	if(config->isMappedTo(BUTTON_OK, input))
 	{
 		if(mDisplayMode != DISP_RELATIVE_TO_NOW) //don't allow editing for relative times
 			mEditing = !mEditing;
@@ -45,7 +45,7 @@ bool DateTimeEditComponent::input(InputConfig* config, Input input)
 
 	if(mEditing)
 	{
-		if(config->isMappedTo("b", input))
+		if(config->isMappedTo(BUTTON_BACK, input))
 		{
 			mEditing = false;
 			mTime = mTimeBeforeEdit;

--- a/es-core/src/components/HelpComponent.cpp
+++ b/es-core/src/components/HelpComponent.cpp
@@ -7,6 +7,7 @@
 #include "utils/StringUtil.h"
 #include "Log.h"
 #include "Settings.h"
+#include "InputConfig.h"
 
 #define OFFSET_X 12 // move the entire thing right by this amount (px)
 #define OFFSET_Y 12 // move the entire thing up by this amount (px)
@@ -73,6 +74,7 @@ void HelpComponent::updateGrid()
 	for(auto it = mPrompts.cbegin(); it != mPrompts.cend(); it++)
 	{
 		auto icon = std::make_shared<ImageComponent>(mWindow);
+
 		icon->setImage(getIconTexture(it->first.c_str()));
 		icon->setColorShift(mStyle.iconColor);
 		icon->setResize(0, height);

--- a/es-core/src/components/ImageComponent.cpp
+++ b/es-core/src/components/ImageComponent.cpp
@@ -472,6 +472,6 @@ void ImageComponent::applyTheme(const std::shared_ptr<ThemeData>& theme, const s
 std::vector<HelpPrompt> ImageComponent::getHelpPrompts()
 {
 	std::vector<HelpPrompt> ret;
-	ret.push_back(HelpPrompt("b", _("SELECT"))); // batocera
+	ret.push_back(HelpPrompt(BUTTON_OK, _("SELECT")));
 	return ret;
 }

--- a/es-core/src/components/OptionListComponent.h
+++ b/es-core/src/components/OptionListComponent.h
@@ -117,7 +117,7 @@ private:
 
 		bool input(InputConfig* config, Input input) override
 		{
-			if(config->isMappedTo("a", input) && input.value != 0) // batocera
+			if(config->isMappedTo(BUTTON_BACK, input) && input.value != 0) // batocera
 			{
 				delete this;
 				return true;
@@ -129,7 +129,7 @@ private:
 		std::vector<HelpPrompt> getHelpPrompts() override
 		{
 			auto prompts = mMenu.getHelpPrompts();
-			prompts.push_back(HelpPrompt("a", _("BACK"))); // batocera
+			prompts.push_back(HelpPrompt(BUTTON_BACK, _("BACK")));
 			return prompts;
 		}
 	};
@@ -184,7 +184,7 @@ public:
 	{
 		if(input.value != 0)
 		{
-			if(config->isMappedTo("b", input)) // batocera
+			if(config->isMappedTo(BUTTON_OK, input))
 			{
 				open();
 				return true;
@@ -360,7 +360,7 @@ private:
 		if(!mMultiSelect)
 			prompts.push_back(HelpPrompt("left/right", _("CHANGE"))); // batocera
 
-		prompts.push_back(HelpPrompt("b", _("SELECT"))); // batocera
+		prompts.push_back(HelpPrompt(BUTTON_OK, _("SELECT")));
 		return prompts;
 	}
 

--- a/es-core/src/components/SwitchComponent.cpp
+++ b/es-core/src/components/SwitchComponent.cpp
@@ -18,7 +18,7 @@ void SwitchComponent::onSizeChanged()
 
 bool SwitchComponent::input(InputConfig* config, Input input)
 {
-	if(config->isMappedTo("b", input) && input.value) // batocera
+	if(config->isMappedTo(BUTTON_OK, input) && input.value)
 	{
 		mState = !mState;
 		onStateChanged();
@@ -74,7 +74,7 @@ void SwitchComponent::onStateChanged()
 std::vector<HelpPrompt> SwitchComponent::getHelpPrompts()
 {
 	std::vector<HelpPrompt> prompts;
-	prompts.push_back(HelpPrompt("b", _("CHANGE"))); // batocera
+	prompts.push_back(HelpPrompt(BUTTON_OK, _("CHANGE")));
 	return prompts;
 }
 

--- a/es-core/src/components/TextEditComponent.cpp
+++ b/es-core/src/components/TextEditComponent.cpp
@@ -104,7 +104,7 @@ bool TextEditComponent::input(InputConfig* config, Input input)
 		return false;
 	}
 
-	if((config->isMappedTo("b", input) || (config->getDeviceId() == DEVICE_KEYBOARD && input.id == SDLK_RETURN)) && mFocused && !mEditing) // batocera
+	if((config->isMappedTo(BUTTON_OK, input) || (config->getDeviceId() == DEVICE_KEYBOARD && input.id == SDLK_RETURN)) && mFocused && !mEditing)
 	{
 		startEditing();
 		return true;
@@ -124,7 +124,7 @@ bool TextEditComponent::input(InputConfig* config, Input input)
 			return true;
 		}
 
-		if((config->getDeviceId() == DEVICE_KEYBOARD && input.id == SDLK_ESCAPE) || (config->getDeviceId() != DEVICE_KEYBOARD && config->isMappedTo("a", input))) // batocera
+		if((config->getDeviceId() == DEVICE_KEYBOARD && input.id == SDLK_ESCAPE) || (config->getDeviceId() != DEVICE_KEYBOARD && config->isMappedTo(BUTTON_BACK, input)))
 		{
 			stopEditing();
 			return true;
@@ -306,9 +306,9 @@ std::vector<HelpPrompt> TextEditComponent::getHelpPrompts()
 	if(mEditing)
 	{
 		prompts.push_back(HelpPrompt("up/down/left/right", _("MOVE CURSOR"))); // batocera
-		prompts.push_back(HelpPrompt("a", _("STOP EDITING"))); // batocera
+		prompts.push_back(HelpPrompt(BUTTON_BACK, _("STOP EDITING")));
 	}else{
-		prompts.push_back(HelpPrompt("b", _("EDIT"))); // batocera
+		prompts.push_back(HelpPrompt(BUTTON_OK, _("EDIT")));
 	}
 	return prompts;
 }

--- a/es-core/src/components/VideoComponent.cpp
+++ b/es-core/src/components/VideoComponent.cpp
@@ -17,7 +17,7 @@ std::string getTitlePath() {
 }
 
 std::string getTitleFolder() {
-	return "/userdata/system/configs/emulationstation/tmp/"; // batocera
+	return Utils::FileSystem::getGenericPath(Utils::FileSystem::getEsConfigPath() + "/tmp/");
 }
 
 void writeSubtitle(const char* gameName, const char* systemName, bool always)
@@ -228,7 +228,7 @@ void VideoComponent::applyTheme(const std::shared_ptr<ThemeData>& theme, const s
 std::vector<HelpPrompt> VideoComponent::getHelpPrompts()
 {
 	std::vector<HelpPrompt> ret;
-	ret.push_back(HelpPrompt("b", _("SELECT"))); // batocera
+	ret.push_back(HelpPrompt(BUTTON_BACK, _("SELECT"))); // batocera
 	return ret;
 }
 

--- a/es-core/src/guis/GuiInputConfig.cpp
+++ b/es-core/src/guis/GuiInputConfig.cpp
@@ -148,7 +148,7 @@ GuiInputConfig::GuiInputConfig(Window* window, InputConfig* target, bool reconfi
 			// if we're not configuring, start configuring when A is pressed
 			if(!mConfiguringRow)
 			{
-				if(config->isMappedTo("a", input) && input.value)
+				if(config->isMappedTo(BUTTON_OK, input) && input.value)
 				{
 					mList->stopScrolling();
 					mConfiguringRow = true;
@@ -166,7 +166,7 @@ GuiInputConfig::GuiInputConfig(Window* window, InputConfig* target, bool reconfi
 				return false;
 
 			// we are configuring, the button is unpressed or the axis is relaxed
-			if(input.value != 0 || (input.type == TYPE_AXIS && input.value > 2000) )
+			if(input.value != 0)
 			{
 				// input down
 				// if we're already holding something, ignore this, otherwise plan to map this input

--- a/es-core/src/guis/GuiMsgBox.cpp
+++ b/es-core/src/guis/GuiMsgBox.cpp
@@ -24,7 +24,7 @@ GuiMsgBox::GuiMsgBox(Window* window, const std::string& text,
 	if(!name3.empty())
 		mButtons.push_back(std::make_shared<ButtonComponent>(mWindow, name3, name3, std::bind(&GuiMsgBox::deleteMeAndCall, this, func3)));
 
-	// set accelerator automatically (button to press when "b" is pressed)
+	// set accelerator automatically (button to press when BUTTON_BACK is pressed)
 	if(mButtons.size() == 1)
 	{
 		mAcceleratorFunc = mButtons.front()->getPressedFunc();
@@ -74,7 +74,7 @@ bool GuiMsgBox::input(InputConfig* config, Input input)
 	}
 
 	/* when it's not configured, allow to remove the message box too to allow the configdevice window a chance */
-	if(mAcceleratorFunc && ((config->isMappedTo("a", input) && input.value != 0) || (config->isConfigured() == false && input.type == TYPE_BUTTON))) // batocera
+	if(mAcceleratorFunc && ((config->isMappedTo(BUTTON_BACK, input) && input.value != 0) || (config->isConfigured() == false && input.type == TYPE_BUTTON))) // batocera
 	{
 		mAcceleratorFunc();
 		return true;

--- a/es-core/src/guis/GuiTextEditPopup.cpp
+++ b/es-core/src/guis/GuiTextEditPopup.cpp
@@ -57,7 +57,7 @@ bool GuiTextEditPopup::input(InputConfig* config, Input input)
 		return true;
 
 	// pressing back when not text editing closes us
-	if(config->isMappedTo("a", input) && input.value) // batocera
+	if(config->isMappedTo(BUTTON_BACK, input) && input.value)
 	{
 		delete this;
 		return true;
@@ -69,6 +69,6 @@ bool GuiTextEditPopup::input(InputConfig* config, Input input)
 std::vector<HelpPrompt> GuiTextEditPopup::getHelpPrompts()
 {
 	std::vector<HelpPrompt> prompts = mGrid.getHelpPrompts();
-	prompts.push_back(HelpPrompt("a", _("BACK"))); // batocera
+	prompts.push_back(HelpPrompt(BUTTON_BACK, _("BACK")));
 	return prompts;
 }

--- a/es-core/src/guis/GuiTextEditPopupKeyboard.cpp
+++ b/es-core/src/guis/GuiTextEditPopupKeyboard.cpp
@@ -249,7 +249,7 @@ bool GuiTextEditPopupKeyboard::input(InputConfig* config, Input input)
 		return true;
 
 	// pressing back when not text editing closes us
-	if (config->isMappedTo("a", input) && input.value)
+	if (config->isMappedTo(BUTTON_BACK, input) && input.value)
 	{
 		delete this;
 		return true;
@@ -342,7 +342,7 @@ std::vector<HelpPrompt> GuiTextEditPopupKeyboard::getHelpPrompts()
 {
 	std::vector<HelpPrompt> prompts = mGrid.getHelpPrompts();
 	prompts.push_back(HelpPrompt("y", _("SHIFT")));
-	prompts.push_back(HelpPrompt("a", _("BACK")));
+	prompts.push_back(HelpPrompt(BUTTON_BACK, _("BACK")));
 	prompts.push_back(HelpPrompt("r", _("SPACE")));
 	prompts.push_back(HelpPrompt("l", _("DELETE")));
 	return prompts;

--- a/es-core/src/resources/Font.h
+++ b/es-core/src/resources/Font.h
@@ -18,8 +18,13 @@ class TextCache;
 #define FONT_SIZE_MEDIUM ((unsigned int)(0.045f * Math::min((int)Renderer::getScreenHeight(), (int)Renderer::getScreenWidth())))
 #define FONT_SIZE_LARGE ((unsigned int)(0.085f * Math::min((int)Renderer::getScreenHeight(), (int)Renderer::getScreenWidth())))
 
+#ifdef WIN32
+#define FONT_PATH_LIGHT ":/opensans_hebrew_condensed_light.ttf"
+#define FONT_PATH_REGULAR ":/opensans_hebrew_condensed_regular.ttf"
+#else
 #define FONT_PATH_LIGHT ":/ubuntu_condensed.ttf" // batocera
 #define FONT_PATH_REGULAR ":/ubuntu_condensed.ttf" // batocera
+#endif
 
 enum Alignment
 {

--- a/es-core/src/resources/ResourceManager.cpp
+++ b/es-core/src/resources/ResourceManager.cpp
@@ -23,25 +23,23 @@ std::shared_ptr<ResourceManager>& ResourceManager::getInstance()
 std::string ResourceManager::getResourcePath(const std::string& path) const
 {
 	// check if this is a resource file
-	if((path[0] == ':') && (path[1] == '/'))
-	{
-		std::string test;
+	if (path.size() < 2 || path[0] != ':' || path[1] != '/')
+		return path;
 
-		// check in homepath
-		test = std::string("/userdata/system/configs/emulationstation/resources/") + &path[2]; // batocera
-		if(Utils::FileSystem::exists(test))
-			return test;
+	// check in homepath
+	std::string test = Utils::FileSystem::getEsConfigPath() + "/resources/" + &path[2];
+	if(Utils::FileSystem::exists(test))
+		return test;
 
-		// check in exepath
-		test = std::string("/usr/share/emulationstation/resources/") + &path[2]; // batocera
-		if(Utils::FileSystem::exists(test))
-			return test;
+	// check in exepath
+	test = Utils::FileSystem::getSharedConfigPath() + "/resources/" + &path[2];
+	if(Utils::FileSystem::exists(test))
+		return test;
 
-		// check in cwd
-		test = Utils::FileSystem::getCWDPath() + "/resources/" + &path[2];
-		if(Utils::FileSystem::exists(test))
-			return test;
-	}
+	// check in cwd
+	test = Utils::FileSystem::getCWDPath() + "/resources/" + &path[2];
+	if(Utils::FileSystem::exists(test))
+		return test;
 
 	// not a resource, return unmodified path
 	return path;

--- a/es-core/src/utils/FileSystemUtil.h
+++ b/es-core/src/utils/FileSystemUtil.h
@@ -38,6 +38,12 @@ namespace Utils
 		bool        isSymlink          (const std::string& _path);
 		bool        isHidden           (const std::string& _path);
 
+		void		setHomePath		   (const std::string& _path);
+		void		setExePath		   (const std::string& _path);
+
+
+		std::string getEsConfigPath();
+		std::string getSharedConfigPath();
 	} // FileSystem::
 
 } // Utils::

--- a/es-core/src/utils/StringUtil.cpp
+++ b/es-core/src/utils/StringUtil.cpp
@@ -294,6 +294,24 @@ namespace Utils
 
 		} // scramble
 
+		std::vector<std::string> split(const std::string& s, char seperator)
+		{
+			std::vector<std::string> output;
+
+			std::string::size_type prev_pos = 0, pos = 0;
+			while ((pos = s.find(seperator, pos)) != std::string::npos)
+			{
+				std::string substring(s.substr(prev_pos, pos - prev_pos));
+
+				output.push_back(substring);
+
+				prev_pos = ++pos;
+			}
+
+			output.push_back(s.substr(prev_pos, pos - prev_pos)); // Last word
+
+			return output;
+		}
 	} // String::
 
 } // Utils::

--- a/es-core/src/utils/StringUtil.h
+++ b/es-core/src/utils/StringUtil.h
@@ -28,6 +28,8 @@ namespace Utils
 		std::string  format             (const char* _string, ...);      
 		std::string  scramble           (const std::string& _input, const std::string& key);
 
+		std::vector<std::string> split  (const std::string& s, char seperator);
+
 	} // String::
 
 } // Utils::

--- a/locale/lang/de/LC_MESSAGES/emulationstation2.po
+++ b/locale/lang/de/LC_MESSAGES/emulationstation2.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: emulationstation\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-08-15 13:34+0200\n"
+"POT-Creation-Date: 2019-08-02 23:26+0200\n"
 "Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -59,10 +59,10 @@ msgid "FILTER GAMELIST"
 msgstr "FILTERE SPIELELISTE"
 
 msgid "ADD/REMOVE GAMES TO THIS GAME COLLECTION"
-msgstr ""
+msgstr "SPIELE ZUR SAMMLUNG HINZUFÜGEN/ENTFERNEN"
 
 msgid "FINISH EDITING COLLECTION"
-msgstr ""
+msgstr "BEARBEITUNG DER SAMMLUNG BEENDEN"
 
 msgid "EDIT THIS GAME'S METADATA"
 msgstr "METADATEN BEARBEITEN"
@@ -92,7 +92,7 @@ msgid "UI SETTINGS"
 msgstr "UI EINSTELLUNGEN"
 
 msgid "GAME COLLECTION SETTINGS"
-msgstr ""
+msgstr "SPIELSAMMLUNGSEINSTELLUNGEN"
 
 msgid "SOUND SETTINGS"
 msgstr "SOUNDEINSTELLUNGEN"
@@ -169,9 +169,6 @@ msgstr "UPDATES"
 msgid "THEMES"
 msgstr "THEMES"
 
-msgid "THE BEZEL PROJECT"
-msgstr ""
-
 msgid "AUTO UPDATES"
 msgstr "AUTOMATISCHE UPDATES"
 
@@ -244,7 +241,7 @@ msgid "RETRO"
 msgstr "RETRO"
 
 msgid "ENHANCED"
-msgstr ""
+msgstr "VERBESSERT"
 
 msgid "INTEGER SCALE (PIXEL PERFECT)"
 msgstr "INTEGER SCALE (PIXEL PERFECT)"
@@ -334,10 +331,12 @@ msgid ""
 "You are changing the UI to a restricted mode:\n"
 "This will hide most menu-options to prevent changes to the system.\n"
 "To unlock and return to the full UI, enter this code:"
-msgstr ""
+msgstr "Sie ändern die Benutzeroberfläche in einen eingeschränkten Modus:\n"
+"Dadurch werden die meisten Menüoptionen ausgeblendet, um Änderungen am System zu verhindern.\n"
+"Geben Sie den folgenden Code ein, um die Sperre aufzuheben und zur vollständigen Benutzeroberfläche zurückzukehren:"
 
 msgid "Do you want to proceed ?"
-msgstr ""
+msgstr "Möchten Sie fortfahren ?"
 
 msgid "VIDEO OUTPUT"
 msgstr "BILD AUSGABE"
@@ -352,7 +351,7 @@ msgid "START ON SYSTEM"
 msgstr "START MIT SYSTEM"
 
 msgid "DISPLAY / HIDE SYSTEMS"
-msgstr ""
+msgstr "ZEIGE / VERSTECKE SYSTEME"
 
 msgid "TRANSITION STYLE"
 msgstr "ÜBERGANGSSTIL"
@@ -422,7 +421,7 @@ msgid "VRAM LIMIT"
 msgstr "VRAM LIMIT"
 
 msgid "POWER SAVER MODES"
-msgstr ""
+msgstr "ENERGIESPAR-MODI"
 
 msgid "SYSTEM VOLUME"
 msgstr "LAUTSTÄRKE"
@@ -430,11 +429,8 @@ msgstr "LAUTSTÄRKE"
 msgid "FRONTEND MUSIC"
 msgstr "FRONTEND MUSIK"
 
-msgid "DISPLAY SONG TITLES"
-msgstr ""
-
 msgid "ONLY PLAY SYSTEM-SPECIFIC MUSIC FOLDER"
-msgstr ""
+msgstr "NUR SYSTEM-SPEZIFISCHE MUSIK-ORDNER ABSPIELEN"
 
 msgid "ENABLE VIDEO AUDIO"
 msgstr "VIDEO AUDIO AKTIVIEREN"
@@ -506,43 +502,43 @@ msgid "VIDEO MODE"
 msgstr "VIDEO MODUS"
 
 msgid "COLORIZATION"
-msgstr ""
+msgstr "FARBEN"
 
 msgid "FULL BOOT"
-msgstr ""
+msgstr "VOLLER START"
 
 msgid "EMULATED WIIMOTES"
-msgstr ""
+msgstr "EMULIERTE WIIMOTES"
 
 msgid "INTERNAL RESOLUTION"
-msgstr ""
+msgstr "INTERNE AUFLÖSUNG"
 
 msgid "CREATE NEW CUSTOM COLLECTION FROM THEME"
-msgstr ""
+msgstr "NEUE BENUTZERDEFINIERTE SAMMLUNG AUS THEMA ERSTELLEN"
 
 msgid "SELECT THEME FOLDER"
-msgstr ""
+msgstr "THEMEN-ORDNER AUSWÄHLEN"
 
 msgid "CREATE NEW CUSTOM COLLECTION"
-msgstr ""
+msgstr "NEUE BENUTZERDEFINIERTE SAMMLUNG ERSTELLEN"
 
 msgid "New Collection Name"
-msgstr ""
+msgstr "Name der neuen Sammlung"
 
 msgid "GROUP UNTHEMED CUSTOM COLLECTIONS"
-msgstr ""
+msgstr "UNTHEMATISIERTE BENUTZERDEFINIERTE SAMMLUNG GRUPPIEREN"
 
 msgid "SORT CUSTOM COLLECTIONS AND SYSTEMS"
-msgstr ""
+msgstr "BENUTZERDEFINIERTE SAMMLUNGEN UND SYSTEME SORTIEREN"
 
 msgid "SELECT COLLECTIONS"
-msgstr ""
+msgstr "SAMMLUNGEN AUSWÄHLEN"
 
 msgid "AUTOMATIC GAME COLLECTIONS"
-msgstr ""
+msgstr "AUTOMATISCHE SPIELE-SAMMLUNGEN"
 
 msgid "CUSTOM GAME COLLECTIONS"
-msgstr ""
+msgstr "BENUTZERDEFINIERTE SPIELE-SAMMLUNGEN"
 
 msgid "INSTALL BATOCERA"
 msgstr "INSTALLIERE BATOCERA"
@@ -612,24 +608,6 @@ msgid_plural "%i GAMES SKIPPED."
 msgstr[0] "%i SPIEL ÜBERSPRUNGEN"
 msgstr[1] "%i SPIELE ÜBERSPRUNGEN"
 
-msgid "INSTALL BEZELS"
-msgstr ""
-
-msgid "UNINSTALL BEZELS"
-msgstr ""
-
-msgid "INSTALL THE BEZEL PROJECT"
-msgstr ""
-
-msgid "SELECT SYSTEM WHERE BEZELS WILL BE INSTALLED"
-msgstr ""
-
-msgid "UNINSTALL THE BEZEL PROJECT"
-msgstr ""
-
-msgid "SELECT SYSTEM WHERE BEZELS WILL BE REMOVED"
-msgstr ""
-
 msgid "THEME INSTALLED SUCCESSFULLY"
 msgstr "THEME ERFOLGREICH INSTALLIERT"
 
@@ -672,12 +650,6 @@ msgstr "KOMPATIBLE NIEDRIGE AUFLÖSUNG FÜR GROSSBUCHSTABEN VERWENDEN"
 msgid "STRETCH VIDEO ON SCREENSAVER"
 msgstr "VIDEO BEI BILDSCHIRMSCHONER STRECKEN"
 
-msgid "BEZELS INSTALLED SUCCESSFULLY"
-msgstr ""
-
-msgid "BEZELS DELETED SUCCESSFULLY"
-msgstr ""
-
 msgid "SCRAPE THESE GAMES"
 msgstr "DIESE SPIELE SCRAPEN"
 
@@ -715,19 +687,19 @@ msgid "NO GAMES FIT THAT CRITERIA."
 msgstr "KEIN SPIEL ERFÜLLT DIE KRITERIEN"
 
 msgid "SELECT SYSTEMS TO DISPLAY"
-msgstr ""
+msgstr "WÄHLE SYSTEME ZUR ANZEIGE AUS"
 
 msgid "SYSTEMS DISPLAYED"
-msgstr ""
+msgstr "ANGEZEIGTE SYSTEME"
 
 msgid "APPLY"
-msgstr ""
+msgstr "ANWENDEN"
 
 msgid "REVERT"
-msgstr ""
+msgstr "ZURÜCKSETZEN"
 
 msgid "VALIDATE"
-msgstr ""
+msgstr "VALIDIEREN"
 
 msgid "SELECT THEME"
 msgstr "THEME AUSWÄHLEN"
@@ -867,9 +839,6 @@ msgstr "Laufschrift"
 msgid "enter path to marquee"
 msgstr "Pfad zur Laufschrift eingeben"
 
-msgid "Now playing: "
-msgstr ""
-
 msgid "DO YOU WANT TO START KODI MEDIA CENTER ?"
 msgstr "MÖCHTEN SIE KODI MEDIA CENTER STARTEN?"
 
@@ -925,28 +894,28 @@ msgid "UPDATE AVAILABLE"
 msgstr "UPDATE VERFÜGBAR"
 
 msgid "all games"
-msgstr ""
+msgstr "alle Spiele"
 
 msgid "last played"
-msgstr ""
+msgstr "zuletzt gespielt"
 
 msgid "favorites"
-msgstr ""
+msgstr "Favoriten"
 
 msgid "2 players"
-msgstr ""
+msgstr "2 Spieler"
 
 msgid "4 players"
-msgstr ""
+msgstr "4 Spieler"
 
 msgid "collections"
-msgstr ""
+msgstr "Sammlungen"
 
 msgid "Editing the collection. Add/remove games with Y."
-msgstr ""
+msgstr "Sammlung bearbeiten. Spiele hinzufügen/entfernen mit Y."
 
 msgid "Finished editing the collection."
-msgstr ""
+msgstr "Bearbeitung der Sammlung beenden"
 
 #, c-format
 msgid "Added '%s' to '%s'"

--- a/locale/lang/ru_RU/LC_MESSAGES/emulationstation2.po
+++ b/locale/lang/ru_RU/LC_MESSAGES/emulationstation2.po
@@ -174,7 +174,7 @@ msgid "THEMES"
 msgstr "ТЕМЫ"
 
 msgid "THE BEZEL PROJECT"
-msgstr ""
+msgstr "ПРОЕКТ РАМКИ"
 
 msgid "AUTO UPDATES"
 msgstr "АВТООБНОВЛЕНИЯ"
@@ -435,7 +435,7 @@ msgid "FRONTEND MUSIC"
 msgstr "МУЗЫКА В МЕНЮ"
 
 msgid "DISPLAY SONG TITLES"
-msgstr ""
+msgstr "ПОКАЗАТЬ НАЗВАНИЕ ПЕСНИ"
 
 msgid "ONLY PLAY SYSTEM-SPECIFIC MUSIC FOLDER"
 msgstr "ТОЛЬКО МУЗЫКА ИЗ СИСТЕМНОЙ ПАПКИ"
@@ -519,7 +519,7 @@ msgid "EMULATED WIIMOTES"
 msgstr "ЭМУЛИРОВАТЬ ВИМОУТЫ"
 
 msgid "INTERNAL RESOLUTION"
-msgstr ""
+msgstr "ВНУТРЕННЕЕ РАЗРЕШЕНИЕ"
 
 msgid "CREATE NEW CUSTOM COLLECTION FROM THEME"
 msgstr "СОЗДАТЬ ТЕМАТИЧЕСКУЮ КОЛЛЕКЦИЮ"
@@ -618,22 +618,22 @@ msgstr[1] "%i ИГРЫ ПРОПУЩЕНЫ."
 msgstr[2] "%i ИГР ПРОПУЩЕНО."
 
 msgid "INSTALL BEZELS"
-msgstr ""
+msgstr "УСТНОВИТЬ РАМКИ (ОВЕРЛЕИ)"
 
 msgid "UNINSTALL BEZELS"
-msgstr ""
+msgstr "УДАЛИТЬ РАМКИ (ОВЕРЛЕИ)"
 
 msgid "INSTALL THE BEZEL PROJECT"
-msgstr ""
+msgstr "УСТАНОВИТЬ ПРОЕКТ РАМКИ"
 
 msgid "SELECT SYSTEM WHERE BEZELS WILL BE INSTALLED"
-msgstr ""
+msgstr "ВЫБЕРИТЕ СИСТЕМУ, В КОТОРОЙ РАМКИ БУДУТ УСТАНОВЛЕНЫ"
 
 msgid "UNINSTALL THE BEZEL PROJECT"
-msgstr ""
+msgstr "УДАЛИТЬ ПРОЕКТ РАМКИ"
 
 msgid "SELECT SYSTEM WHERE BEZELS WILL BE REMOVED"
-msgstr ""
+msgstr "ВЫБЕРИТЕ СИСТЕМУ, ГДЕ РАМКИ БУДУТ УДАЛЕНЫ"
 
 msgid "THEME INSTALLED SUCCESSFULLY"
 msgstr "ТЕМА УСПЕШНО УСТАНОВЛЕНА"
@@ -678,10 +678,10 @@ msgid "STRETCH VIDEO ON SCREENSAVER"
 msgstr "РАСТЯНУТЬ ВИДЕО НА ЗАСТАВКЕ"
 
 msgid "BEZELS INSTALLED SUCCESSFULLY"
-msgstr ""
+msgstr "РАМКИ УСПЕШНО УСТАНОВЛЕНЫ"
 
 msgid "BEZELS DELETED SUCCESSFULLY"
-msgstr ""
+msgstr "РАМКИ УСПЕШНО УДАЛЕНЫ"
 
 msgid "SCRAPE THESE GAMES"
 msgstr "ЗАГРУЗИТЬ ДАННЫЕ ЭТИХ ИГР"
@@ -873,7 +873,7 @@ msgid "enter path to marquee"
 msgstr "введите путь к банеру"
 
 msgid "Now playing: "
-msgstr ""
+msgstr "Сейчас играет: "
 
 msgid "DO YOU WANT TO START KODI MEDIA CENTER ?"
 msgstr "ВЫ ХОТИТЕ ЗАПУСТИТЬ МЕДИА-ЦЕНТР KODI?"


### PR DESCRIPTION
- Removed boost except boost::locale (for linux) & use std, stringutil & fileutil instead.
- Windows : Use of internal code for locale instead of boost. This code uses PO files. (Added LocaleES.cpp file )
- Normalized paths in Utils::FileSystem::getEsConfigPath() & Utils::FileSystem::getSharedConfigPath()
- Buttons : Use #define BUTTON_BACK and BUTTON_OK instead of "a" and "b" : batocera inverted button order from Retropie -> Windows is a=OK b=BACK, batocera is b=OK, a=BACK
- Added --home command line for Windows to set homepath using a command line
- SystemConf::loadSystemConf : stop using boost regex to load configuration file. Use faster "string" loader.

