### PR TITLE
Threaded loading of systems + added a progressbar during loading.

### DIFF
--- a/es-app/src/CollectionSystemManager.cpp
+++ b/es-app/src/CollectionSystemManager.cpp
@@ -127,7 +127,7 @@ void CollectionSystemManager::saveCustomCollection(SystemData* sys)
 
 /* Methods to load all Collections into memory, and handle enabling the active ones */
 // loads all Collection Systems
-void CollectionSystemManager::loadCollectionSystems()
+void CollectionSystemManager::loadCollectionSystems(bool async)
 {
 	initAutoCollectionSystems();
 	CollectionSystemDecl decl = mCollectionSystemDeclsIndex[myCollectionsName];
@@ -138,8 +138,10 @@ void CollectionSystemManager::loadCollectionSystems()
 	{
 		// Now see which ones are enabled
 		loadEnabledListFromSettings();
+		
 		// add to the main System Vector, and create Views as needed
-		updateSystemsList();
+		if (!async)
+			updateSystemsList();
 	}
 }
 

--- a/es-app/src/CollectionSystemManager.h
+++ b/es-app/src/CollectionSystemManager.h
@@ -51,7 +51,7 @@ public:
 	static void deinit();
 	void saveCustomCollection(SystemData* sys);
 
-	void loadCollectionSystems();
+	void loadCollectionSystems(bool async = false);
 	void loadEnabledListFromSettings();
 	void updateSystemsList();
 

--- a/es-app/src/SystemData.cpp
+++ b/es-app/src/SystemData.cpp
@@ -2,6 +2,7 @@
 
 #include "SystemConf.h"
 #include "utils/FileSystemUtil.h"
+#include "utils/ThreadPool.h"
 #include "CollectionSystemManager.h"
 #include "FileFilterIndex.h"
 #include "FileSorts.h"
@@ -11,11 +12,11 @@
 #include "Settings.h"
 #include "ThemeData.h"
 #include "views/UIModeController.h"
-#include <pugixml/src/pugixml.hpp>
 #include <fstream>
-#ifdef WIN32
-#include <Windows.h>
-#endif
+#include "Window.h"
+#include "LocaleES.h"
+
+using namespace Utils;
 
 std::vector<SystemData*> SystemData::sSystemVector;
 std::vector<SystemData*> SystemData::sFileSystemVector; //batocera
@@ -53,12 +54,6 @@ SystemData::SystemData(const std::string& name, const std::string& fullName, Sys
 
 SystemData::~SystemData()
 {
-	//save changed game data back to xml
-	if(!Settings::getInstance()->getBool("IgnoreGamelist") && Settings::getInstance()->getBool("SaveGamelistsOnExit") && !mIsCollectionSystem)
-	{
-		updateGamelist(this);
-	}
-
 	delete mRootFolder;
 	delete mFilterIndex;
 }
@@ -171,7 +166,7 @@ std::vector<std::string> readList(const std::string& str, const char* delims = "
 }
 
 //creates systems from information located in a config file
-bool SystemData::loadConfig()
+bool SystemData::loadConfig(Window* window)
 {
 	deleteSystems();
 
@@ -179,7 +174,7 @@ bool SystemData::loadConfig()
 
 	LOG(LogInfo) << "Loading system config file " << path << "...";
 
-	if(!Utils::FileSystem::exists(path))
+	if (!Utils::FileSystem::exists(path))
 	{
 		LOG(LogError) << "es_systems.cfg file does not exist!";
 		writeExampleConfig(getConfigPath(true));
@@ -189,7 +184,7 @@ bool SystemData::loadConfig()
 	pugi::xml_document doc;
 	pugi::xml_parse_result res = doc.load_file(path.c_str());
 
-	if(!res)
+	if (!res)
 	{
 		LOG(LogError) << "Could not parse es_systems.cfg file!";
 		LOG(LogError) << res.description();
@@ -198,104 +193,203 @@ bool SystemData::loadConfig()
 
 	//actually read the file
 	pugi::xml_node systemList = doc.child("systemList");
-
-	if(!systemList)
+	if (!systemList)
 	{
 		LOG(LogError) << "es_systems.cfg is missing the <systemList> tag!";
 		return false;
 	}
 
-	for(pugi::xml_node system = systemList.child("system"); system; system = system.next_sibling("system"))
+	std::vector<std::string> systemsNames;
+
+	int systemCount = 0;
+	for (pugi::xml_node system = systemList.child("system"); system; system = system.next_sibling("system"))
 	{
-		std::string name, fullname, path, cmd, themeFolder;
-
-		name = system.child("name").text().get();
-		fullname = system.child("fullname").text().get();
-		path = system.child("path").text().get();
-
-		// convert extensions list from a string into a vector of strings
-		std::vector<std::string> extensions = readList(system.child("extension").text().get());
-
-		cmd = system.child("command").text().get();
-
-		// platform id list
-		const char* platformList = system.child("platform").text().get();
-		std::vector<std::string> platformStrs = readList(platformList);
-		std::vector<PlatformIds::PlatformId> platformIds;
-		for(auto it = platformStrs.cbegin(); it != platformStrs.cend(); it++)
-		{
-			const char* str = it->c_str();
-			PlatformIds::PlatformId platformId = PlatformIds::getPlatformId(str);
-
-			if(platformId == PlatformIds::PLATFORM_IGNORE)
-			{
-				// when platform is ignore, do not allow other platforms
-				platformIds.clear();
-				platformIds.push_back(platformId);
-				break;
-			}
-
-			// if there appears to be an actual platform ID supplied but it didn't match the list, warn
-			if(str != NULL && str[0] != '\0' && platformId == PlatformIds::PLATFORM_UNKNOWN)
-				LOG(LogWarning) << "  Unknown platform for system \"" << name << "\" (platform \"" << str << "\" from list \"" << platformList << "\")";
-			else if(platformId != PlatformIds::PLATFORM_UNKNOWN)
-				platformIds.push_back(platformId);
-		}
-
-		// theme folder
-		themeFolder = system.child("theme").text().as_string(name.c_str());
-
-		//validate
-		if(name.empty() || path.empty() || extensions.empty() || cmd.empty())
-		{
-			LOG(LogError) << "System \"" << name << "\" is missing name, path, extension, or command!";
-			continue;
-		}
-
-		//convert path to generic directory seperators
-		path = Utils::FileSystem::getGenericPath(path);
-
-		//expand home symbol if the startpath contains ~
-		if(path[0] == '~')
-		{
-			path.erase(0, 1);
-			path.insert(0, Utils::FileSystem::getHomePath());
-		}
-
-		//create the system runtime environment data
-		SystemEnvironmentData* envData = new SystemEnvironmentData;
-		envData->mStartPath = path;
-		envData->mSearchExtensions = extensions;
-		envData->mLaunchCommand = cmd;
-		envData->mPlatformIds = platformIds;
-
-                // batocera
-		// emulators and cores
-		std::map<std::string, std::vector<std::string>*> * systemEmulators = new std::map<std::string, std::vector<std::string>*>();
-		pugi::xml_node emulatorsNode = system.child("emulators");
-		for(pugi::xml_node emuNode = emulatorsNode.child("emulator"); emuNode; emuNode = emuNode.next_sibling("emulator")) {
-		  std::string emulatorName = emuNode.attribute("name").as_string();
-		  (*systemEmulators)[emulatorName] = new std::vector<std::string>();
-		  pugi::xml_node coresNode = emuNode.child("cores");
-		  for (pugi::xml_node coreNode = coresNode.child("core"); coreNode; coreNode = coreNode.next_sibling("core")) {
-		    std::string corename = coreNode.text().as_string();
-		    (*systemEmulators)[emulatorName]->push_back(corename);
-		  }
-		}
-		
-		SystemData* newSys = new SystemData(name, fullname, envData, themeFolder, systemEmulators); // batocera
-		if(newSys->getRootFolder()->getChildrenByFilename().size() == 0)
-		{
-			LOG(LogWarning) << "System \"" << name << "\" has no games! Ignoring it.";
-			delete newSys;
-		}else{
-			sSystemVector.push_back(newSys);
-			sFileSystemVector.push_back(newSys); //batocera
-		}
+		systemsNames.push_back(system.child("fullname").text().get());
+		systemCount++;
 	}
-	CollectionSystemManager::get()->loadCollectionSystems();
+
+	if (systemCount == 0)
+	{
+		LOG(LogError) << "no system found in es_systems.cfg";
+		return false;
+	}
+
+	int currentSystem = 0;
+
+	typedef SystemData* SystemDataPtr;
+
+	ThreadPool* pThreadPool = NULL;
+	SystemDataPtr* systems = NULL;
+
+	// Allow threaded loading only if processor threads > 2 so it does not apply on machines like Pi0.
+	if (std::thread::hardware_concurrency() > 2 && Settings::getInstance()->getBool("ThreadedLoading"))
+	{
+		pThreadPool = new ThreadPool();
+
+		systems = new SystemDataPtr[systemCount];
+		for (int i = 0; i < systemCount; i++)
+			systems[i] = nullptr;
+
+		pThreadPool->queueWorkItem([] { CollectionSystemManager::get()->loadCollectionSystems(true); });
+	}
+
+	int processedSystem = 0;
+
+	for (pugi::xml_node system = systemList.child("system"); system; system = system.next_sibling("system"))
+	{
+		if (pThreadPool != NULL)
+		{
+			pThreadPool->queueWorkItem([system, currentSystem, systems, &processedSystem]
+			{
+				systems[currentSystem] = loadSystem(system);
+				processedSystem++;
+			});
+		}
+		else
+		{
+			std::string fullname = system.child("fullname").text().get();
+
+			if (window != NULL)
+				window->renderLoadingScreen(fullname, systemCount == 0 ? 0 : (float)currentSystem / (float)(systemCount + 1));
+
+			std::string nm = system.child("name").text().get();
+
+			SystemData* pSystem = loadSystem(system);
+			if (pSystem != nullptr)
+				sSystemVector.push_back(pSystem);
+		}
+
+		currentSystem++;
+	}
+
+	if (pThreadPool != NULL)
+	{
+		if (window != NULL)
+		{
+			pThreadPool->wait([window, &processedSystem, systemCount, &systemsNames]
+			{
+				int px = processedSystem - 1;
+				if (px >= 0 && px < systemsNames.size())
+					window->renderLoadingScreen(systemsNames.at(px), (float)px / (float)(systemCount + 1));
+			}, 10);
+		}
+		else
+			pThreadPool->wait();
+
+		for (int i = 0; i < systemCount; i++)
+		{
+			SystemData* pSystem = systems[i];
+			if (pSystem != nullptr)
+				sSystemVector.push_back(pSystem);
+		}
+
+		delete[] systems;
+		delete pThreadPool;
+
+		if (window != NULL)
+			window->renderLoadingScreen(_("Favorites"), systemCount == 0 ? 0 : currentSystem / systemCount);
+
+		// updateSystemsList can't be run async, systems have to be created before
+		CollectionSystemManager::get()->updateSystemsList();
+	}
+	else
+	{
+		if (window != NULL)
+			window->renderLoadingScreen(_("Favorites"), systemCount == 0 ? 0 : currentSystem / systemCount);
+
+		CollectionSystemManager::get()->loadCollectionSystems();
+	}
 
 	return true;
+}
+
+SystemData* SystemData::loadSystem(pugi::xml_node system)
+{
+	std::string name, fullname, path, cmd, themeFolder;
+
+	name = system.child("name").text().get();
+	fullname = system.child("fullname").text().get();
+	path = system.child("path").text().get();
+
+	// convert extensions list from a string into a vector of strings
+	std::vector<std::string> extensions = readList(system.child("extension").text().get());
+
+	cmd = system.child("command").text().get();
+
+	// platform id list
+	const char* platformList = system.child("platform").text().get();
+	std::vector<std::string> platformStrs = readList(platformList);
+	std::vector<PlatformIds::PlatformId> platformIds;
+	for (auto it = platformStrs.cbegin(); it != platformStrs.cend(); it++)
+	{
+		const char* str = it->c_str();
+		PlatformIds::PlatformId platformId = PlatformIds::getPlatformId(str);
+
+		if (platformId == PlatformIds::PLATFORM_IGNORE)
+		{
+			// when platform is ignore, do not allow other platforms
+			platformIds.clear();
+			platformIds.push_back(platformId);
+			break;
+		}
+
+		// if there appears to be an actual platform ID supplied but it didn't match the list, warn
+		if (str != NULL && str[0] != '\0' && platformId == PlatformIds::PLATFORM_UNKNOWN)
+			LOG(LogWarning) << "  Unknown platform for system \"" << name << "\" (platform \"" << str << "\" from list \"" << platformList << "\")";
+		else if (platformId != PlatformIds::PLATFORM_UNKNOWN)
+			platformIds.push_back(platformId);
+	}
+
+	// theme folder
+	themeFolder = system.child("theme").text().as_string(name.c_str());
+
+	//validate
+	if (name.empty() || path.empty() || extensions.empty() || cmd.empty())
+	{
+		LOG(LogError) << "System \"" << name << "\" is missing name, path, extension, or command!";
+		return nullptr;
+	}
+
+	//convert path to generic directory seperators
+	path = Utils::FileSystem::getGenericPath(path);
+
+	//expand home symbol if the startpath contains ~
+	if (path[0] == '~')
+	{
+		path.erase(0, 1);
+		path.insert(0, Utils::FileSystem::getHomePath());
+	}
+
+	//create the system runtime environment data
+	SystemEnvironmentData* envData = new SystemEnvironmentData;
+	envData->mStartPath = path;
+	envData->mSearchExtensions = extensions;
+	envData->mLaunchCommand = cmd;
+	envData->mPlatformIds = platformIds;
+
+	// batocera
+// emulators and cores
+	std::map<std::string, std::vector<std::string>*> * systemEmulators = new std::map<std::string, std::vector<std::string>*>();
+	pugi::xml_node emulatorsNode = system.child("emulators");
+	for (pugi::xml_node emuNode = emulatorsNode.child("emulator"); emuNode; emuNode = emuNode.next_sibling("emulator")) {
+		std::string emulatorName = emuNode.attribute("name").as_string();
+		(*systemEmulators)[emulatorName] = new std::vector<std::string>();
+		pugi::xml_node coresNode = emuNode.child("cores");
+		for (pugi::xml_node coreNode = coresNode.child("core"); coreNode; coreNode = coreNode.next_sibling("core")) {
+			std::string corename = coreNode.text().as_string();
+			(*systemEmulators)[emulatorName]->push_back(corename);
+		}
+	}
+
+	SystemData* newSys = new SystemData(name, fullname, envData, themeFolder, systemEmulators); // batocera
+	if (newSys->getRootFolder()->getChildrenByFilename().size() == 0)
+	{
+		LOG(LogWarning) << "System \"" << name << "\" has no games! Ignoring it.";
+		delete newSys;
+		return nullptr;
+	}
+
+	return newSys;
 }
 
 void SystemData::writeExampleConfig(const std::string& path)
@@ -346,10 +440,18 @@ void SystemData::writeExampleConfig(const std::string& path)
 
 void SystemData::deleteSystems()
 {
-	for(unsigned int i = 0; i < sSystemVector.size(); i++)
+	bool saveOnExit = !Settings::getInstance()->getBool("IgnoreGamelist") && Settings::getInstance()->getBool("SaveGamelistsOnExit");
+
+	for (unsigned int i = 0; i < sSystemVector.size(); i++)
 	{
-		delete sSystemVector.at(i);
+		SystemData* pData = sSystemVector.at(i);
+
+		if (saveOnExit && !pData->mIsCollectionSystem)
+			updateGamelist(pData);
+
+		delete pData;
 	}
+
 	sSystemVector.clear();
 }
 

--- a/es-app/src/SystemData.h
+++ b/es-app/src/SystemData.h
@@ -8,10 +8,12 @@
 #include <string>
 #include <vector>
 #include <map>
+#include <pugixml/src/pugixml.hpp>
 
 class FileData;
 class FileFilterIndex;
 class ThemeData;
+class Window;
 
 struct SystemEnvironmentData
 {
@@ -47,7 +49,7 @@ public:
 	unsigned int getDisplayedGameCount() const;
 
 	static void deleteSystems();
-	static bool loadConfig(); //Load the system config file at getConfigPath(). Returns true if no errors were encountered. An example will be written if the file doesn't exist.
+	static bool loadConfig(Window* window = nullptr); //Load the system config file at getConfigPath(). Returns true if no errors were encountered. An example will be written if the file doesn't exist.
 	static void writeExampleConfig(const std::string& path);
 	static std::string getConfigPath(bool forWrite); // if forWrite, will only return ~/.emulationstation/es_systems.cfg, never /etc/emulationstation/es_systems.cfg
 
@@ -83,6 +85,8 @@ private:
 	void populateFolder(FileData* folder);
 	void indexAllGameFilters(const FileData* folder);
 	void setIsGameSystemStatus();
+	
+	static SystemData* loadSystem(pugi::xml_node system);
 
 	FileFilterIndex* mFilterIndex;
 

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -1344,7 +1344,7 @@ void GuiMenu::openGamesSettings_batocera() {
 					  ViewController::init(window);
 					  CollectionSystemManager::deinit();
 					  CollectionSystemManager::init(window);
-					  SystemData::loadConfig();
+					  SystemData::loadConfig(window);
 					  GuiComponent *gui;
 					  while ((gui = window->peekGui()) != NULL) {
 					    window->removeGui(gui);
@@ -1876,6 +1876,12 @@ void GuiMenu::openUISettings_batocera()
 		Settings::getInstance()->setString("PowerSaverMode", power_saver->getSelected());
 		PowerSaver::init();
 	});
+
+	// threaded loading -> Should be moved in a "developper" submenu
+	auto threadedLoading = std::make_shared<SwitchComponent>(mWindow);
+	threadedLoading->setState(Settings::getInstance()->getBool("ThreadedLoading"));
+	s->addWithLabel(_("THREADED LOADING"), threadedLoading);
+	s->addSaveFunc([threadedLoading] { Settings::getInstance()->setBool("ThreadedLoading", threadedLoading->getState()); });
 
 	mWindow->pushGui(s);
 }

--- a/es-app/src/main.cpp
+++ b/es-app/src/main.cpp
@@ -223,11 +223,11 @@ bool verifyHomeFolderExists()
 }
 
 // Returns true if everything is OK,
-bool loadSystemConfigFile(const char** errorString)
+bool loadSystemConfigFile(Window* window, const char** errorString)
 {
 	*errorString = NULL;
 
-	if(!SystemData::loadConfig())
+	if(!SystemData::loadConfig(window))
 	{
 		LOG(LogError) << "Error while parsing systems configuration file!";
 		*errorString = "IT LOOKS LIKE YOUR SYSTEMS CONFIGURATION FILE HAS NOT BEEN SET UP OR IS INVALID. YOU'LL NEED TO DO THIS BY HAND, UNFORTUNATELY.\n\n"
@@ -402,7 +402,7 @@ int main(int argc, char* argv[])
 	}
 
 	const char* errorMsg = NULL;
-	if(!loadSystemConfigFile(&errorMsg))
+	if(!loadSystemConfigFile(splashScreen && splashScreenProgress ? &window : nullptr, &errorMsg))
 	{
 		// something went terribly wrong
 		if(errorMsg == NULL)

--- a/es-core/CMakeLists.txt
+++ b/es-core/CMakeLists.txt
@@ -79,6 +79,7 @@ set(CORE_HEADERS
 	${CMAKE_CURRENT_SOURCE_DIR}/src/utils/FileSystemUtil.h
 	${CMAKE_CURRENT_SOURCE_DIR}/src/utils/StringUtil.h
 	${CMAKE_CURRENT_SOURCE_DIR}/src/utils/TimeUtil.h
+	${CMAKE_CURRENT_SOURCE_DIR}/src/utils/ThreadPool.h
 )
 
 set(CORE_SOURCES
@@ -156,6 +157,7 @@ set(CORE_SOURCES
 	${CMAKE_CURRENT_SOURCE_DIR}/src/utils/FileSystemUtil.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/utils/StringUtil.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/utils/TimeUtil.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/src/utils/ThreadPool.cpp
 )
 
 include_directories(${COMMON_INCLUDE_DIRS})

--- a/es-core/src/Settings.cpp
+++ b/es-core/src/Settings.cpp
@@ -160,6 +160,8 @@ void Settings::setDefaults()
 	mBoolMap["ForceKid"] = false;
 	mBoolMap["ForceDisableFilters"] = false;
 
+	mBoolMap["ThreadedLoading"] = true;
+
 	mIntMap["WindowWidth"]   = 0;
 	mIntMap["WindowHeight"]  = 0;
 	mIntMap["ScreenWidth"]   = 0;

--- a/es-core/src/Window.h
+++ b/es-core/src/Window.h
@@ -65,7 +65,7 @@ public:
 	bool getAllowSleep();
 	void setAllowSleep(bool sleep);
 
-	void renderLoadingScreen(std::string text);
+	void renderLoadingScreen(std::string text, float percent = -1, unsigned char opacity = 255);
 
 	void renderHelpPromptsEarly(); // used to render HelpPrompts before a fade
 	void setHelpPrompts(const std::vector<HelpPrompt>& prompts, const HelpStyle& style);

--- a/es-core/src/utils/ThreadPool.cpp
+++ b/es-core/src/utils/ThreadPool.cpp
@@ -1,0 +1,93 @@
+#include "ThreadPool.h"
+
+#if WIN32
+#include <Windows.h>
+#endif
+
+namespace Utils
+{
+	ThreadPool::ThreadPool() : mRunning(true), mWaiting(false), mNumWork(0)
+	{
+		size_t num_threads = std::thread::hardware_concurrency() - 1;
+
+		auto doWork = [&](size_t id)
+		{
+#if WIN32
+			auto mask = (static_cast<DWORD_PTR>(1) << id);
+			SetThreadAffinityMask(GetCurrentThread(), mask);
+#endif
+
+			while (mRunning)
+			{
+				_mutex.lock();
+				if (!mWorkQueue.empty())
+				{
+					auto work = mWorkQueue.front();
+					mWorkQueue.pop();
+					_mutex.unlock();
+
+					try
+					{
+						work();
+					}
+					catch (...) {}
+
+					mNumWork--;
+				}
+				else
+				{
+					_mutex.unlock();
+
+					// Extra code : Exit finished threads
+					if (mWaiting)
+						return;
+
+					std::this_thread::yield();
+					std::this_thread::sleep_for(std::chrono::milliseconds(1));
+				}
+			}
+		};
+
+		mThreads.reserve(num_threads);
+
+		for (size_t i = 0; i < num_threads; i++)
+			mThreads.push_back(std::thread(doWork, i));
+	}
+
+	ThreadPool::~ThreadPool()
+	{
+		mRunning = false;
+
+		for (std::thread& t : mThreads)
+			if (t.joinable())
+				t.join();
+	}
+
+	void ThreadPool::queueWorkItem(work_function work)
+	{
+		_mutex.lock();
+		mWorkQueue.push(work);
+		mNumWork++;
+		_mutex.unlock();
+	}
+
+	void ThreadPool::wait()
+	{
+		mWaiting = true;
+		while (mNumWork.load() > 0)
+			std::this_thread::yield();
+	}
+
+	void ThreadPool::wait(work_function work, int delay)
+	{
+		mWaiting = true;
+
+		while (mNumWork.load() > 0)
+		{
+			work();
+
+			std::this_thread::yield();
+			std::this_thread::sleep_for(std::chrono::milliseconds(delay));
+		}
+	}
+}

--- a/es-core/src/utils/ThreadPool.h
+++ b/es-core/src/utils/ThreadPool.h
@@ -1,0 +1,35 @@
+#ifndef __THREADPOOL
+#define __THREADPOOL
+
+#include <thread>
+#include <mutex>
+#include <queue>
+#include <atomic>
+#include <functional>
+
+namespace Utils
+{
+	class ThreadPool
+	{
+	public:
+		typedef std::function<void(void)> work_function;
+
+		ThreadPool();
+		~ThreadPool();
+
+		void queueWorkItem(work_function work);
+		void wait();
+		void wait(work_function work, int delay = 50);
+
+	private:
+		bool mRunning;
+		bool mWaiting;
+		std::queue<work_function> mWorkQueue;
+		std::atomic<size_t> mNumWork;
+		std::mutex _mutex;
+		std::vector<std::thread> mThreads;
+
+	};
+}
+
+#endif


### PR DESCRIPTION
- Load systems using threaded loading when processor threads > 2 (so it doesn't apply on pi0), making loading systems faster.
- Added a progressbar during loading (red for batocera)
- The titlescreen/progressbar is also displayed when "UPDATE GAMES LISTS" runs.
- Moved updateGamelist() call in deleteAllSystems : it was previously called by  ~SystemData and was also called when a system was loaded but deleted because it had no roms in it.
