### PR TITLE
Many things : Settings / Clipping / NinePatchComponent /VideoVlcComponent / VRAM Optimization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,5 @@ CPackSourceConfig.cmake
 # batocera
 # po backup
 *.po~
+/.vs/
+*.sqlite

--- a/es-app/src/EmulationStation.h
+++ b/es-app/src/EmulationStation.h
@@ -4,14 +4,14 @@
 
 // These numbers and strings need to be manually updated for a new version.
 // Do this version number update as the very last commit for the new release version.
-#define PROGRAM_VERSION_MAJOR       2
-#define PROGRAM_VERSION_MINOR        9
+#define PROGRAM_VERSION_MAJOR        5
+#define PROGRAM_VERSION_MINOR        24
 #define PROGRAM_VERSION_MAINTENANCE  0
-#define PROGRAM_VERSION_STRING "2.9.0rp-dev"
+#define PROGRAM_VERSION_STRING "5.24-dev"
 
 #define PROGRAM_BUILT_STRING __DATE__ " - " __TIME__
 
-#define RESOURCE_VERSION_STRING "2,9,0\0"
+#define RESOURCE_VERSION_STRING "5,24,0\0"
 #define RESOURCE_VERSION PROGRAM_VERSION_MAJOR,PROGRAM_VERSION_MINOR,PROGRAM_VERSION_MAINTENANCE
 
 #endif // ES_APP_EMULATION_STATION_H

--- a/es-app/src/components/RatingComponent.cpp
+++ b/es-app/src/components/RatingComponent.cpp
@@ -110,6 +110,10 @@ void RatingComponent::render(const Transform4x4f& parentTrans)
 		return;
 
 	Transform4x4f trans = parentTrans * getTransform();
+
+	if (!Renderer::isVisibleOnScreen(trans.translation().x(), trans.translation().y(), mSize.x(), mSize.y()))
+		return;
+
 	Renderer::setMatrix(trans);
 
 	mFilledTexture->bind();

--- a/es-app/src/components/TextListComponent.h
+++ b/es-app/src/components/TextListComponent.h
@@ -143,6 +143,9 @@ void TextListComponent<T>::render(const Transform4x4f& parentTrans)
 	if(size() == 0)
 		return;
 
+	if (!Renderer::isVisibleOnScreen(trans.translation().x(), trans.translation().y(), mSize.x(), mSize.y()))
+		return;
+
 	const float entrySize = Math::max(font->getHeight(1.0), (float)font->getSize()) * mLineSpacing;
 
 	int startEntry = 0;

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -439,6 +439,12 @@ void GuiMenu::openDeveloperSettings()
 	s->addWithLabel(_("THREADED LOADING"), threadedLoading);
 	s->addSaveFunc([threadedLoading] { Settings::getInstance()->setBool("ThreadedLoading", threadedLoading->getState()); });
 
+	// optimizeVram
+	auto optimizeVram = std::make_shared<SwitchComponent>(mWindow);
+	optimizeVram->setState(Settings::getInstance()->getBool("OptimizeVRAM"));
+	s->addWithLabel(_("OPTIMIZE IMAGES VRAM USE"), optimizeVram);
+	s->addSaveFunc([optimizeVram] { Settings::getInstance()->setBool("OptimizeVRAM", optimizeVram->getState()); });
+
 	// support
 	s->addEntry(_("CREATE A SUPPORT FILE"), true, [window] {
 		window->pushGui(new GuiMsgBox(window, _("CREATE A SUPPORT FILE ?"), _("YES"),

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -80,7 +80,7 @@ GuiMenu::GuiMenu(Window *window) : GuiComponent(window), mMenu(window, _("MAIN M
 		addEntry(_("GAME COLLECTION SETTINGS").c_str(), true, [this] { openCollectionSystemSettings(); }, "iconAdvanced");
 
 	if (isFullUI)
-		addEntry(_("SOUND SETTINGS").c_str(), true, [this] { openSoundSettings_batocera(); }, "iconSound");
+		addEntry(_("SOUND SETTINGS").c_str(), true, [this] { openSoundSettings(); }, "iconSound");
 
 	if (isFullUI)
 		addEntry(_("NETWORK SETTINGS").c_str(), true, [this] { openNetworkSettings_batocera(); }, "iconNetwork");
@@ -141,120 +141,6 @@ void GuiMenu::openScraperSettings()
 	s->addEntry(_("SCRAPE NOW"), true, openAndSave);
 
 	mWindow->pushGui(s);
-}
-
-void GuiMenu::openSoundSettings()
-{
-	auto s = new GuiSettings(mWindow, "SOUND SETTINGS");
-
-	// volume
-	auto volume = std::make_shared<SliderComponent>(mWindow, 0.f, 100.f, 1.f, "%");
-	volume->setValue((float)VolumeControl::getInstance()->getVolume());
-	s->addWithLabel("SYSTEM VOLUME", volume);
-	s->addSaveFunc([volume] { VolumeControl::getInstance()->setVolume((int)Math::round(volume->getValue())); });
-
-	if (UIModeController::getInstance()->isUIModeFull())
-	{
-#if defined(__linux__)
-		// audio card
-		auto audio_card = std::make_shared< OptionListComponent<std::string> >(mWindow, "AUDIO CARD", false);
-		std::vector<std::string> audio_cards;
-	#ifdef _RPI_
-		// RPi Specific  Audio Cards
-		audio_cards.push_back("local");
-		audio_cards.push_back("hdmi");
-		audio_cards.push_back("both");
-	#endif
-		audio_cards.push_back("default");
-		audio_cards.push_back("sysdefault");
-		audio_cards.push_back("dmix");
-		audio_cards.push_back("hw");
-		audio_cards.push_back("plughw");
-		audio_cards.push_back("null");
-		if (Settings::getInstance()->getString("AudioCard") != "") {
-			if(std::find(audio_cards.begin(), audio_cards.end(), Settings::getInstance()->getString("AudioCard")) == audio_cards.end()) {
-				audio_cards.push_back(Settings::getInstance()->getString("AudioCard"));
-			}
-		}
-		for(auto ac = audio_cards.cbegin(); ac != audio_cards.cend(); ac++)
-			audio_card->add(*ac, *ac, Settings::getInstance()->getString("AudioCard") == *ac);
-		s->addWithLabel("AUDIO CARD", audio_card);
-		s->addSaveFunc([audio_card] {
-			Settings::getInstance()->setString("AudioCard", audio_card->getSelected());
-			VolumeControl::getInstance()->deinit();
-			VolumeControl::getInstance()->init();
-		});
-
-		// volume control device
-		auto vol_dev = std::make_shared< OptionListComponent<std::string> >(mWindow, "AUDIO DEVICE", false);
-		std::vector<std::string> transitions;
-		transitions.push_back("PCM");
-		transitions.push_back("Speaker");
-		transitions.push_back("Master");
-		transitions.push_back("Digital");
-		transitions.push_back("Analogue");
-		if (Settings::getInstance()->getString("AudioDevice") != "") {
-			if(std::find(transitions.begin(), transitions.end(), Settings::getInstance()->getString("AudioDevice")) == transitions.end()) {
-				transitions.push_back(Settings::getInstance()->getString("AudioDevice"));
-			}
-		}
-		for(auto it = transitions.cbegin(); it != transitions.cend(); it++)
-			vol_dev->add(*it, *it, Settings::getInstance()->getString("AudioDevice") == *it);
-		s->addWithLabel("AUDIO DEVICE", vol_dev);
-		s->addSaveFunc([vol_dev] {
-			Settings::getInstance()->setString("AudioDevice", vol_dev->getSelected());
-			VolumeControl::getInstance()->deinit();
-			VolumeControl::getInstance()->init();
-		});
-#endif
-
-		// disable sounds
-		auto sounds_enabled = std::make_shared<SwitchComponent>(mWindow);
-		sounds_enabled->setState(Settings::getInstance()->getBool("EnableSounds"));
-		s->addWithLabel("ENABLE NAVIGATION SOUNDS", sounds_enabled);
-		s->addSaveFunc([sounds_enabled] {
-			if (sounds_enabled->getState()
-				&& !Settings::getInstance()->getBool("EnableSounds")
-				&& PowerSaver::getMode() == PowerSaver::INSTANT)
-			{
-				Settings::getInstance()->setString("PowerSaverMode", "default");
-				PowerSaver::init();
-			}
-			Settings::getInstance()->setBool("EnableSounds", sounds_enabled->getState());
-		});
-
-		auto video_audio = std::make_shared<SwitchComponent>(mWindow);
-		video_audio->setState(Settings::getInstance()->getBool("VideoAudio"));
-		s->addWithLabel("ENABLE VIDEO AUDIO", video_audio);
-		s->addSaveFunc([video_audio] { Settings::getInstance()->setBool("VideoAudio", video_audio->getState()); });
-
-#ifdef _RPI_
-		// OMX player Audio Device
-		auto omx_audio_dev = std::make_shared< OptionListComponent<std::string> >(mWindow, "OMX PLAYER AUDIO DEVICE", false);
-		std::vector<std::string> omx_cards;
-		// RPi Specific  Audio Cards
-		omx_cards.push_back("local");
-		omx_cards.push_back("hdmi");
-		omx_cards.push_back("both");
-		omx_cards.push_back("alsa:hw:0,0");
-		omx_cards.push_back("alsa:hw:1,0");
-		if (Settings::getInstance()->getString("OMXAudioDev") != "") {
-			if (std::find(omx_cards.begin(), omx_cards.end(), Settings::getInstance()->getString("OMXAudioDev")) == omx_cards.end()) {
-				omx_cards.push_back(Settings::getInstance()->getString("OMXAudioDev"));
-			}
-		}
-		for (auto it = omx_cards.cbegin(); it != omx_cards.cend(); it++)
-			omx_audio_dev->add(*it, *it, Settings::getInstance()->getString("OMXAudioDev") == *it);
-		s->addWithLabel("OMX PLAYER AUDIO DEVICE", omx_audio_dev);
-		s->addSaveFunc([omx_audio_dev] {
-			if (Settings::getInstance()->getString("OMXAudioDev") != omx_audio_dev->getSelected())
-				Settings::getInstance()->setString("OMXAudioDev", omx_audio_dev->getSelected());
-		});
-#endif
-	}
-
-	mWindow->pushGui(s);
-
 }
 
 void GuiMenu::openOtherSettings()
@@ -508,31 +394,16 @@ void GuiMenu::openSystemInformations_batocera()
 			informationsGui->addWithLabel(tokens.at(0), space);
 		}
 	}
-
-	// support
-	if (isFullUI) 
-	{
-		informationsGui->addEntry(_("CREATE A SUPPORT FILE"), false, [window] {
-			window->pushGui(new GuiMsgBox(window, _("CREATE A SUPPORT FILE ?"), _("YES"),
-				[window] {
-				if (ApiSystem::getInstance()->generateSupportFile()) {
-					window->pushGui(new GuiMsgBox(window, _("FILE GENERATED SUCCESSFULLY"), _("OK")));
-				}
-				else {
-					window->pushGui(new GuiMsgBox(window, _("FILE GENERATION FAILED"), _("OK")));
-				}
-			}, _("NO"), nullptr));
-		});
-	}
-
+	
 	window->pushGui(informationsGui);
 }
 
 void GuiMenu::openDeveloperSettings()
 {
-	auto s = new GuiSettings(mWindow, _("DEVELOPER SETTINGS").c_str());
+	Window *window = mWindow;
 
-
+	auto s = new GuiSettings(mWindow, _("DEVELOPER").c_str());
+	
 	// maximum vram
 	auto max_vram = std::make_shared<SliderComponent>(mWindow, 0.f, 1000.f, 10.f, "Mb");
 	max_vram->setValue((float)(Settings::getInstance()->getInt("MaxVRAM")));
@@ -546,11 +417,40 @@ void GuiMenu::openDeveloperSettings()
 	s->addSaveFunc(
 		[framerate] { Settings::getInstance()->setBool("DrawFramerate", framerate->getState()); });
 	
+	// vsync
+	auto vsync = std::make_shared<SwitchComponent>(mWindow);
+	vsync->setState(Settings::getInstance()->getBool("VSync"));
+	s->addWithLabel(_("VSYNC"), vsync);
+	s->addSaveFunc([vsync]
+	{
+		if (Settings::getInstance()->setBool("VSync", vsync->getState()))
+			Renderer::setSwapInterval();
+	});
+
+	// preload UI
+	auto preloadUI = std::make_shared<SwitchComponent>(mWindow);
+	preloadUI->setState(Settings::getInstance()->getBool("PreloadUI"));
+	s->addWithLabel(_("PRELOAD UI"), preloadUI);
+	s->addSaveFunc([preloadUI] { Settings::getInstance()->setBool("PreloadUI", preloadUI->getState()); });
+
 	// threaded loading -> Should be moved in a "developper" submenu
 	auto threadedLoading = std::make_shared<SwitchComponent>(mWindow);
 	threadedLoading->setState(Settings::getInstance()->getBool("ThreadedLoading"));
 	s->addWithLabel(_("THREADED LOADING"), threadedLoading);
 	s->addSaveFunc([threadedLoading] { Settings::getInstance()->setBool("ThreadedLoading", threadedLoading->getState()); });
+
+	// support
+	s->addEntry(_("CREATE A SUPPORT FILE"), true, [window] {
+		window->pushGui(new GuiMsgBox(window, _("CREATE A SUPPORT FILE ?"), _("YES"),
+			[window] {
+			if (ApiSystem::getInstance()->generateSupportFile()) {
+				window->pushGui(new GuiMsgBox(window, _("FILE GENERATED SUCCESSFULLY"), _("OK")));
+			}
+			else {
+				window->pushGui(new GuiMsgBox(window, _("FILE GENERATION FAILED"), _("OK")));
+			}
+		}, _("NO"), nullptr));
+	});
 
 	mWindow->pushGui(s);
 }
@@ -662,7 +562,9 @@ void GuiMenu::openSystemSettings_batocera()
 	if (isOneSet == false)
 		overclock_choice->add(currentOverclock, currentOverclock, true);
 	
+#ifndef WIN32
 	s->addWithLabel(_("OVERCLOCK"), overclock_choice);
+#endif
 
 	// Updates
 	s->addEntry(_("UPDATES"), true, [this] 
@@ -782,7 +684,8 @@ void GuiMenu::openSystemSettings_batocera()
 	});
 
 	// Developer options
-	s->addEntry(_("DEVELOPER"), true, [this] { openDeveloperSettings(); });
+	if (isFullUI)
+		s->addEntry(_("DEVELOPER"), true, [this] { openDeveloperSettings(); });
 
 	mWindow->pushGui(s);
 }
@@ -1759,7 +1662,7 @@ void GuiMenu::openUISettings()
 	mWindow->pushGui(s);
 }
 
-void GuiMenu::openSoundSettings_batocera() 
+void GuiMenu::openSoundSettings() 
 {
 	auto s = new GuiSettings(mWindow, _("SOUND SETTINGS").c_str());
 
@@ -1767,6 +1670,7 @@ void GuiMenu::openSoundSettings_batocera()
 	auto volume = std::make_shared<SliderComponent>(mWindow, 0.f, 100.f, 1.f, "%");
 	volume->setValue((float)VolumeControl::getInstance()->getVolume());
 	s->addWithLabel(_("SYSTEM VOLUME"), volume);
+	s->addSaveFunc([volume] { VolumeControl::getInstance()->setVolume((int)Math::round(volume->getValue())); });
 
 	// disable sounds
 	auto music_enabled = std::make_shared<SwitchComponent>(mWindow);

--- a/es-app/src/guis/GuiMenu.h
+++ b/es-app/src/guis/GuiMenu.h
@@ -51,8 +51,7 @@ private:
 	void openKodiLauncher_batocera();
 	void openSystemSettings_batocera();
 	void openGamesSettings_batocera();
-	void openControllersSettings_batocera();	
-	void openSoundSettings_batocera();
+	void openControllersSettings_batocera();		
 	void openRetroAchievements_batocera();	
 	void openNetworkSettings_batocera();
 	void openScraperSettings_batocera();

--- a/es-app/src/guis/GuiSettings.cpp
+++ b/es-app/src/guis/GuiSettings.cpp
@@ -5,6 +5,7 @@
 #include "SystemData.h"
 #include "Window.h"
 #include "LocaleES.h"
+#include "SystemConf.h"
 
 GuiSettings::GuiSettings(Window* window, const char* title) : GuiComponent(window), mMenu(window, title)
 {
@@ -34,6 +35,7 @@ void GuiSettings::save()
 		(*it)();
 
 	Settings::getInstance()->saveFile();
+	SystemConf::getInstance()->saveSystemConf();
 }
 
 bool GuiSettings::input(InputConfig* config, Input input)

--- a/es-app/src/views/SystemView.cpp
+++ b/es-app/src/views/SystemView.cpp
@@ -26,14 +26,44 @@ SystemView::SystemView(Window* window) : IList<SystemViewData, SystemData*>(wind
 	mExtrasCamOffset = 0;
 	mExtrasFadeOpacity = 0.0f;
 	launchKodi = false; // batocera
-
+	mScreensaverActive = false;
+	mDisable = false;
+	mShowing = false;
+	mLastCursor = 0;
+	mStaticBackground = nullptr;
+	
 	setSize((float)Renderer::getScreenWidth(), (float)Renderer::getScreenHeight());
 	populate();
 }
 
+SystemView::~SystemView()
+{
+	if (mStaticBackground != nullptr)
+	{
+		delete mStaticBackground;
+		mStaticBackground = nullptr;
+	}
+
+	clearEntries();
+}
+
+void SystemView::clearEntries()
+{
+	for (int i = 0; i < mEntries.size(); i++)
+	{
+		for (auto extra : mEntries[i].data.backgroundExtras)
+			delete extra;
+
+		mEntries[i].data.backgroundExtras.clear();
+	}
+
+	mEntries.clear();
+}
+
+
 void SystemView::populate()
 {
-	mEntries.clear();
+	clearEntries();
 
 	for(auto it = SystemData::sSystemVector.cbegin(); it != SystemData::sSystemVector.cend(); it++)
 	{
@@ -259,6 +289,7 @@ bool SystemView::input(InputConfig* config, Input input)
 void SystemView::update(int deltaTime)
 {
 	listUpdate(deltaTime);
+	updateExtras([this, deltaTime](GuiComponent* p) { p->update(deltaTime); });
 	GuiComponent::update(deltaTime);
 }
 
@@ -339,6 +370,12 @@ void SystemView::onCursorChanged(const CursorState& /*state*/)
 	if(endPos == mCamOffset && endPos == mExtrasCamOffset)
 		return;
 
+	if (mLastCursor == mCursor)
+		return;
+
+	int oldCursor = mLastCursor;
+	mLastCursor = mCursor;
+
 	Animation* anim;
 	bool move_carousel = Settings::getInstance()->getBool("MoveCarousel");
 	if(transition_style == "fade")
@@ -400,8 +437,19 @@ void SystemView::onCursorChanged(const CursorState& /*state*/)
 		}, move_carousel ? 500 : 1);
 	}
 
+	for (int i = 0; i < mEntries.size(); i++)
+		if (i != oldCursor && i != mCursor)
+			activateExtras(i, false);
 
-	setAnimation(anim, 0, nullptr, false, 0);
+	activateExtras(mCursor);
+
+	setAnimation(anim, 0, [this]
+	{
+		for (int i = 0; i < mEntries.size(); i++)
+			if (i != mCursor)
+				activateExtras(i, false);
+
+	}, false, 0);
 }
 
 void SystemView::render(const Transform4x4f& parentTrans)
@@ -419,6 +467,9 @@ void SystemView::render(const Transform4x4f& parentTrans)
 
 	renderExtras(trans, INT16_MIN, minMax.first);
 	renderFade(trans);
+
+	if (mStaticBackground != nullptr)
+		mStaticBackground->render(trans);
 
 	if (mCarousel.zIndex > mSystemInfo.getZIndex()) {
 		renderInfoBar(trans);
@@ -499,6 +550,20 @@ void  SystemView::getViewElements(const std::shared_ptr<ThemeData>& theme)
 	if (sysInfoElem)
 		mSystemInfo.applyTheme(theme, "system", "systemInfo", ThemeFlags::ALL);
 
+	const ThemeData::ThemeElement* fixedBackgroundElem = theme->getElement("system", "fixedBackground", "image");
+	if (fixedBackgroundElem)
+	{
+		if (mStaticBackground == nullptr)
+			mStaticBackground = new ImageComponent(mWindow, false);
+
+		mStaticBackground->applyTheme(theme, "system", "staticBackground", ThemeFlags::ALL);
+	}
+	else if (mStaticBackground != nullptr)
+	{
+		delete mStaticBackground;
+		mStaticBackground = nullptr;
+	}
+
 	mViewNeedsReload = false;
 }
 
@@ -566,6 +631,12 @@ void SystemView::renderCarousel(const Transform4x4f& trans)
 			break;
 	}
 
+	if (mCarousel.logoPos.x() >= 0)
+		xOff = mCarousel.logoPos.x() - (mCarousel.type == HORIZONTAL ? (mCamOffset * logoSpacing[0]) : 0);
+
+	if (mCarousel.logoPos.y() >= 0)
+		yOff = mCarousel.logoPos.y() - (mCarousel.type == VERTICAL ? (mCamOffset * logoSpacing[1]) : 0);
+
 	int center = (int)(mCamOffset);
 	int logoCount = Math::min(mCarousel.maxLogoCount, (int)mEntries.size());
 
@@ -573,7 +644,7 @@ void SystemView::renderCarousel(const Transform4x4f& trans)
 	int bufferIndex = getScrollingVelocity() + 1;
 	int bufferLeft = logoBuffersLeft[bufferIndex];
 	int bufferRight = logoBuffersRight[bufferIndex];
-	if (logoCount == 1)
+	if (logoCount == 1 && mCamOffset == 0)
 	{
 		bufferLeft = 0;
 		bufferRight = 0;
@@ -691,6 +762,7 @@ void  SystemView::getDefaultElements(void)
 	mCarousel.logoRotationOrigin.y() = 0.5;
 	mCarousel.logoSize.x() = 0.25f * mSize.x();
 	mCarousel.logoSize.y() = 0.155f * mSize.y();
+	mCarousel.logoPos = Vector2f(-1, -1);
 	mCarousel.maxLogoCount = 3;
 	mCarousel.zIndex = 40;
 
@@ -703,6 +775,12 @@ void  SystemView::getDefaultElements(void)
 	mSystemInfo.setColor(0x000000FF);
 	mSystemInfo.setZIndex(50);
 	mSystemInfo.setDefaultZIndex(50);
+
+	if (mStaticBackground != nullptr)
+	{
+		delete mStaticBackground;
+		mStaticBackground = nullptr;
+	}
 }
 
 void SystemView::getCarouselFromTheme(const ThemeData::ThemeElement* elem)
@@ -737,6 +815,8 @@ void SystemView::getCarouselFromTheme(const ThemeData::ThemeElement* elem)
 		mCarousel.logoScale = elem->get<float>("logoScale");
 	if (elem->has("logoSize"))
 		mCarousel.logoSize = elem->get<Vector2f>("logoSize") * mSize;
+	if (elem->has("logoPos"))
+		mCarousel.logoPos = elem->get<Vector2f>("logoPos") * mSize;
 	if (elem->has("maxLogoCount"))
 		mCarousel.maxLogoCount = (int)Math::round(elem->get<float>("maxLogoCount"));
 	if (elem->has("zIndex"))
@@ -763,9 +843,60 @@ void SystemView::getCarouselFromTheme(const ThemeData::ThemeElement* elem)
 void SystemView::onShow()
 {
 	mShowing = true;
+	activateExtras(mCursor);
 }
 
 void SystemView::onHide()
 {
 	mShowing = false;
+	updateExtras([this](GuiComponent* p) { p->onHide(); });
+}
+
+void SystemView::onScreenSaverActivate()
+{
+	mScreensaverActive = true;
+	updateExtras([this](GuiComponent* p) { p->onScreenSaverActivate(); });
+}
+
+void SystemView::onScreenSaverDeactivate()
+{
+	mScreensaverActive = false;
+	updateExtras([this](GuiComponent* p) { p->onScreenSaverDeactivate(); });
+}
+
+void SystemView::topWindow(bool isTop)
+{
+	mDisable = !isTop;
+	updateExtras([this, isTop](GuiComponent* p) { p->topWindow(isTop); });
+}
+
+void SystemView::updateExtras(const std::function<void(GuiComponent*)>& func)
+{
+	for (int i = 0; i < mEntries.size(); i++)
+	{
+		SystemViewData data = mEntries.at(i).data;
+		for (unsigned int j = 0; j < data.backgroundExtras.size(); j++)
+		{
+			GuiComponent* extra = data.backgroundExtras[j];
+			func(extra);
+		}
+	}
+}
+
+void SystemView::activateExtras(int cursor, bool activate)
+{
+	if (cursor < 0 || cursor >= mEntries.size())
+		return;
+
+	bool show = activate && mShowing && !mScreensaverActive && !mDisable;
+
+	SystemViewData data = mEntries.at(cursor).data;
+	for (unsigned int j = 0; j < data.backgroundExtras.size(); j++)
+	{
+		GuiComponent *extra = data.backgroundExtras[j];
+		if (show && activate)
+			extra->onShow();
+		else
+			extra->onHide();
+	}
 }

--- a/es-app/src/views/SystemView.cpp
+++ b/es-app/src/views/SystemView.cpp
@@ -411,6 +411,9 @@ void SystemView::render(const Transform4x4f& parentTrans)
 
 	Transform4x4f trans = getTransform() * parentTrans;
 
+	if (!Renderer::isVisibleOnScreen(trans.translation().x(), trans.translation().y(), mSize.x(), mSize.y()))
+		return;
+
 	auto systemInfoZIndex = mSystemInfo.getZIndex();
 	auto minMax = std::minmax(mCarousel.zIndex, systemInfoZIndex);
 

--- a/es-app/src/views/SystemView.cpp
+++ b/es-app/src/views/SystemView.cpp
@@ -89,7 +89,17 @@ void SystemView::populate()
 				{
 					ImageComponent* logo = new ImageComponent(mWindow, false, false);
 					logo->setMaxSize(mCarousel.logoSize * mCarousel.logoScale);
-					logo->applyTheme(theme, "system", "logo", ThemeFlags::PATH | ThemeFlags::COLOR);
+					logo->applyTheme(theme, "system", "logo", ThemeFlags::COLOR); //  ThemeFlags::PATH | 
+
+					// Process here to be enable to set max picture size
+					auto elem = theme->getElement("system", "logo", "image");
+					if (elem && elem->has("path"))
+					{
+						auto path = elem->get<std::string>("path");
+						if (Utils::FileSystem::exists(path))
+							logo->setImage(path, (elem->has("tile") && elem->get<bool>("tile")), MaxSizeInfo(mCarousel.logoSize * mCarousel.logoScale));
+					}
+
 					logo->setRotateByTargetSize(true);
 					e.data.logo = std::shared_ptr<GuiComponent>(logo);
 				}

--- a/es-app/src/views/SystemView.h
+++ b/es-app/src/views/SystemView.h
@@ -7,6 +7,7 @@
 #include "resources/Font.h"
 #include "GuiComponent.h"
 #include <memory>
+#include <functional>
 
 class AnimatedImageComponent;
 class SystemData;
@@ -40,6 +41,7 @@ struct SystemViewCarousel
 	bool colorGradientHorizontal;
 	int maxLogoCount; // number of logos shown on the carousel
 	Vector2f logoSize;
+	Vector2f logoPos;
 	float zIndex;
 };
 
@@ -47,6 +49,7 @@ class SystemView : public IList<SystemViewData, SystemData*>
 {
 public:
 	SystemView(Window* window);
+	~SystemView();
 
 	virtual void onShow() override;
 	virtual void onHide() override;
@@ -66,6 +69,14 @@ protected:
 	void onCursorChanged(const CursorState& state) override;
 
 private:
+	void	 activateExtras(int cursor, bool activate = true);
+	void	 updateExtras(const std::function<void(GuiComponent*)>& func);
+	void	 clearEntries();
+
+	virtual void onScreenSaverActivate() override;
+	virtual void onScreenSaverDeactivate() override;
+	virtual void topWindow(bool isTop) override;
+
 	void populate();
 	void getViewElements(const std::shared_ptr<ThemeData>& theme);
 	void getDefaultElements(void);
@@ -79,6 +90,7 @@ private:
 
 	SystemViewCarousel mCarousel;
 	TextComponent mSystemInfo;
+	ImageComponent*		mStaticBackground;
 
 	// unit is list index
 	float mCamOffset;
@@ -88,6 +100,11 @@ private:
 	bool mViewNeedsReload;
 	bool mShowing;
 	bool launchKodi;
+
+	bool mDisable;
+	bool mScreensaverActive;
+
+	int mLastCursor;
 };
 
 #endif // ES_APP_VIEWS_SYSTEM_VIEW_H

--- a/es-app/src/views/ViewController.cpp
+++ b/es-app/src/views/ViewController.cpp
@@ -462,22 +462,24 @@ void ViewController::render(const Transform4x4f& parentTrans)
 
 void ViewController::preload()
 {
-	uint32_t i = 0;
+	int i = 1;
+	int max = SystemData::sSystemVector.size() + 1;
+
+	bool preloadUI = Settings::getInstance()->getBool("PreloadUI");
+	bool splash = preloadUI && Settings::getInstance()->getBool("SplashScreen") && Settings::getInstance()->getBool("SplashScreenProgress");
+
 	for(auto it = SystemData::sSystemVector.cbegin(); it != SystemData::sSystemVector.cend(); it++)
-	{
-		/*
-		if(Settings::getInstance()->getBool("SplashScreen") &&
-			Settings::getInstance()->getBool("SplashScreenProgress"))
+	{		
+		if (splash)
 		{
 			i++;
-			char buffer[100];
-			sprintf (buffer, "Loading '%s' (%d/%d)",
-				(*it)->getFullName().c_str(), i, (int)SystemData::sSystemVector.size());
-			mWindow->renderLoadingScreen(std::string(buffer));
+			mWindow->renderLoadingScreen(_("Preloading UI"), (float)i / (float)max);
 		}
-		*/
+
 		(*it)->getIndex()->resetFilters();
-		// getGameListView(*it); // batocera - performances
+
+		if (preloadUI)
+			getGameListView(*it);
 	}
 }
 

--- a/es-app/src/views/gamelist/DetailedGameListView.cpp
+++ b/es-app/src/views/gamelist/DetailedGameListView.cpp
@@ -314,14 +314,14 @@ void DetailedGameListView::updateInfoPanel()
 			if (!mVideo->setVideo(file->getVideoPath()))
 				mVideo->setDefaultVideo();
 
-			mVideo->setImage(imagePath);
+			mVideo->setImage(imagePath, false, mVideo->getMaxSizeInfo());
 		}
 
 		if (mImage != nullptr)
-			mImage->setImage(imagePath);
+			mImage->setImage(imagePath, false, mImage->getMaxSizeInfo());
 
 		if (mMarquee != nullptr)
-			mMarquee->setImage(file->getMarqueePath());
+			mMarquee->setImage(file->getMarqueePath(), false, mMarquee->getMaxSizeInfo());
 		
 		mDescription.setText(file->metadata.get("desc"));
 		mDescContainer.reset();

--- a/es-app/src/views/gamelist/IGameListView.cpp
+++ b/es-app/src/views/gamelist/IGameListView.cpp
@@ -49,6 +49,9 @@ void IGameListView::render(const Transform4x4f& parentTrans)
 
 	Vector2i pos((int)Math::round(trans.translation()[0]), (int)Math::round(trans.translation()[1]));
 	Vector2i size((int)Math::round(mSize.x() * scaleX), (int)Math::round(mSize.y() * scaleY));
+	
+	if (!Renderer::isVisibleOnScreen(trans.translation().x(), trans.translation().y(), size.x(), size.y()))
+		return;
 
 	Renderer::pushClipRect(pos, size);
 	renderChildren(trans);

--- a/es-app/src/views/gamelist/VideoGameListView.cpp
+++ b/es-app/src/views/gamelist/VideoGameListView.cpp
@@ -252,9 +252,9 @@ void VideoGameListView::updateInfoPanel()
 		}
 		mVideoPlaying = true;
 
-		mVideo->setImage(file->getThumbnailPath());
-		mMarquee.setImage(file->getMarqueePath());
-		mImage.setImage(file->getImagePath());
+		mVideo->setImage(file->getThumbnailPath(), false, mVideo->getMaxSizeInfo());
+		mMarquee.setImage(file->getMarqueePath(), false, mMarquee.getMaxSizeInfo());
+		mImage.setImage(file->getImagePath(), false, mImage.getMaxSizeInfo());
 
 		mDescription.setText(file->metadata.get("desc"));
 		mDescContainer.reset();

--- a/es-core/src/GuiComponent.cpp
+++ b/es-core/src/GuiComponent.cpp
@@ -67,6 +67,10 @@ void GuiComponent::render(const Transform4x4f& parentTrans)
 		return;
 
 	Transform4x4f trans = parentTrans * getTransform();
+
+	if (!Renderer::isVisibleOnScreen(trans.translation().x(), trans.translation().y(), mSize.x(), mSize.y()))
+		return;
+
 	renderChildren(trans);
 }
 

--- a/es-core/src/ImageIO.cpp
+++ b/es-core/src/ImageIO.cpp
@@ -87,3 +87,19 @@ void ImageIO::flipPixelsVert(unsigned char* imagePx, const size_t& width, const 
 		}
 	}
 }
+
+Vector2f ImageIO::getPictureMinSize(Vector2f imageSize, Vector2f maxSize)
+{
+	float cxDIB = maxSize.x();
+	float cyDIB = maxSize.y();
+
+	float xCoef = maxSize.x() / imageSize.x();
+	float yCoef = maxSize.y() / imageSize.y();
+
+	if (imageSize.x() * yCoef < maxSize.x())
+		cyDIB = imageSize.y() * xCoef;
+	else
+		cxDIB = imageSize.x() * yCoef;
+
+	return Vector2f(cxDIB, cyDIB);
+}

--- a/es-core/src/ImageIO.h
+++ b/es-core/src/ImageIO.h
@@ -4,12 +4,16 @@
 
 #include <stdlib.h>
 #include <vector>
+#include "math/Vector2f.h"
 
 class ImageIO
 {
 public:
 	static unsigned char*  loadFromMemoryRGBA32(const unsigned char * data, const size_t size, size_t & width, size_t & height);
 	static void flipPixelsVert(unsigned char* imagePx, const size_t& width, const size_t& height);
+
+	// batocera
+	static Vector2f getPictureMinSize(Vector2f imageSize, Vector2f maxSize);
 };
 
 #endif // ES_CORE_IMAGE_IO

--- a/es-core/src/ImageIO.h
+++ b/es-core/src/ImageIO.h
@@ -5,15 +5,50 @@
 #include <stdlib.h>
 #include <vector>
 #include "math/Vector2f.h"
+#include "math/Vector2i.h"
+
+
+class MaxSizeInfo
+{
+public:
+	MaxSizeInfo() : mSize(Vector2f(0, 0)), mExternalZoom(false) {}
+
+	MaxSizeInfo(float x, float y) : mSize(Vector2f(x, y)), mExternalZoom(false), mExternalZoomKnown(false) { }
+	MaxSizeInfo(Vector2f size) : mSize(size), mExternalZoom(false), mExternalZoomKnown(false) { }
+
+	MaxSizeInfo(float x, float y, bool externalZoom) : mSize(Vector2f(x, y)), mExternalZoom(externalZoom), mExternalZoomKnown(true) { }
+	MaxSizeInfo(Vector2f size, bool externalZoom) : mSize(size), mExternalZoom(externalZoom), mExternalZoomKnown(true) { }
+
+	bool empty() { return mSize.x() <= 1 && mSize.y() <= 1; }
+
+	float x() { return mSize.x(); }
+	float y() { return mSize.y(); }
+
+	bool externalZoom()
+	{
+		return mExternalZoom;
+	}
+
+	bool isExternalZoomKnown()
+	{
+		return mExternalZoomKnown;
+	}
+
+private:
+	Vector2f mSize;
+	bool	 mExternalZoom;
+	bool	 mExternalZoomKnown;
+};
 
 class ImageIO
 {
 public:
-	static unsigned char*  loadFromMemoryRGBA32(const unsigned char * data, const size_t size, size_t & width, size_t & height);
+	static unsigned char*  loadFromMemoryRGBA32(const unsigned char * data, const size_t size, size_t & width, size_t & height, MaxSizeInfo* maxSize = nullptr, Vector2i* baseSize = nullptr, Vector2i* packedSize = nullptr);
 	static void flipPixelsVert(unsigned char* imagePx, const size_t& width, const size_t& height);
 
 	// batocera
 	static Vector2f getPictureMinSize(Vector2f imageSize, Vector2f maxSize);
+	static Vector2i adjustPictureSize(Vector2i imageSize, Vector2i maxSize, bool externSize = false);
 };
 
 #endif // ES_CORE_IMAGE_IO

--- a/es-core/src/Settings.cpp
+++ b/es-core/src/Settings.cpp
@@ -174,6 +174,8 @@ void Settings::setDefaults()
 
 	mBoolMap["ThreadedLoading"] = true;
 	mBoolMap["PreloadUI"] = false;
+	mBoolMap["OptimizeVRAM"] = true;
+	
 
 	mIntMap["WindowWidth"]   = 0;
 	mIntMap["WindowHeight"]  = 0;

--- a/es-core/src/Settings.h
+++ b/es-core/src/Settings.h
@@ -19,10 +19,10 @@ public:
 	float getFloat(const std::string& name);
 	const std::string& getString(const std::string& name);
 
-	void setBool(const std::string& name, bool value);
-	void setInt(const std::string& name, int value);
-	void setFloat(const std::string& name, float value);
-	void setString(const std::string& name, const std::string& value);
+	bool setBool(const std::string& name, bool value);
+	bool setInt(const std::string& name, int value);
+	bool setFloat(const std::string& name, float value);
+	bool setString(const std::string& name, const std::string& value);
 
 private:
 	static Settings* sInstance;
@@ -36,6 +36,13 @@ private:
 	std::map<std::string, int> mIntMap;
 	std::map<std::string, float> mFloatMap;
 	std::map<std::string, std::string> mStringMap;
+
+	bool mWasChanged;
+
+	std::map<std::string, bool> mDefaultBoolMap;
+	std::map<std::string, int> mDefaultIntMap;
+	std::map<std::string, float> mDefaultFloatMap;
+	std::map<std::string, std::string> mDefaultStringMap;
 };
 
 #endif // ES_CORE_SETTINGS_H

--- a/es-core/src/Sound.cpp
+++ b/es-core/src/Sound.cpp
@@ -86,6 +86,9 @@ void Sound::play()
 	if (mSampleData == nullptr)
 		return;
 
+	if (!Settings::getInstance()->getBool("EnableSounds"))
+		return;
+
 	mPlayingChannel = Mix_PlayChannel(-1, mSampleData, 0);
 }
 

--- a/es-core/src/SystemConf.cpp
+++ b/es-core/src/SystemConf.cpp
@@ -33,7 +33,9 @@ SystemConf *SystemConf::getInstance() {
 #include <string>
 #include <iostream>
 
-bool SystemConf::loadSystemConf() {
+bool SystemConf::loadSystemConf() 
+{
+	mWasChanged = false;
 
     std::string line;
     std::ifstream systemConf(systemConfFile);
@@ -59,7 +61,11 @@ bool SystemConf::loadSystemConf() {
 }
 
 
-bool SystemConf::saveSystemConf() {
+bool SystemConf::saveSystemConf() 
+{
+	if (!mWasChanged)
+		return false;
+
 	std::ifstream filein(systemConfFile); //File to read from
 	if (!filein) {
 		LOG(LogError) << "Unable to open for saving :  " << systemConfFile << "\n";
@@ -68,9 +74,9 @@ bool SystemConf::saveSystemConf() {
 	/* Read all lines in a vector */
 	std::vector<std::string> fileLines;
 	std::string line;
-	while (std::getline(filein, line)) {
+	while (std::getline(filein, line))
 		fileLines.push_back(line);
-	}
+
 	filein.close();
 
 
@@ -108,31 +114,42 @@ bool SystemConf::saveSystemConf() {
 	}
 
 	fileout.close();
-
-
+	
 	/* Copy back the tmp to batocera.conf */
 	std::ifstream  src(systemConfFileTmp, std::ios::binary);
 	std::ofstream  dst(systemConfFile, std::ios::binary);
 	dst << src.rdbuf();
 
 	remove(systemConfFileTmp.c_str());
+	mWasChanged = false;
 
 	return true;
 }
 
-std::string SystemConf::get(const std::string &name) {
-    if (confMap.count(name)) {
+std::string SystemConf::get(const std::string &name) 
+{
+    if (confMap.count(name))
         return confMap[name];
-    }
+    
     return "";
 }
-std::string SystemConf::get(const std::string &name, const std::string &defaut) {
-    if (confMap.count(name)) {
+
+std::string SystemConf::get(const std::string &name, const std::string &defaut) 
+{
+    if (confMap.count(name))
         return confMap[name];
-    }
+    
     return defaut;
 }
 
-void SystemConf::set(const std::string &name, const std::string &value) {
-    confMap[name] = value;
+bool SystemConf::set(const std::string &name, const std::string &value) 
+{
+	if (confMap.count(name) == 0 || confMap[name] != value)
+	{
+		confMap[name] = value;
+		mWasChanged = true;
+		return true;
+	}
+
+	return false;
 }

--- a/es-core/src/SystemConf.h
+++ b/es-core/src/SystemConf.h
@@ -17,14 +17,14 @@ public:
     std::string get(const std::string &name);
     std::string get(const std::string &name, const std::string &defaut);
 
-    void set(const std::string &name, const std::string &value);
+    bool set(const std::string &name, const std::string &value);
 
     static SystemConf *sInstance;
 
     static SystemConf *getInstance();
 private:
     std::map<std::string, std::string> confMap;
-
+	bool mWasChanged;
 };
 
 

--- a/es-core/src/ThemeData.cpp
+++ b/es-core/src/ThemeData.cpp
@@ -546,7 +546,14 @@ bool ThemeData::parseRegion(const pugi::xml_node& node)
 		return true;
 
 	std::string regionsetting = Settings::getInstance()->getString("ThemeRegionName");
-	
+	if (regionsetting.empty())
+	{
+		if (mHasSubsets)
+			regionsetting = "en";
+		else
+			return true;
+	}
+
 	const char* delim = " \t\r\n,";
 	const std::string nameAttr = node.attribute("region").as_string();
 	size_t prevOff = nameAttr.find_first_not_of(delim, 0);

--- a/es-core/src/ThemeData.cpp
+++ b/es-core/src/ThemeData.cpp
@@ -2,6 +2,7 @@
 
 #include "components/ImageComponent.h"
 #include "components/TextComponent.h"
+#include "components/NinePatchComponent.h"
 #include "utils/FileSystemUtil.h"
 #include "Log.h"
 #include "platform.h"
@@ -93,6 +94,10 @@ std::map<std::string, std::map<std::string, ThemeData::ElementPropertyType>> The
 		{ "size", NORMALIZED_PAIR },
 		{ "path", PATH },
 	 	{ "visible", BOOLEAN },
+		{ "color", COLOR },
+		{ "cornerSize", NORMALIZED_PAIR },
+		{ "centerColor", COLOR },
+		{ "edgeColor", COLOR },
 		{ "zIndex", FLOAT } } },
 	{ "datetime", {
 		{ "pos", NORMALIZED_PAIR },
@@ -748,6 +753,8 @@ std::vector<GuiComponent*> ThemeData::makeExtras(const std::shared_ptr<ThemeData
 				comp = new ImageComponent(window);
 			else if(t == "text")
 				comp = new TextComponent(window);
+			else if (t == "ninepatch")
+				comp = new NinePatchComponent(window);
 
 			if (comp == nullptr)
 				continue;

--- a/es-core/src/ThemeData.cpp
+++ b/es-core/src/ThemeData.cpp
@@ -3,6 +3,7 @@
 #include "components/ImageComponent.h"
 #include "components/TextComponent.h"
 #include "components/NinePatchComponent.h"
+#include "components/VideoVlcComponent.h"
 #include "utils/FileSystemUtil.h"
 #include "Log.h"
 #include "platform.h"
@@ -157,10 +158,12 @@ std::map<std::string, std::map<std::string, ThemeData::ElementPropertyType>> The
 		{ "pos", NORMALIZED_PAIR },
 		{ "size", NORMALIZED_PAIR },
 		{ "maxSize", NORMALIZED_PAIR },
+		{ "minSize", NORMALIZED_PAIR },
 		{ "origin", NORMALIZED_PAIR },
 		{ "rotation", FLOAT },
 		{ "rotationOrigin", NORMALIZED_PAIR },
 		{ "default", PATH },
+		{ "path", PATH },
 		{ "delay", FLOAT },
 	 	{ "visible", BOOLEAN },
 	 	{ "zIndex", FLOAT },
@@ -178,6 +181,7 @@ std::map<std::string, std::map<std::string, ThemeData::ElementPropertyType>> The
 		{ "logoRotation", FLOAT },
 		{ "logoRotationOrigin", NORMALIZED_PAIR },
 		{ "logoSize", NORMALIZED_PAIR },
+		{ "logoPos", NORMALIZED_PAIR },
 		{ "logoAlignment", STRING },
 		{ "maxLogoCount", FLOAT },
 		{ "zIndex", FLOAT } } },
@@ -755,6 +759,8 @@ std::vector<GuiComponent*> ThemeData::makeExtras(const std::shared_ptr<ThemeData
 				comp = new TextComponent(window);
 			else if (t == "ninepatch")
 				comp = new NinePatchComponent(window);
+			else if (t == "video")
+				comp = new VideoVlcComponent(window);
 
 			if (comp == nullptr)
 				continue;

--- a/es-core/src/components/ComponentGrid.cpp
+++ b/es-core/src/components/ComponentGrid.cpp
@@ -356,6 +356,9 @@ void ComponentGrid::render(const Transform4x4f& parentTrans)
 {
 	Transform4x4f trans = parentTrans * getTransform();
 
+	if (!Renderer::isVisibleOnScreen(trans.translation().x(), trans.translation().y(), mSize.x(), mSize.y()))
+		return;
+
 	renderChildren(trans);
 	
 	// draw cell separators

--- a/es-core/src/components/ComponentGrid.cpp
+++ b/es-core/src/components/ComponentGrid.cpp
@@ -153,7 +153,7 @@ void ComponentGrid::updateSeparators()
 {
 	mLines.clear();
 
-	const unsigned int color = Renderer::convertColor(0xC6C7C6FF);
+	const unsigned int color = Renderer::convertColor(mSeparatorColor);
 	bool drawAll = Settings::getInstance()->getBool("DebugGrid");
 
 	Vector2f pos;

--- a/es-core/src/components/DateTimeEditComponent.cpp
+++ b/es-core/src/components/DateTimeEditComponent.cpp
@@ -146,6 +146,9 @@ void DateTimeEditComponent::render(const Transform4x4f& parentTrans)
 {
 	Transform4x4f trans = parentTrans * getTransform();
 
+	if (!Renderer::isVisibleOnScreen(trans.translation().x(), trans.translation().y(), mSize.x(), mSize.y()))
+		return;
+
 	if(mTextCache)
 	{
 		// vertically center

--- a/es-core/src/components/ImageComponent.cpp
+++ b/es-core/src/components/ImageComponent.cpp
@@ -24,6 +24,7 @@ ImageComponent::ImageComponent(Window* window, bool forceLoad, bool dynamic) : G
 	mColorShiftEnd(0xFFFFFFFF), mColorGradientHorizontal(true), mForceLoad(forceLoad), mDynamic(dynamic),
 	mFadeOpacity(0), mFading(false), mRotateByTargetSize(false), mTopLeftCrop(0.0f, 0.0f), mBottomRightCrop(1.0f, 1.0f)
 {
+	mAllowFading = true;
 	updateColors();
 }
 
@@ -325,6 +326,10 @@ void ImageComponent::render(const Transform4x4f& parentTrans)
 		return;
 
 	Transform4x4f trans = parentTrans * getTransform();
+
+	if (!Renderer::isVisibleOnScreen(trans.translation().x(), trans.translation().y(), mSize.x(), mSize.y()))
+		return;
+
 	Renderer::setMatrix(trans);
 
 	if(mTexture && mOpacity > 0)
@@ -354,6 +359,9 @@ void ImageComponent::render(const Transform4x4f& parentTrans)
 
 void ImageComponent::fadeIn(bool textureLoaded)
 {
+	if (!mAllowFading)
+		return;
+
 	if (!mForceLoad)
 	{
 		if (!textureLoaded)
@@ -368,7 +376,7 @@ void ImageComponent::fadeIn(bool textureLoaded)
 				updateColors();
 			}
 		}
-		else if (mFading)
+		else if (mFading && textureLoaded)
 		{
 			// The texture is loaded and we need to fade it in. The fade is based on the frame rate
 			// and is 1/4 second if running at 60 frames per second although the actual value is not
@@ -434,7 +442,10 @@ void ImageComponent::applyTheme(const std::shared_ptr<ThemeData>& theme, const s
 	if(properties & PATH && elem->has("path"))
 	{
 		bool tile = (elem->has("tile") && elem->get<bool>("tile"));
-		setImage(elem->get<std::string>("path"), tile);
+
+		auto path = elem->get<std::string>("path");
+		if (Utils::FileSystem::exists(path))
+			setImage(path, tile);
 	}
 
 	if(properties & COLOR)

--- a/es-core/src/components/ImageComponent.cpp
+++ b/es-core/src/components/ImageComponent.cpp
@@ -132,17 +132,17 @@ void ImageComponent::setDefaultImage(std::string path)
 	mDefaultPath = path;
 }
 
-void ImageComponent::setImage(std::string path, bool tile)
+void ImageComponent::setImage(std::string path, bool tile, MaxSizeInfo maxSize)
 {
 	if(path.empty() || !ResourceManager::getInstance()->fileExists(path))
 	{
 		if(mDefaultPath.empty() || !ResourceManager::getInstance()->fileExists(mDefaultPath))
 			mTexture.reset();
 		else
-			mTexture = TextureResource::get(mDefaultPath, tile, mForceLoad, mDynamic);
-	} else {
-		mTexture = TextureResource::get(path, tile, mForceLoad, mDynamic);
-	}
+			mTexture = TextureResource::get(mDefaultPath, tile, mForceLoad, mDynamic, true, maxSize.empty() ? nullptr : &maxSize);
+	} 
+	else
+		mTexture = TextureResource::get(path, tile, mForceLoad, mDynamic, true, maxSize.empty() ? nullptr : &maxSize);
 
 	resize();
 }

--- a/es-core/src/components/ImageComponent.h
+++ b/es-core/src/components/ImageComponent.h
@@ -5,8 +5,10 @@
 #include "renderers/Renderer.h"
 #include "math/Vector2i.h"
 #include "GuiComponent.h"
+#include "ImageIO.h"
 
 class TextureResource;
+class MaxSizeInfo;
 
 class ImageComponent : public GuiComponent
 {
@@ -17,7 +19,7 @@ public:
 	void setDefaultImage(std::string path);
 
 	//Loads the image at the given filepath. Will tile if tile is true (retrieves texture as tiling, creates vertices accordingly).
-	void setImage(std::string path, bool tile = false);
+	void setImage(std::string path, bool tile = false, MaxSizeInfo maxSize = MaxSizeInfo());
 	//Loads an image from memory.
 	void setImage(const char* image, size_t length, bool tile = false);
 	//Use an already existing texture.
@@ -78,6 +80,14 @@ public:
 	virtual std::vector<HelpPrompt> getHelpPrompts() override;
 
 	void setAllowFading(bool fade) { mAllowFading = fade; };
+
+	const MaxSizeInfo getMaxSizeInfo()
+	{
+		if (mTargetSize == Vector2f(0, 0))
+			return MaxSizeInfo(mSize, mTargetIsMax);
+
+		return MaxSizeInfo(mTargetSize, mTargetIsMax);
+	};
 
 private:
 	Vector2f mTargetSize;

--- a/es-core/src/components/ImageComponent.h
+++ b/es-core/src/components/ImageComponent.h
@@ -76,6 +76,9 @@ public:
 	virtual void applyTheme(const std::shared_ptr<ThemeData>& theme, const std::string& view, const std::string& element, unsigned int properties) override;
 
 	virtual std::vector<HelpPrompt> getHelpPrompts() override;
+
+	void setAllowFading(bool fade) { mAllowFading = fade; };
+
 private:
 	Vector2f mTargetSize;
 
@@ -106,6 +109,8 @@ private:
 
 	Vector2f mTopLeftCrop;
 	Vector2f mBottomRightCrop;
+
+	bool mAllowFading;
 };
 
 #endif // ES_CORE_COMPONENTS_IMAGE_COMPONENT_H

--- a/es-core/src/components/NinePatchComponent.cpp
+++ b/es-core/src/components/NinePatchComponent.cpp
@@ -111,6 +111,9 @@ void NinePatchComponent::render(const Transform4x4f& parentTrans)
 
 	Transform4x4f trans = parentTrans * getTransform();
 
+	if (!Renderer::isVisibleOnScreen(trans.translation().x(), trans.translation().y(), mSize.x(), mSize.y()))
+		return;
+
 	if(mTexture && mVertices != NULL)
 	{
 		Renderer::setMatrix(trans);

--- a/es-core/src/components/NinePatchComponent.cpp
+++ b/es-core/src/components/NinePatchComponent.cpp
@@ -10,6 +10,8 @@ NinePatchComponent::NinePatchComponent(Window* window, const std::string& path, 
 	mPath(path),
 	mVertices(NULL)
 {
+	mPreviousSize = Vector2f(0, 0);
+
 	if(!mPath.empty())
 		buildVertices();
 }
@@ -127,6 +129,10 @@ void NinePatchComponent::render(const Transform4x4f& parentTrans)
 
 void NinePatchComponent::onSizeChanged()
 {
+	if (mPreviousSize == mSize)
+		return;
+
+	mPreviousSize = mSize;
 	buildVertices();
 }
 
@@ -137,6 +143,9 @@ const Vector2f& NinePatchComponent::getCornerSize() const
 
 void NinePatchComponent::setCornerSize(int sizeX, int sizeY)
 {
+	if (mCornerSize.x() == sizeX && mCornerSize.y() == sizeY)
+		return;
+
 	mCornerSize = Vector2f(sizeX, sizeY);
 	buildVertices();
 }
@@ -154,18 +163,28 @@ void NinePatchComponent::fitTo(Vector2f size, Vector3f position, Vector2f paddin
 
 void NinePatchComponent::setImagePath(const std::string& path)
 {
+	if (mPath == path)
+		return;
+
 	mPath = path;
+	mTexture = nullptr;
 	buildVertices();
 }
 
 void NinePatchComponent::setEdgeColor(unsigned int edgeColor)
 {
+	if (mEdgeColor == edgeColor)
+		return;
+
 	mEdgeColor = edgeColor;
 	updateColors();
 }
 
 void NinePatchComponent::setCenterColor(unsigned int centerColor)
 {
+	if (mCenterColor == centerColor)
+		return;
+
 	mCenterColor = centerColor;
 	updateColors();
 }
@@ -182,4 +201,22 @@ void NinePatchComponent::applyTheme(const std::shared_ptr<ThemeData>& theme, con
 
 	if(properties & PATH && elem->has("path"))
 		setImagePath(elem->get<std::string>("path"));
+
+	if(properties & COLOR)
+	{
+		if(elem->has("color"))
+		{
+			setCenterColor(elem->get<unsigned int>("color"));
+			setEdgeColor(elem->get<unsigned int>("color"));
+		}
+
+		if(elem->has("centerColor"))
+			setCenterColor(elem->get<unsigned int>("centerColor"));
+
+		if(elem->has("edgeColor"))
+			setEdgeColor(elem->get<unsigned int>("edgeColor"));
+	}
+
+	if(elem->has("cornerSize"))
+		setCornerSize(elem->get<Vector2f>("cornerSize"));
 }

--- a/es-core/src/components/NinePatchComponent.h
+++ b/es-core/src/components/NinePatchComponent.h
@@ -53,6 +53,8 @@ private:
 	unsigned int mEdgeColor;
 	unsigned int mCenterColor;
 	std::shared_ptr<TextureResource> mTexture;
+	
+	Vector2f mPreviousSize;
 };
 
 #endif // ES_CORE_COMPONENTS_NINE_PATCH_COMPONENT_H

--- a/es-core/src/components/ScrollableContainer.cpp
+++ b/es-core/src/components/ScrollableContainer.cpp
@@ -19,6 +19,9 @@ void ScrollableContainer::render(const Transform4x4f& parentTrans)
 
 	Transform4x4f trans = parentTrans * getTransform();
 
+	if (!Renderer::isVisibleOnScreen(trans.translation().x(), trans.translation().y(), mSize.x(), mSize.y()))
+		return;
+
 	Vector2i clipPos((int)trans.translation().x(), (int)trans.translation().y());
 
 	Vector3f dimScaled = trans * Vector3f(mSize.x(), mSize.y(), 0);

--- a/es-core/src/components/SliderComponent.cpp
+++ b/es-core/src/components/SliderComponent.cpp
@@ -73,6 +73,10 @@ void SliderComponent::update(int deltaTime)
 void SliderComponent::render(const Transform4x4f& parentTrans)
 {
 	Transform4x4f trans = parentTrans * getTransform();
+
+	if (!Renderer::isVisibleOnScreen(trans.translation().x(), trans.translation().y(), mSize.x(), mSize.y()))
+		return;
+
 	Renderer::setMatrix(trans);
 
 	// render suffix

--- a/es-core/src/components/TextComponent.cpp
+++ b/es-core/src/components/TextComponent.cpp
@@ -99,6 +99,9 @@ void TextComponent::render(const Transform4x4f& parentTrans)
 
 	Transform4x4f trans = parentTrans * getTransform();
 
+	if (!Renderer::isVisibleOnScreen(trans.translation().x(), trans.translation().y(), mSize.x(), mSize.y()))
+		return;
+
 	if (mRenderBackground)
 	{
 		Renderer::setMatrix(trans);

--- a/es-core/src/components/TextEditComponent.cpp
+++ b/es-core/src/components/TextEditComponent.cpp
@@ -243,6 +243,10 @@ void TextEditComponent::onCursorChanged()
 void TextEditComponent::render(const Transform4x4f& parentTrans)
 {
 	Transform4x4f trans = getTransform() * parentTrans;
+
+	if (!Renderer::isVisibleOnScreen(trans.translation().x(), trans.translation().y(), mSize.x(), mSize.y()))
+		return;
+
 	renderChildren(trans);
 
 	// text + cursor rendering

--- a/es-core/src/components/VideoComponent.cpp
+++ b/es-core/src/components/VideoComponent.cpp
@@ -62,6 +62,7 @@ VideoComponent::VideoComponent(Window* window) :
 	mDisable(false),
 	mScreensaverMode(false),
 	mTargetIsMax(false),
+	mTargetIsMin(false),
 	mTargetSize(0, 0)
 {
 	mFadeIn = 0.0f;
@@ -223,6 +224,8 @@ void VideoComponent::applyTheme(const std::shared_ptr<ThemeData>& theme, const s
 			setResize(elem->get<Vector2f>("size") * scale);
 		else if(elem->has("maxSize"))
 			setMaxSize(elem->get<Vector2f>("maxSize") * scale);
+		else if (elem->has("minSize"))
+			setMinSize(elem->get<Vector2f>("minSize") * scale);
 	}
 
 	// position + size also implies origin
@@ -257,6 +260,14 @@ void VideoComponent::applyTheme(const std::shared_ptr<ThemeData>& theme, const s
 		setVisible(elem->get<bool>("visible"));
 	else
 		setVisible(true);
+
+	if (elem->has("path"))
+	{
+		if (Utils::FileSystem::exists(elem->get<std::string>("path")))
+			mVideoPath = elem->get<std::string>("path");
+		else
+			mVideoPath = mConfig.defaultVideoPath;
+	}
 }
 
 std::vector<HelpPrompt> VideoComponent::getHelpPrompts()

--- a/es-core/src/components/VideoComponent.cpp
+++ b/es-core/src/components/VideoComponent.cpp
@@ -155,6 +155,10 @@ void VideoComponent::render(const Transform4x4f& parentTrans)
 		return;
 
 	Transform4x4f trans = parentTrans * getTransform();
+
+	if (!Renderer::isVisibleOnScreen(trans.translation().x(), trans.translation().y(), mSize.x(), mSize.y()))
+		return;
+
 	GuiComponent::renderChildren(trans);
 
 	VideoComponent::renderSnapshot(parentTrans);

--- a/es-core/src/components/VideoComponent.cpp
+++ b/es-core/src/components/VideoComponent.cpp
@@ -127,13 +127,13 @@ bool VideoComponent::setVideo(std::string path)
 	return false;
 }
 
-void VideoComponent::setImage(std::string path)
+void VideoComponent::setImage(std::string path, bool tile, MaxSizeInfo maxSize)
 {
 	// Check that the image has changed
 	if (path == mStaticImagePath)
 		return;
 
-	mStaticImage.setImage(path);
+	mStaticImage.setImage(path, tile, maxSize);
 	mFadeIn = 0.0f;
 	mStaticImagePath = path;
 }

--- a/es-core/src/components/VideoComponent.h
+++ b/es-core/src/components/VideoComponent.h
@@ -4,6 +4,7 @@
 
 #include "components/ImageComponent.h"
 #include "GuiComponent.h"
+#include "ImageIO.h"
 #include <string>
 
 class TextureResource;
@@ -30,7 +31,7 @@ public:
 	// Loads the video at the given filepath
 	bool setVideo(std::string path);
 	// Loads a static image that is displayed if the video cannot be played
-	void setImage(std::string path);
+	void setImage(std::string path, bool tile = false, MaxSizeInfo maxSize = MaxSizeInfo());
 
 	// Configures the component to show the default video
 	void setDefaultVideo();
@@ -85,6 +86,14 @@ public:
 	}
 
 	virtual void onVideoStarted();
+
+	const MaxSizeInfo getMaxSizeInfo()
+	{
+		if (mTargetSize == Vector2f(0, 0))
+			return MaxSizeInfo(mSize, mTargetIsMax);
+
+		return MaxSizeInfo(mTargetSize, mTargetIsMax);
+	};
 
 private:
 	// Start the video Immediately

--- a/es-core/src/components/VideoComponent.h
+++ b/es-core/src/components/VideoComponent.h
@@ -72,6 +72,9 @@ public:
 	virtual void setMaxSize(float width, float height) = 0;
 	inline void setMaxSize(const Vector2f& size) { setMaxSize(size.x(), size.y()); }
 
+	virtual void setMinSize(float width, float height) = 0;
+	inline void setMinSize(const Vector2f& size) { setMinSize(size.x(), size.y()); }
+
 	Vector2f getVideoSize() { return Vector2f(mVideoWidth, mVideoHeight); }
 	bool isPlaying() {
 		return mIsPlaying;
@@ -119,6 +122,7 @@ protected:
 	bool							mScreensaverActive;
 	bool							mScreensaverMode;
 	bool							mTargetIsMax;
+	bool							mTargetIsMin;
 
 	bool							mIsWaitingForVideoToStart;
 

--- a/es-core/src/components/VideoPlayerComponent.cpp
+++ b/es-core/src/components/VideoPlayerComponent.cpp
@@ -57,6 +57,17 @@ void VideoPlayerComponent::setMaxSize(float width, float height)
 	onSizeChanged();
 }
 
+void VideoPlayerComponent::setMinSize(float width, float height)
+{
+	setSize(width, height);
+	mTargetSize = Vector2f(width, height);
+	mTargetIsMax = false;
+	mStaticImage.setMinSize(width, height);
+	onSizeChanged();
+
+	// TODO add cropping with  --crop 100,100,300,300
+}
+
 void VideoPlayerComponent::startVideo()
 {
 	if (!mIsPlaying)
@@ -158,7 +169,7 @@ void VideoPlayerComponent::startVideo()
 				// We need to specify the layer of 10000 or above to ensure the video is displayed on top
 				// of our SDL display
 
-				const char* argv[] = { "", "--layer", "10010", "--loop", "--no-osd", "--aspect-mode", "letterbox", "--vol", "0", "-o", "both","--win", buf1, "--orientation", buf2, "", "", "", "", NULL };
+				const char* argv[] = { "", "--layer", "10010", "--loop", "--no-osd", "--aspect-mode", "letterbox", "--vol", "0", "-o", "both","--win", buf1, "--orientation", buf2, "", "", "", "", "", "", "", "", "", "", "", NULL };
 
 				// check if we want to mute the audio
 				if (!Settings::getInstance()->getBool("VideoAudio") || (float)VolumeControl::getInstance()->getVolume() == 0)
@@ -189,6 +200,14 @@ void VideoPlayerComponent::startVideo()
 						argv[15] = "--subtitles";
 						argv[16] = subtitlePath.c_str();
 						argv[17] = mPlayingVideoPath.c_str();
+						argv[18] = "--font";
+						argv[19] = Settings::getInstance()->getString("SubtitleFont").c_str();
+						argv[20] = "--italic-font";
+						argv[21] = Settings::getInstance()->getString("SubtitleItalicFont").c_str();
+						argv[22] = "--font-size";
+						argv[23] = std::to_string(Settings::getInstance()->getInt("SubtitleSize")).c_str();
+						argv[24] = "--align";
+						argv[25] = Settings::getInstance()->getString("SubtitleAlignment").c_str();
 					}
 					else
 					{

--- a/es-core/src/components/VideoPlayerComponent.h
+++ b/es-core/src/components/VideoPlayerComponent.h
@@ -25,6 +25,7 @@ public:
 	// Can be set before or after a video is loaded.
 	// Never breaks the aspect ratio. setMaxSize() and setResize() are mutually exclusive.
 	void setMaxSize(float width, float height);
+	void setMinSize(float width, float height);
 
 private:
 	// Start the video Immediately

--- a/es-core/src/components/VideoVlcComponent.cpp
+++ b/es-core/src/components/VideoVlcComponent.cpp
@@ -179,6 +179,10 @@ void VideoVlcComponent::render(const Transform4x4f& parentTrans)
 		return;
 
 	Transform4x4f trans = parentTrans * getTransform();
+
+	if (!Renderer::isVisibleOnScreen(trans.translation().x(), trans.translation().y(), mSize.x(), mSize.y()))
+		return;
+
 	GuiComponent::renderChildren(trans);
 	Renderer::setMatrix(trans);
 

--- a/es-core/src/components/VideoVlcComponent.h
+++ b/es-core/src/components/VideoVlcComponent.h
@@ -31,7 +31,7 @@ class VideoVlcComponent : public VideoComponent
 public:
 	static void setupVLC(std::string subtitles);
 
-	VideoVlcComponent(Window* window, std::string subtitles);
+	VideoVlcComponent(Window* window, std::string subtitles="");
 	virtual ~VideoVlcComponent();
 
 	void render(const Transform4x4f& parentTrans) override;
@@ -47,6 +47,7 @@ public:
 	// Can be set before or after a video is loaded.
 	// Never breaks the aspect ratio. setMaxSize() and setResize() are mutually exclusive.
 	void setMaxSize(float width, float height);
+	void setMinSize(float width, float height);
 
 private:
 	// Calculates the correct mSize from our resizing information (set by setResize/setMaxSize).
@@ -70,6 +71,9 @@ private:
 	libvlc_media_player_t*			mMediaPlayer;
 	VideoContext					mContext;
 	std::shared_ptr<TextureResource> mTexture;
+
+	std::string					    mSubtitlePath;
+	std::string					    mSubtitleTmpFile;
 };
 
 #endif // ES_CORE_COMPONENTS_VIDEO_VLC_COMPONENT_H

--- a/es-core/src/renderers/Renderer.h
+++ b/es-core/src/renderers/Renderer.h
@@ -97,6 +97,9 @@ namespace Renderer
 	void         setSwapInterval   ();
 	void         swapBuffers       ();
 
+	// batocera methods
+	bool         isClippingEnabled  ();
+	bool         isVisibleOnScreen  (float x, float y, float w, float h);
 	bool         isSmallScreen      ();
 } // Renderer::
 

--- a/es-core/src/resources/TextureData.h
+++ b/es-core/src/resources/TextureData.h
@@ -4,6 +4,7 @@
 
 #include <mutex>
 #include <string>
+#include "ImageIO.h"
 
 class TextureResource;
 
@@ -50,6 +51,10 @@ public:
 	unsigned char* getDataRGBA() {
 		return mDataRGBA;
 	}
+
+	void setMaxSize(MaxSizeInfo maxSize);
+	bool isMaxSizeValid();
+
 private:
 	std::mutex		mMutex;
 	bool			mTile;
@@ -62,6 +67,10 @@ private:
 	float			mSourceHeight;
 	bool			mScalable;
 	bool			mReloadable;
+
+	MaxSizeInfo		mMaxSize;
+	Vector2i		mPackedSize;
+	Vector2i		mBaseSize;
 };
 
 #endif // ES_CORE_RESOURCES_TEXTURE_DATA_H

--- a/es-core/src/resources/TextureDataManager.cpp
+++ b/es-core/src/resources/TextureDataManager.cpp
@@ -105,7 +105,17 @@ void TextureDataManager::load(std::shared_ptr<TextureData> tex, bool block)
 {
 	// See if it's already loaded
 	if (tex->isLoaded())
-		return;
+	{
+		if (tex->isMaxSizeValid())
+			return;
+
+		tex->releaseVRAM();
+		tex->releaseRAM();
+
+		mLoader->remove(tex);
+		block = true; // Reload instantly or other instances will fade again
+	}
+
 	// Not loaded. Make sure there is room
 	size_t size = TextureResource::getTotalMemUsage();
 	size_t max_texture = (size_t)Settings::getInstance()->getInt("MaxVRAM") * 1024 * 1024;

--- a/es-core/src/resources/TextureResource.h
+++ b/es-core/src/resources/TextureResource.h
@@ -6,17 +6,16 @@
 #include "math/Vector2f.h"
 #include "resources/ResourceManager.h"
 #include "resources/TextureDataManager.h"
+#include "resources/TextureData.h"
 #include <set>
 #include <string>
-
-class TextureData;
 
 // An OpenGL texture.
 // Automatically recreates the texture with renderer deinit/reinit.
 class TextureResource : public IReloadable
 {
 public:
-	static std::shared_ptr<TextureResource> get(const std::string& path, bool tile = false, bool forceLoad = false, bool dynamic = true, bool asReloadable = true);
+	static std::shared_ptr<TextureResource> get(const std::string& path, bool tile = false, bool forceLoad = false, bool dynamic = true, bool asReloadable = true, MaxSizeInfo* maxSize = nullptr);
 	void initFromPixels(unsigned char* dataRGBA, size_t width, size_t height);
 	virtual void initFromMemory(const char* file, size_t length);
 
@@ -36,7 +35,7 @@ public:
 	static size_t getTotalTextureSize(); // returns the number of bytes that would be used if all textures were in memory
 
 protected:
-	TextureResource(const std::string& path, bool tile, bool dynamic);
+	TextureResource(const std::string& path, bool tile, bool dynamic, MaxSizeInfo* maxSize = nullptr);
 	virtual bool unload();
 	virtual void reload();
 


### PR DESCRIPTION
I did a single PR, but I splitted functionnalities into 5 distinct commits.

- SystemConf: Some Audio settings were not saved. 
Don't save if nothing is changed
Settings : Don't save items with default value. 
Don't save if nothing is changed. 
Allow using dynamic / non declared settings
Sound : Setting EnableSounds not working if set to true, when it was false at loading time.

- Software clipping : Don't try to render components that are not visible on screen. OpenGl was doing it with glScissor, but all the openGl logic was called ( like binding & rendering textures... )

- NinePatchComponent : fixed & added support for color, centerColor, edgeColor and cornerSize in themes & can be created as "extra" in themes.

- VideoVlcComponent : can now be added as extra in themes + support forminSize.
   SystemView : fixed to handle extra components as videos.
-> **Video systemview now supported**

- OPTIMIZE IMAGES VRAM USE : Scraped resource & logo themes can be scaled to the container to ensure they don't take too much VRAM. ( required for the future work in the grid )