### PR TITLE
Video components : lot of fixes !!

### DIFF
--- a/es-app/src/components/ScraperSearchComponent.cpp
+++ b/es-app/src/components/ScraperSearchComponent.cpp
@@ -20,6 +20,8 @@ ScraperSearchComponent::ScraperSearchComponent(Window* window, SearchType type) 
 	mGrid(window, Vector2i(4, 3)), mBusyAnim(window), 
 	mSearchType(type)
 {
+	mBusyAnim.setText(_("SEARCHING"));
+
 	auto theme = ThemeData::getMenuTheme();
 	addChild(&mGrid);
 

--- a/es-app/src/guis/GuiMenu.h
+++ b/es-app/src/guis/GuiMenu.h
@@ -38,8 +38,7 @@ private:
 	void addEntry(std::string name, bool add_arrow, const std::function<void()>& func, const std::string iconName = "");
 	void addVersionInfo();
 	void openCollectionSystemSettings();
-	void openConfigInput();
-	void openOtherSettings();	
+	void openConfigInput();	
 	void openScraperSettings();
 	void openScreensaverOptions();
 	void openSlideshowScreensaverOptions();

--- a/es-app/src/main.cpp
+++ b/es-app/src/main.cpp
@@ -492,6 +492,10 @@ int main(int argc, char* argv[])
 
 		if(ps_standby ? SDL_WaitEventTimeout(&event, PowerSaver::getTimeout()) : SDL_PollEvent(&event))
 		{
+			// PowerSaver can push events to exit SDL_WaitEventTimeout immediatly
+			// Reset this event's state
+			PowerSaver::resetRefreshEvent();
+
 			do
 			{
 				InputManager::getInstance()->parseEvent(event, &window);

--- a/es-app/src/views/ViewController.cpp
+++ b/es-app/src/views/ViewController.cpp
@@ -107,7 +107,10 @@ void ViewController::goToSystemView(SystemData* system, bool forceImmediate)
 	systemList->goToSystem(system, false);
 	mCurrentView = systemList;
 	mCurrentView->onShow();
-	PowerSaver::setState(true);
+
+	PowerSaver::pause();
+	PowerSaver::resume();
+	//PowerSaver::setState(true);
 
 	playViewTransition(forceImmediate);
 }

--- a/es-app/src/views/gamelist/DetailedGameListView.cpp
+++ b/es-app/src/views/gamelist/DetailedGameListView.cpp
@@ -317,11 +317,11 @@ void DetailedGameListView::updateInfoPanel()
 			if (!mVideo->setVideo(file->getVideoPath()))
 				mVideo->setDefaultVideo();
 
-			mVideo->setImage(imagePath, false, mVideo->getMaxSizeInfo());
+			mVideo->setImage(imagePath);
 		}
 
 		if (mImage != nullptr)
-			mImage->setImage(imagePath, false, mImage->getMaxSizeInfo());
+			mImage->setImage(imagePath);
 
 		if (mMarquee != nullptr)
 			mMarquee->setImage(file->getMarqueePath(), false, mMarquee->getMaxSizeInfo());

--- a/es-app/src/views/gamelist/VideoGameListView.cpp
+++ b/es-app/src/views/gamelist/VideoGameListView.cpp
@@ -254,8 +254,8 @@ void VideoGameListView::updateInfoPanel()
 		}
 		mVideoPlaying = true;
 
-		mVideo->setImage(file->getThumbnailPath(), false, mVideo->getMaxSizeInfo());
-		mMarquee.setImage(file->getMarqueePath(), false, mMarquee.getMaxSizeInfo());
+		mVideo->setImage(file->getThumbnailPath()/*, false, mVideo->getMaxSizeInfo()*/); // Too slow on pi
+		mMarquee.setImage(file->getMarqueePath()/*, false, mMarquee.getMaxSizeInfo()*/); // Too slow on pi
 		mImage.setImage(file->getImagePath(), false, mImage.getMaxSizeInfo());
 
 		mDescription.setText(file->metadata.get("desc"));

--- a/es-core/src/PowerSaver.h
+++ b/es-core/src/PowerSaver.h
@@ -7,6 +7,9 @@ class PowerSaver
 public:
 	enum mode : int { DISABLED = -1, INSTANT = 200, ENHANCED = 3000, DEFAULT = 10000 };
 
+	static void pushRefreshEvent();
+	static void resetRefreshEvent();
+
 	// Call when you want PS to reload all state and settings
 	static void init();
 
@@ -23,18 +26,48 @@ public:
 	// Get current state of PS. Not to be confused with Mode
 	static bool getState();
 	// State is used to temporarily pause and resume PS
-	static void setState(bool state);
+	
 
 	// Paired calls when you want to pause PS briefly till you finish animating
 	// or processing over cycles
-	static void pause() { setState(false); }
-	static void resume() { setState(true); }
+	static void pause() 
+	{ 
+		mPauseCounter++;
+		setState(false); 
+	}
+
+	static void resume() 
+	{ 
+		mPauseCounter--;
+		if (mPauseCounter < 0)
+			mPauseCounter = 0;
+
+		if (mPauseCounter == 0)
+			setState(true); 
+	}
+
+	static void lock(bool state)
+	{
+		if (state)
+		{
+			if (mPauseCounter == 0)
+				setState(true);
+		}
+		else
+			setState(false);
+	}
+
 
 	// This is used by ScreenSaver to let PS know when to switch to SS timeouts
 	static void runningScreenSaver(bool state);
 	static bool isScreenSaverActive();
 
 private:
+	static void setState(bool state);
+
+	static bool mHasPushedEvent;
+	static int  mPushEventID;
+
 	static bool mState;
 	static bool mRunningScreenSaver;
 
@@ -43,6 +76,9 @@ private:
 	static int mScreenSaverTimeout;
 
 	static void loadWakeupTime();
+
+
+	static int mPauseCounter;
 };
 
 #endif // ES_CORE_POWER_SAVER_H

--- a/es-core/src/Settings.cpp
+++ b/es-core/src/Settings.cpp
@@ -191,7 +191,8 @@ void Settings::setDefaults()
 	mBoolMap["PreloadUI"] = false;
 	mBoolMap["OptimizeVRAM"] = true;
 	mBoolMap["EnableLogging"] = true;
-
+	mBoolMap["OptimizeVideo"] = true;
+	
 	mIntMap["WindowWidth"]   = 0;
 	mIntMap["WindowHeight"]  = 0;
 	mIntMap["ScreenWidth"]   = 0;

--- a/es-core/src/SystemConf.cpp
+++ b/es-core/src/SystemConf.cpp
@@ -67,17 +67,26 @@ bool SystemConf::saveSystemConf()
 		return false;
 
 	std::ifstream filein(systemConfFile); //File to read from
-	if (!filein) {
+
+#ifndef WIN32
+	if (!filein) 
+	{
 		LOG(LogError) << "Unable to open for saving :  " << systemConfFile << "\n";
 		return false;
 	}
+#endif
+
 	/* Read all lines in a vector */
 	std::vector<std::string> fileLines;
 	std::string line;
-	while (std::getline(filein, line))
-		fileLines.push_back(line);
 
-	filein.close();
+	if (filein)
+	{
+		while (std::getline(filein, line))
+			fileLines.push_back(line);
+
+		filein.close();
+	}
 
 
 	/* Save new value if exists */

--- a/es-core/src/components/BusyComponent.cpp
+++ b/es-core/src/components/BusyComponent.cpp
@@ -4,6 +4,7 @@
 #include "components/ImageComponent.h"
 #include "components/TextComponent.h"
 #include "LocaleES.h"
+#include "PowerSaver.h"
 
 // animation definition
 AnimationFrame BUSY_ANIMATION_FRAMES[] = {
@@ -33,33 +34,42 @@ BusyComponent::BusyComponent(Window* window) : GuiComponent(window),
 
 	addChild(&mBackground);
 	addChild(&mGrid);
+
+	PowerSaver::pause();
 }
 
 // batocera
-BusyComponent::~BusyComponent() {
-  SDL_DestroyMutex(mutex);
+BusyComponent::~BusyComponent() 
+{
+	PowerSaver::resume();
+	SDL_DestroyMutex(mutex);
 }
 
 // batocera
-void BusyComponent::setText(std::string txt) {
-  if (SDL_LockMutex(mutex) == 0) {
-    threadMessage = txt;
-    threadMessagechanged = true;
-    SDL_UnlockMutex(mutex);
-  }
+void BusyComponent::setText(std::string txt)
+{
+	if (SDL_LockMutex(mutex) == 0)
+	{
+		threadMessage = txt;
+		threadMessagechanged = true;
+		SDL_UnlockMutex(mutex);
+	}
 }
 
 // batocera
-void BusyComponent::render(const Transform4x4f& parentTrans) {
-  if (SDL_LockMutex(mutex) == 0) {
-    if(threadMessagechanged) {
-      threadMessagechanged = false;
-      mText->setText(threadMessage);
-      onSizeChanged();
-    }
-    SDL_UnlockMutex(mutex);
-  }
-  GuiComponent::render(parentTrans);
+void BusyComponent::render(const Transform4x4f& parentTrans)
+{
+	if (SDL_LockMutex(mutex) == 0)
+	{
+		if (threadMessagechanged) 
+		{
+			threadMessagechanged = false;
+			mText->setText(threadMessage);
+			onSizeChanged();
+		}
+		SDL_UnlockMutex(mutex);
+	}
+	GuiComponent::render(parentTrans);
 }
 
 void BusyComponent::onSizeChanged()

--- a/es-core/src/components/IList.h
+++ b/es-core/src/components/IList.h
@@ -211,7 +211,7 @@ protected:
 
 	bool listInput(int velocity) // a velocity of 0 = stop scrolling
 	{
-		PowerSaver::setState(velocity == 0);
+		PowerSaver::lock(velocity == 0);
 
 		// generate an onCursorChanged event in the stopped state when the user lets go of the key
 		if(velocity == 0 && mScrollVelocity != 0)

--- a/es-core/src/components/VideoComponent.cpp
+++ b/es-core/src/components/VideoComponent.cpp
@@ -52,7 +52,7 @@ void VideoComponent::setScreensaverMode(bool isScreensaver)
 
 VideoComponent::VideoComponent(Window* window) :
 	GuiComponent(window),
-	mStaticImage(window),
+	mStaticImage(window, true),
 	mVideoHeight(0),
 	mVideoWidth(0),
 	mStartDelayed(false),

--- a/es-core/src/components/VideoPlayerComponent.cpp
+++ b/es-core/src/components/VideoPlayerComponent.cpp
@@ -236,8 +236,8 @@ void VideoPlayerComponent::startVideo()
 				dup2(fdin, 0);
 				dup2(fdout, 1);
 				// Run the omxplayer binary
-				execve("/usr/bin/omxplayer.bin", (char**)argv, (char**)env);
-
+				execve("/usr/bin/omxplayer", (char**)argv, (char**)env); // .bin
+				
 				_exit(EXIT_FAILURE);
 			}
 		}

--- a/es-core/src/components/VideoVlcComponent.h
+++ b/es-core/src/components/VideoVlcComponent.h
@@ -15,6 +15,7 @@ struct VideoContext {
 	SDL_mutex*			mutex;
 	VideoComponent*		component;
 	bool				valid;
+	bool				hasFrame;
 };
 
 class VideoVlcComponent : public VideoComponent
@@ -35,7 +36,6 @@ public:
 	virtual ~VideoVlcComponent();
 
 	void render(const Transform4x4f& parentTrans) override;
-
 
 	// Resize the video to fit this size. If one axis is zero, scale that axis to maintain aspect ratio.
 	// If both are non-zero, potentially break the aspect ratio.  If both are zero, no resizing.

--- a/es-core/src/guis/GuiInfoPopup.cpp
+++ b/es-core/src/guis/GuiInfoPopup.cpp
@@ -4,6 +4,7 @@
 #include "components/NinePatchComponent.h"
 #include "components/TextComponent.h"
 #include <SDL_timer.h>
+#include "PowerSaver.h"
 
 GuiInfoPopup::GuiInfoPopup(Window* window, std::string message, int duration) :
 	GuiComponent(window), mMessage(message), mDuration(duration), running(true)
@@ -60,6 +61,18 @@ GuiInfoPopup::GuiInfoPopup(Window* window, std::string message, int duration) :
 	mGrid->setSize(mSize);
 	mGrid->setEntry(s, Vector2i(0, 1), false, true);
 	addChild(mGrid);
+
+	PowerSaver::pause();
+}
+
+GuiInfoPopup::~GuiInfoPopup()
+{
+	if (running)
+	{
+		// if SDL reset
+		running = false;
+		PowerSaver::resume();
+	}
 }
 
 void GuiInfoPopup::render(const Transform4x4f& /*parentTrans*/)
@@ -87,13 +100,23 @@ bool GuiInfoPopup::updateState()
 	// compute fade in effect
 	if (curTime - mStartTime > mDuration)
 	{
-		// we're past the popup duration, no need to render
-		running = false;
+		if (running)
+		{
+			// we're past the popup duration, no need to render
+			running = false;
+			PowerSaver::resume();
+		}
+
 		return false;
 	}
-	else if (curTime < mStartTime) {
-		// if SDL reset
-		running = false;
+	else if (curTime < mStartTime) 
+	{
+		if (running)
+		{
+			// if SDL reset
+			running = false;
+			PowerSaver::resume();
+		}
 		return false;
 	}
 	else if (curTime - mStartTime <= 500) {

--- a/es-core/src/guis/GuiInfoPopup.h
+++ b/es-core/src/guis/GuiInfoPopup.h
@@ -12,6 +12,7 @@ class GuiInfoPopup : public GuiComponent, public Window::InfoPopup
 {
 public:
 	GuiInfoPopup(Window* window, std::string message, int duration);
+	~GuiInfoPopup();
 
 	void render(const Transform4x4f& parentTrans) override;
 	inline void stop() { running = false; };

--- a/es-core/src/renderers/Renderer_GL21.cpp
+++ b/es-core/src/renderers/Renderer_GL21.cpp
@@ -115,7 +115,7 @@ namespace Renderer
 		return texture;
 
 	} // createTexture
-
+	
 	void destroyTexture(const unsigned int _texture)
 	{
 		glDeleteTextures(1, &_texture);
@@ -124,9 +124,17 @@ namespace Renderer
 
 	void updateTexture(const unsigned int _texture, const Texture::Type _type, const unsigned int _x, const unsigned _y, const unsigned int _width, const unsigned int _height, void* _data)
 	{
-		bindTexture(_texture);
-		glTexSubImage2D(GL_TEXTURE_2D, 0, _x, _y, _width, _height, convertTextureType(_type), GL_UNSIGNED_BYTE, _data);
-		bindTexture(0);
+		glBindTexture(GL_TEXTURE_2D, _texture);
+
+		if (_x == -1 && _y == -1)
+		{
+			const GLenum type = convertTextureType(_type);
+			glTexImage2D(GL_TEXTURE_2D, 0, type, _width, _height, 0, type, GL_UNSIGNED_BYTE, _data);
+		}
+		else 
+			glTexSubImage2D(GL_TEXTURE_2D, 0, _x, _y, _width, _height, convertTextureType(_type), GL_UNSIGNED_BYTE, _data);
+
+		glBindTexture(GL_TEXTURE_2D, 0);
 
 	} // updateTexture
 

--- a/es-core/src/renderers/Renderer_GLES10.cpp
+++ b/es-core/src/renderers/Renderer_GLES10.cpp
@@ -125,7 +125,15 @@ namespace Renderer
 	void updateTexture(const unsigned int _texture, const Texture::Type _type, const unsigned int _x, const unsigned _y, const unsigned int _width, const unsigned int _height, void* _data)
 	{
 		bindTexture(_texture);
-		glTexSubImage2D(GL_TEXTURE_2D, 0, _x, _y, _width, _height, convertTextureType(_type), GL_UNSIGNED_BYTE, _data);
+
+		if (_x == -1 && _y == -1)
+		{
+			const GLenum type = convertTextureType(_type);
+			glTexImage2D(GL_TEXTURE_2D, 0, type, _width, _height, 0, type, GL_UNSIGNED_BYTE, _data);
+		}
+		else
+			glTexSubImage2D(GL_TEXTURE_2D, 0, _x, _y, _width, _height, convertTextureType(_type), GL_UNSIGNED_BYTE, _data);
+
 		bindTexture(0);
 
 	} // updateTexture

--- a/es-core/src/resources/TextureData.h
+++ b/es-core/src/resources/TextureData.h
@@ -59,6 +59,8 @@ public:
 
 	inline const std::string& getPath() { return mPath; };
 
+	bool initFromExternalRGBA(unsigned char* dataRGBA, size_t width, size_t height);
+
 private:
 	std::mutex		mMutex;
 	bool			mTile;
@@ -75,6 +77,8 @@ private:
 	MaxSizeInfo		mMaxSize;
 	Vector2i		mPackedSize;
 	Vector2i		mBaseSize;
+
+	bool			mIsExternalDataRGBA;
 };
 
 #endif // ES_CORE_RESOURCES_TEXTURE_DATA_H

--- a/es-core/src/resources/TextureResource.cpp
+++ b/es-core/src/resources/TextureResource.cpp
@@ -4,6 +4,7 @@
 #include "resources/TextureData.h"
 #include <cstring>
 #include "Settings.h"
+#include "PowerSaver.h"
 
 TextureDataManager		TextureResource::sTextureDataManager;
 std::map< TextureResource::TextureKeyType, std::weak_ptr<TextureResource> > TextureResource::sTextureMap;
@@ -93,7 +94,19 @@ void TextureResource::onTextureLoaded(std::shared_ptr<TextureData> tex)
 {
 	mSize = Vector2i((int)tex->width(), (int)tex->height());
 	mSourceSize = Vector2f(tex->sourceWidth(), tex->sourceHeight());
+
+	PowerSaver::pushRefreshEvent();
 }
+
+void TextureResource::initFromExternalPixels(unsigned char* dataRGBA, size_t width, size_t height)
+{
+	mTextureData->initFromExternalRGBA(dataRGBA, width, height);
+
+	// Cache the image dimensions
+	mSize = Vector2i((int)width, (int)height);
+	mSourceSize = Vector2f(mTextureData->sourceWidth(), mTextureData->sourceHeight());
+}
+
 
 void TextureResource::initFromPixels(unsigned char* dataRGBA, size_t width, size_t height)
 {

--- a/es-core/src/resources/TextureResource.h
+++ b/es-core/src/resources/TextureResource.h
@@ -21,6 +21,7 @@ public:
 	static void cancelAsync(std::shared_ptr<TextureResource> texture);
 	static std::shared_ptr<TextureResource> get(const std::string& path, bool tile = false, bool forceLoad = false, bool dynamic = true, bool asReloadable = true, MaxSizeInfo* maxSize = nullptr);
 	void initFromPixels(unsigned char* dataRGBA, size_t width, size_t height);
+	void initFromExternalPixels(unsigned char* dataRGBA, size_t width, size_t height);
 	virtual void initFromMemory(const char* file, size_t length);
 
 	// For scalable source images in textures we want to set the resolution to rasterize at


### PR DESCRIPTION
- VLC Video : Stop coping bytes in memory. Stop deleting / creating texture for each frame -> Just update the texture. ( should be really really faster ! )
- VLC Video : Don't copy bytes / delete / create texture when VLC has no new rendered frame !!!!
- VLC Video : Release the texture if it is not visible anymore ( when moving to another gamelist ) -> Retropie's component keep the last frame texture in memory permanently !!!!
- VLC Video : Added developer option "OPTIMIZE VIDEO VRAM USE" for VLC : if a video is bigger than the display, ask VLC to size it.
- VLC Video : Support for extra command line arguments in bacotera.conf file, variable vlc.commandline=xxx ( intended for debugging )
- OMX Player : Fixed omxplayer executable path.
- VideoComponent : Disabled async for static images. The visual result is not good when stopping video.
- Moved POWER SAVER MODES in System settings ( under overclock )
- Power Save mode : Better management (with reference counter) & disable power saving during busy animation, infopopup & video.
- Video & detailed gamelists : Stop "maxsize" calculation on scrapped image -> It is too slow on RPI platforms.
- Windows only : create empty batocera.conf file if it does not exist.

