### PR TITLE
Potential fix for rpi crash & misc optimisations

### DIFF
--- a/es-app/src/guis/GuiCollectionSystemsOptions.cpp
+++ b/es-app/src/guis/GuiCollectionSystemsOptions.cpp
@@ -167,36 +167,29 @@ void GuiCollectionSystemsOptions::addSystemsToMenu()
 }
 
 void GuiCollectionSystemsOptions::applySettings()
-{
-	std::string outAuto = Utils::String::vectorToCommaString(autoOptionList->getSelectedObjects());
-	std::string prevAuto = Settings::getInstance()->getString("CollectionSystemsAuto");
-	std::string outCustom = Utils::String::vectorToCommaString(customOptionList->getSelectedObjects());
-	std::string prevCustom = Settings::getInstance()->getString("CollectionSystemsCustom");
-	bool outSort = sortAllSystemsSwitch->getState();
-	bool prevSort = Settings::getInstance()->getBool("SortAllSystems");
-	bool outBundle = bundleCustomCollections->getState();
-	bool prevBundle = Settings::getInstance()->getBool("UseCustomCollectionsSystem");
-
-	bool needUpdateSettings = prevAuto != outAuto || prevCustom != outCustom || outSort != prevSort || outBundle != prevBundle;
-	if (needUpdateSettings)
-	{
-		updateSettings(outAuto, outCustom);
-	}
+{	
+	std::string newAutoSettings = Utils::String::vectorToCommaString(autoOptionList->getSelectedObjects());
+	std::string newCustomSettings = Utils::String::vectorToCommaString(customOptionList->getSelectedObjects());
+	updateSettings(newAutoSettings, newCustomSettings);
 	delete this;
 }
 
 void GuiCollectionSystemsOptions::updateSettings(std::string newAutoSettings, std::string newCustomSettings)
 {
-	Settings::getInstance()->setString("CollectionSystemsAuto", newAutoSettings);
-	Settings::getInstance()->setString("CollectionSystemsCustom", newCustomSettings);
-	Settings::getInstance()->setBool("SortAllSystems", sortAllSystemsSwitch->getState());
-	Settings::getInstance()->setBool("UseCustomCollectionsSystem", bundleCustomCollections->getState());
-	Settings::getInstance()->setBool("CollectionShowSystemInfo", toggleSystemNameInCollections->getState());	
-	Settings::getInstance()->saveFile();
-	CollectionSystemManager::get()->loadEnabledListFromSettings();
-	CollectionSystemManager::get()->updateSystemsList();
-	ViewController::get()->goToStart();
-	ViewController::get()->reloadAll();
+	bool dirty = Settings::getInstance()->setString("CollectionSystemsAuto", newAutoSettings);
+	dirty |= Settings::getInstance()->setString("CollectionSystemsCustom", newCustomSettings);
+	dirty |= Settings::getInstance()->setBool("SortAllSystems", sortAllSystemsSwitch->getState());
+	dirty |= Settings::getInstance()->setBool("UseCustomCollectionsSystem", bundleCustomCollections->getState());
+	dirty |= Settings::getInstance()->setBool("CollectionShowSystemInfo", toggleSystemNameInCollections->getState());
+
+	if (dirty)
+	{
+		Settings::getInstance()->saveFile();
+		CollectionSystemManager::get()->loadEnabledListFromSettings();
+		CollectionSystemManager::get()->updateSystemsList();
+		ViewController::get()->goToStart();
+		ViewController::get()->reloadAll();
+	}
 }
 
 bool GuiCollectionSystemsOptions::input(InputConfig* config, Input input)

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -152,6 +152,7 @@ void GuiMenu::openScraperSettings()
 		auto imageSource = std::make_shared< OptionListComponent<std::string> >(mWindow, _("PREFERED IMAGE SOURCE"), false);
 		imageSource->add(_("NONE"), "", imageSourceName.empty());
 		imageSource->add(_("SCREENSHOT"), "ss", imageSourceName == "ss");
+		imageSource->add(_("TITLE SCREENSHOT"), "sstitle", imageSourceName == "sstitle");
 		imageSource->add(_("BOX 2D"), "box-2D", imageSourceName == "box-2D");
 		imageSource->add(_("BOX 3D"), "box-3D", imageSourceName == "box-3D");
 		imageSource->add(_("MIX"), "mixrbv1", imageSourceName == "mixrbv1");
@@ -167,6 +168,7 @@ void GuiMenu::openScraperSettings()
 		auto thumbSource = std::make_shared< OptionListComponent<std::string> >(mWindow, _("PREFERED THUMBNAIL SOURCE"), false);
 		thumbSource->add(_("NONE"), "", thumbSourceName.empty());
 		thumbSource->add(_("SCREENSHOT"), "ss", thumbSourceName == "ss");
+		imageSource->add(_("TITLE SCREENSHOT"), "sstitle", thumbSourceName == "sstitle");
 		thumbSource->add(_("BOX 2D"), "box-2D", thumbSourceName == "box-2D");
 		thumbSource->add(_("BOX 3D"), "box-3D", thumbSourceName == "box-3D");
 		thumbSource->add(_("MIX"), "mixrbv1", thumbSourceName == "mixrbv1");
@@ -1210,20 +1212,20 @@ void GuiMenu::openControllersSettings_batocera()
 
 void GuiMenu::openThemeConfiguration(GuiSettings* s, std::shared_ptr<OptionListComponent<std::string>> theme_set)
 {
-	auto SelectedTheme = theme_set->getSelected();
-	Window* window = mWindow;
-
-	if (Settings::getInstance()->getString("ThemeSet") != SelectedTheme)
+	if (Settings::getInstance()->getString("ThemeSet") != theme_set->getSelected())
 	{
 		mWindow->pushGui(new GuiMsgBox(mWindow, _("YOU MUST APPLY THE THEME BEFORE EDIT CONFIGURATION"), _("OK")));
 		return;
 	}
 
-	auto themeconfig = new GuiSettings(mWindow, _("THEME CONFIGURATION").c_str());
+	Window* window = mWindow;
 
 	auto system = ViewController::get()->getState().getSystem();
+	auto theme = system->getTheme();
 
-	auto themeSubSets = ThemeData::getThemeSubSets(SelectedTheme);
+	auto themeconfig = new GuiSettings(mWindow, _("THEME CONFIGURATION").c_str());
+
+	auto themeSubSets = theme->getSubSets();
 	auto themeColorSets = ThemeData::getSubSet(themeSubSets, "colorset");
 	auto themeIconSets = ThemeData::getSubSet(themeSubSets, "iconset");
 	auto themeMenus = ThemeData::getSubSet(themeSubSets, "menu");
@@ -1344,7 +1346,7 @@ void GuiMenu::openThemeConfiguration(GuiSettings* s, std::shared_ptr<OptionListC
 	
 		if (system != NULL)
 		{
-			auto mViews = system->getTheme()->getViewsOfTheme();
+			auto mViews = theme->getViewsOfTheme();
 			for (auto it = mViews.cbegin(); it != mViews.cend(); ++it)
 				styles.push_back(*it);
 		}
@@ -1355,7 +1357,7 @@ void GuiMenu::openThemeConfiguration(GuiSettings* s, std::shared_ptr<OptionListC
 		}
 
 		auto viewPreference = Settings::getInstance()->getString("GamelistViewStyle");
-		if (!system->getTheme()->hasView(viewPreference))
+		if (!theme->hasView(viewPreference))
 			viewPreference = "automatic";
 
 		for (auto it = styles.cbegin(); it != styles.cend(); it++)
@@ -1366,7 +1368,7 @@ void GuiMenu::openThemeConfiguration(GuiSettings* s, std::shared_ptr<OptionListC
 
 	// Default grid size
 	std::shared_ptr<OptionListComponent<std::string>> mGridSize = nullptr;
-	if (system != NULL && system->getTheme()->hasView("grid"))
+	if (system != NULL && theme->hasView("grid"))
 	{
 		Vector2f gridOverride = Vector2f::parseString(Settings::getInstance()->getString("DefaultGridSize"));
 		auto ovv = std::to_string((int)gridOverride.x()) + "x" + std::to_string((int)gridOverride.y());
@@ -1530,16 +1532,8 @@ void GuiMenu::openUISettings()
 			{
 				Settings::getInstance()->setString("ThemeSet", theme_set->getSelected());
 
-				auto themeSubSets = ThemeData::getThemeSubSets(theme_set->getSelected());
-				auto themeColorSets = ThemeData::getSubSet(themeSubSets, "colorset");
-				auto themeIconSets = ThemeData::getSubSet(themeSubSets, "iconset");
-				auto themeMenus = ThemeData::getSubSet(themeSubSets, "menu");
-				auto themeSystemviewSets = ThemeData::getSubSet(themeSubSets, "systemview");
-				auto themeGamelistViewSets = ThemeData::getSubSet(themeSubSets, "gamelistview");
-				auto themeRegions = ThemeData::getSubSet(themeSubSets, "region");
-
 				// theme changed without setting options, forcing options to avoid crash/blank theme
-				Settings::getInstance()->setString("ThemeRegionName", themeRegions.empty() || themeRegions[0]  == "en" ? "" : themeRegions[0]);
+				Settings::getInstance()->setString("ThemeRegionName", "");
 				Settings::getInstance()->setString("ThemeColorSet", "");
 				Settings::getInstance()->setString("ThemeIconSet", "");
 				Settings::getInstance()->setString("ThemeMenu", "");

--- a/es-app/src/scrapers/ScreenScraper.cpp
+++ b/es-app/src/scrapers/ScreenScraper.cpp
@@ -242,7 +242,9 @@ std::vector<std::string> ScreenScraperRequest::getRipList(std::string imageSourc
 	std::vector<std::string> ripList;
 
 	if (imageSource == "ss")
-		ripList = { "ss", "mixrbv1", "mixrbv2", "box-2D", "box-3D" };
+		ripList = { "ss", "sstitle", "mixrbv1", "mixrbv2", "box-2D", "box-3D" };
+	else if (imageSource == "sstitle")
+		ripList = { "sstitle", "ss", "mixrbv1", "mixrbv2", "box-2D", "box-3D" };
 	else if (imageSource == "mixrbv1" || imageSource == "mixrbv2" || imageSource == "mixrbv")
 		ripList = { "mixrbv1", "mixrbv2", "ss", "box-3D", "box-2D" };
 	else if (imageSource == "box-2D")

--- a/es-core/src/ThemeData.cpp
+++ b/es-core/src/ThemeData.cpp
@@ -299,8 +299,7 @@ std::string ThemeData::resolvePlaceholders(const char* in)
 }
 
 ThemeData::ThemeData()
-{
-	mHasSubsets = false;
+{	
 	mColorset = Settings::getInstance()->getString("ThemeColorSet");
 	mIconset = Settings::getInstance()->getString("ThemeIconSet");
 	mMenu = Settings::getInstance()->getString("ThemeMenu");
@@ -319,8 +318,7 @@ void ThemeData::loadFile(const std::string system, std::map<std::string, std::st
 
 	if(!Utils::FileSystem::exists(path))
 		throw error << "File does not exist!";
-
-	mHasSubsets = false;
+	
 	mVersion = 0;
 	mViews.clear();
 
@@ -403,11 +401,24 @@ bool ThemeData::parseSubset(const pugi::xml_node& node)
 	if (!node.attribute("subset"))
 		return true;
 
-	mHasSubsets = true;
-
 	const std::string subsetAttr = node.attribute("subset").as_string();
 	const std::string nameAttr = node.attribute("name").as_string();
 
+	if (!subsetAttr.empty())
+	{
+		bool add = true;
+
+		for (auto sb : mSubsets) {
+			if (sb.subset == subsetAttr && sb.name == nameAttr) {
+				add = false; break;
+			}
+		}
+
+		if (add)
+			mSubsets.push_back(Subset(subsetAttr, nameAttr));
+	}
+
+	
 	if (subsetAttr == "colorset" && (nameAttr == mColorset || (mColorset.empty() && isFirstSubset(node))))
 		return true;
 
@@ -535,29 +546,6 @@ void ThemeData::parseViewElement(const pugi::xml_node& node)
 	{
 		LOG(LogWarning) << "View missing \"name\" attribute!";
 		return;
-	}
-
-	if (node.attribute("tinyScreen"))
-	{
-		const std::string tinyScreenAttr = node.attribute("tinyScreen").as_string();
-
-		if (!Renderer::isSmallScreen() && tinyScreenAttr == "true")
-			return;
-
-		if (Renderer::isSmallScreen() && tinyScreenAttr == "false")
-			return;
-	}
-
-	if (node.attribute("ifHelpPrompts"))
-	{
-		const std::string helpVisibleAttr = node.attribute("ifHelpPrompts").as_string();
-		bool help = Settings::getInstance()->getBool("ShowHelpPrompts");
-
-		if (!help && helpVisibleAttr == "true")
-			return;
-
-		if (help && helpVisibleAttr == "false")
-			return;
 	}
 
 	const char* delim = " \t\r\n,";
@@ -720,6 +708,29 @@ void ThemeData::parseView(const pugi::xml_node& root, ThemeView& view, bool over
 	ThemeException error;
 	error.setFiles(mPaths);
 
+	if (root.attribute("tinyScreen"))
+	{
+		const std::string tinyScreenAttr = root.attribute("tinyScreen").as_string();
+
+		if (!Renderer::isSmallScreen() && tinyScreenAttr == "true")
+			return;
+
+		if (Renderer::isSmallScreen() && tinyScreenAttr == "false")
+			return;
+	}
+
+	if (root.attribute("ifHelpPrompts"))
+	{
+		const std::string helpVisibleAttr = root.attribute("ifHelpPrompts").as_string();
+		bool help = Settings::getInstance()->getBool("ShowHelpPrompts");
+
+		if (!help && helpVisibleAttr == "true")
+			return;
+
+		if (help && helpVisibleAttr == "false")
+			return;
+	}
+
 	for(pugi::xml_node node = root.first_child(); node; node = node.next_sibling())
 	{
 		if(!node.attribute("name"))
@@ -764,9 +775,23 @@ bool ThemeData::parseRegion(const pugi::xml_node& node)
 
 	const std::string nameAttr = node.attribute("region").as_string();
 
+	if (!nameAttr.empty())
+	{
+		bool add = true;
+
+		for (auto sb : mSubsets) {
+			if (sb.subset == "region" && sb.name == nameAttr) {
+				add = false; break;
+			}
+		}
+
+		if (add)
+			mSubsets.push_back(Subset("region", nameAttr));
+	}
+
 	std::string regionsetting = Settings::getInstance()->getString("ThemeRegionName");
 	if (regionsetting.empty())
-		regionsetting = "eu";
+		regionsetting = "eu";	
 
 	const char* delim = " \t\r\n,";
 	
@@ -1196,127 +1221,14 @@ std::vector<std::string> ThemeData::getViewsOfTheme()
 	return ret;
 }
 
-std::vector<Subset> ThemeData::getThemeSubSets(const std::string& theme)
-{
-	std::vector<Subset> sets;
-
-	std::deque<std::string> dequepath;
-
-	static const size_t pathCount = 3;
-	std::string paths[pathCount] =
-	{
-		"/etc/emulationstation/themes",		
-		Utils::FileSystem::getEsConfigPath() + "/themes",
-		"/userdata/themes" // batocera
-	};
-
-	for (size_t i = 0; i < pathCount; i++)
-	{
-		if (!Utils::FileSystem::isDirectory(paths[i]))
-			continue;
-
-		auto dirs = Utils::FileSystem::getDirectoryFiles(paths[i] + "/" + theme);
-		for (auto it = dirs.cbegin(); it != dirs.cend(); ++it)
-		{
-			if (!it->directory || it->hidden)
-				continue;
-
-			std::string path = it->path + "/theme.xml";
-			if (!Utils::FileSystem::exists(path))
-				continue;
-
-			dequepath.push_back(path);
-			pugi::xml_document doc;
-			doc.load_file(path.c_str());
-
-			pugi::xml_node root = doc.child("theme");
-			crawlIncludes(root, sets, dequepath);
-			findRegion(doc, sets);
-			dequepath.pop_back();
-		}
-
-		std::string path = paths[i] + "/" + theme + "/theme.xml";
-		if (!Utils::FileSystem::exists(path))
-			continue;
-
-		dequepath.push_back(path);
-		pugi::xml_document doc;
-		doc.load_file(path.c_str());
-
-		pugi::xml_node root = doc.child("theme");
-		crawlIncludes(root, sets, dequepath);
-		findRegion(doc, sets);
-		dequepath.pop_back();
-	}
-
-	return sets;
-}
-
 std::vector<std::string> ThemeData::getSubSet(const std::vector<Subset>& subsets, const std::string& subset)
 {
 	std::vector<std::string> ret;
 
 	for (const auto& it : subsets)
-	{
 		if (it.subset == subset)
 			ret.push_back(it.name);
-	}
 
 	return ret;
 }
 
-
-void ThemeData::crawlIncludes(const pugi::xml_node& root, std::vector<Subset>& sets, std::deque<std::string>& dequepath)
-{
-	for (pugi::xml_node node = root.child("include"); node; node = node.next_sibling("include"))
-	{
-		std::string name = node.attribute("name").as_string();
-		std::string subset = node.attribute("subset").as_string();
-		if (!subset.empty())
-		{
-			bool add = true;
-
-			for (auto sb : sets) {
-				if (sb.subset == subset && sb.name == name) {
-					add = false; break;
-				}
-			}
-
-			if (add)
-				sets.push_back(Subset(subset, name));
-		}
-		//	sets.insert(std::pair<std::string, std::string>(name, subset));
-
-		const char* relPath = node.text().get();
-		std::string path = Utils::FileSystem::resolveRelativePath(relPath, dequepath.back(), true);
-
-		dequepath.push_back(path);
-		pugi::xml_document includeDoc;
-		includeDoc.load_file(path.c_str());
-
-		pugi::xml_node root = includeDoc.child("theme");
-		crawlIncludes(root, sets, dequepath);
-		findRegion(includeDoc, sets);
-		dequepath.pop_back();
-	}
-}
-
-void ThemeData::findRegion(const pugi::xml_document& doc, std::vector<Subset>& sets)
-{
-	pugi::xpath_node_set regionattr = doc.select_nodes("//@region");
-	for (auto xpath_node : regionattr)
-	{
-		if (xpath_node.attribute() == nullptr)
-			continue;
-		
-		std::string elemKey = xpath_node.attribute().value();
-		if (elemKey.empty())
-			continue;
-
-		for (auto sb : sets)
-			if (sb.subset == "region" && sb.name == elemKey)
-				return;
-
-		sets.push_back(Subset("region", elemKey));
-	}
-}

--- a/es-core/src/ThemeData.h
+++ b/es-core/src/ThemeData.h
@@ -236,13 +236,12 @@ public:
 	static std::map<std::string, ThemeSet> getThemeSets();
 	static std::string getThemeFromCurrentSet(const std::string& system);
 	
-	bool hasSubsets() { return mHasSubsets; }
+	bool hasSubsets() { return mSubsets.size() > 0; }
 	static const std::shared_ptr<ThemeData::ThemeMenu>& getMenuTheme();
 
-	static std::vector<Subset>		getThemeSubSets(const std::string& theme);
+	std::vector<Subset>		getSubSets() { return mSubsets; }
+
 	static std::vector<std::string> getSubSet(const std::vector<Subset>& subsets, const std::string& subset);
-	static void findRegion(const pugi::xml_document& doc, std::vector<Subset>& sets);
-	static void crawlIncludes(const pugi::xml_node& root, std::vector<Subset>& sets, std::deque<std::string>& dequepath);
 
 	static void setDefaultTheme(ThemeData* theme);
 	static ThemeData* getDefaultTheme() { return mDefaultTheme; }
@@ -286,11 +285,12 @@ private:
 	std::string mMenu;
 	std::string mSystemview;
 	std::string mGamelistview;
-	std::string mSystemThemeFolder;
-	bool mHasSubsets;
+	std::string mSystemThemeFolder;	
 	
 	std::map<std::string, std::string> mVariables;
 	std::map<std::string, ThemeView> mViews;
+
+	std::vector<Subset> mSubsets;
 
 	static std::shared_ptr<ThemeData::ThemeMenu> mMenuTheme;
 	static ThemeData* mDefaultTheme;	

--- a/es-core/src/components/GridTileComponent.cpp
+++ b/es-core/src/components/GridTileComponent.cpp
@@ -104,7 +104,7 @@ std::shared_ptr<TextureResource> GridTileComponent::getTexture()
 
 void GridTileComponent::resize()
 {
-	const GridTileProperties& currentProperties = getCurrentProperties();
+	auto currentProperties = getCurrentProperties();
 
 	Vector2f size = currentProperties.mSize;
 	if (mSize != size)
@@ -270,17 +270,19 @@ void GridTileComponent::renderContent(const Transform4x4f& parentTrans)
 	if (!Renderer::isVisibleOnScreen(clipPos.x(), clipPos.y(), mSize.x(), mSize.y()))
 		return;
 
-	float padding = getCurrentProperties().mPadding.x();
-	float topPadding = getCurrentProperties().mPadding.y();
+	auto currentProperties = getCurrentProperties();
+
+	float padding = currentProperties.mPadding.x();
+	float topPadding = currentProperties.mPadding.y();
 	float bottomPadding = topPadding;
 
 	if (mLabelVisible && !mLabelMerged)
-		bottomPadding = std::max((int)topPadding, (int)(mSize.y() * getCurrentProperties().mLabelSize.y()));
+		bottomPadding = std::max((int)topPadding, (int)(mSize.y() * currentProperties.mLabelSize.y()));
 
 	Vector2i pos((int)Math::round(trans.translation()[0] + padding), (int)Math::round(trans.translation()[1] + topPadding));
 	Vector2i size((int)Math::round(mSize.x() - 2 * padding), (int)Math::round(mSize.y() - topPadding - bottomPadding));
 	
-	if (getCurrentProperties().mImageSizeMode == "minSize")
+	if (currentProperties.mImageSizeMode == "minSize")
 		Renderer::pushClipRect(pos, size);
 
 	if (mImage != NULL)
@@ -289,13 +291,13 @@ void GridTileComponent::renderContent(const Transform4x4f& parentTrans)
 	if (mSelected && !mVideoPath.empty() && mVideo != nullptr)
 		mVideo->render(trans);
 
-	if (!mLabelMerged && getCurrentProperties().mImageSizeMode == "minSize")
+	if (!mLabelMerged && currentProperties.mImageSizeMode == "minSize")
 		Renderer::popClipRect();
 
-	if (mLabelVisible && getCurrentProperties().mLabelSize.y()>0)
+	if (mLabelVisible && currentProperties.mLabelSize.y()>0)
 		mLabel.render(trans);
 
-	if (mLabelMerged && getCurrentProperties().mImageSizeMode == "minSize")
+	if (mLabelMerged && currentProperties.mImageSizeMode == "minSize")
 		Renderer::popClipRect();
 }
 
@@ -548,7 +550,7 @@ void GridTileComponent::setImage(const std::string& path)
 	resize();	
 }
 
-void GridTileComponent::reset()
+void GridTileComponent::resetImages()
 {
 	setLabel("");
 	setVideo("");
@@ -701,8 +703,10 @@ void GridTileComponent::setVisible(bool visible)
 	mVisible = visible;
 }
 
-const GridTileProperties& GridTileComponent::getCurrentProperties() 
+GridTileProperties GridTileComponent::getCurrentProperties() 
 {
+	GridTileProperties mMixedProperties;
+
 	if (mSelectedZoomPercent == 0.0f || mSelectedZoomPercent == 1.0f)
 		return mSelected ? mSelectedProperties : mDefaultProperties;
 

--- a/es-core/src/components/GridTileComponent.h
+++ b/es-core/src/components/GridTileComponent.h
@@ -6,8 +6,8 @@
 #include "ImageComponent.h"
 #include "TextComponent.h"
 
-
 class VideoComponent;
+
 struct GridTileProperties
 {
 	Vector2f mSize;
@@ -32,10 +32,6 @@ struct GridTileProperties
 	unsigned int	mFontSize;
 
 	Vector2f		mMirror;
-
-	/*
-	<fontPath>. / main / fonts / Dosis - Bold.ttf< / fontPath>
-		<fontSize>0.025< / fontSize>*/
 };
 
 class GridTileComponent : public GuiComponent
@@ -54,7 +50,7 @@ public:
 	Vector2f getSelectedTileSize() const;
 	bool isSelected() const;
 
-	void reset();
+	void resetImages();
 
 	void setLabel(std::string name);
 	void setVideo(const std::string& path, float defaultDelay = -1.0);
@@ -84,7 +80,7 @@ private:
 	void	createVideo();
 
 	void resize();
-	const GridTileProperties& getCurrentProperties();
+	GridTileProperties getCurrentProperties();
 
 	std::shared_ptr<ImageComponent> mImage;
 
@@ -96,8 +92,7 @@ private:
 	NinePatchComponent mBackground;
 
 	GridTileProperties mDefaultProperties;
-	GridTileProperties mSelectedProperties;
-	GridTileProperties mMixedProperties;
+	GridTileProperties mSelectedProperties;	
 
 	std::string mCurrentPath;
 	std::string mVideoPath;

--- a/es-core/src/components/ImageGridComponent.h
+++ b/es-core/src/components/ImageGridComponent.h
@@ -158,6 +158,8 @@ ImageGridComponent<T>::ImageGridComponent(Window* window) : IList<ImageGridData,
 	mCenterSelection = false;
 	mScrollLoop = false;
 	mScrollDirection = SCROLL_VERTICALLY;
+
+	mCursorChangedCallback = nullptr;
 }
 
 template<typename T>
@@ -528,8 +530,7 @@ void ImageGridComponent<T>::onCursorChanged(const CursorState& state)
 			mCursorChangedCallback(state);
 
 		return;
-	}
-	
+	}	
 		
 	bool direction = mCursor >= mLastCursor;
 
@@ -541,6 +542,8 @@ void ImageGridComponent<T>::onCursorChanged(const CursorState& state)
 
 	float dimScrollable = isVertical() ? mGridDimension.y() - 2 * EXTRAITEMS : mGridDimension.x() - 2 * EXTRAITEMS;
 	float dimOpposite = isVertical() ? mGridDimension.x() : mGridDimension.y();
+	if (dimOpposite == 0)
+		dimOpposite = 1;
 
 	int centralCol = (int)(dimScrollable - 0.5) / 2;
 	int maxCentralCol = (int)(dimScrollable) / 2;
@@ -767,7 +770,7 @@ void ImageGridComponent<T>::updateTileAtPos(int tilePos, int imgPos, bool allowA
 		if (updateSelectedState)
 			tile->setSelected(false, allowAnimation);
 
-		tile->reset();
+		tile->resetImages();
 		tile->setVisible(false);
 	}
 	else
@@ -875,13 +878,10 @@ void ImageGridComponent<T>::buildTiles()
 			// In Horizontal mod, tiles are ordered from top to bottom, then from left to right
 			X = vert ? x : y - EXTRAITEMS;
 			Y = vert ? y - EXTRAITEMS : x;
-			
-			//if (!isVertical())
-			//	X--;
 
 			tile->setPosition(X * tileDistance.x() + startPosition.x(), Y * tileDistance.y() + startPosition.y());
 			tile->setOrigin(0.5f, 0.5f);
-			tile->reset();
+	//		tile->resetImages();
 
 			if (mTheme)
 				tile->applyTheme(mTheme, mName, "gridtile", ThemeFlags::ALL);

--- a/es-core/src/components/TextComponent.h
+++ b/es-core/src/components/TextComponent.h
@@ -56,6 +56,7 @@ protected:
 
 private:
 	void calculateExtent();
+	void renderSingleGlow(const Transform4x4f& parentTrans, float yOff, float x, float y);
 
 	void onColorChanged();
 

--- a/es-core/src/renderers/Renderer.cpp
+++ b/es-core/src/renderers/Renderer.cpp
@@ -316,6 +316,12 @@ namespace Renderer
 		if (clipStack.empty())
 			return true;
 
+		if (nativeClipStack.empty())
+		{
+			LOG(LogDebug) << "Renderer::isVisibleOnScreen used without any clip stack!";
+			return true;
+		}
+
 		screen = nativeClipStack.top();
 		return rectOverlap(screen, box);
 	}

--- a/es-core/src/resources/TextureDataManager.h
+++ b/es-core/src/resources/TextureDataManager.h
@@ -30,8 +30,7 @@ private:
 	void threadProc();
 
 	std::list<std::shared_ptr<TextureData>> 										mProcessingTextureDataQ;
-	std::list<std::shared_ptr<TextureData> > 										mTextureDataQ;
-	std::map<TextureData*, std::list<std::shared_ptr<TextureData> >::const_iterator > 	mTextureDataLookup;
+	std::list<std::shared_ptr<TextureData>> 										mTextureDataQ;
 
 	std::vector<std::thread>	mThreads;
 	std::mutex					mLoaderLock;


### PR DESCRIPTION
- TextComponent : reviewed glow code ( avoid using lambas ) - potential fix for rpi crash.
- TextureDataManager : Better threading, no more sleeping 10 ms to process the queue.
- Collection settings : fixed some settings were not saved.
- Screenscraper : Added "title screenshot" as source.
- ThemeData : Changed the way to collect subset to avoir reparsing the xml files + fixed tinyScreen & ifHelpPrompts attributes on view elements