### PR TITLE
 Filter : Add text search filter in gamelist options + misc fixes

### DIFF
--- a/es-app/src/FileData.cpp
+++ b/es-app/src/FileData.cpp
@@ -120,16 +120,6 @@ const std::string FileData::getName()
 	return metadata.getName();
 }
 
-const std::string FileData::getCore() const
-{
-	return metadata.get("core");	
-}
-
-const std::string FileData::getEmulator() const
-{
-	return metadata.get("emulator");
-}
-
 const std::string FileData::getVideoPath() const
 {
 	std::string video = metadata.get("video");
@@ -216,6 +206,7 @@ void FileData::launchGame(Window* window)
 
 	AudioManager::getInstance()->deinit(); // batocera
 	VolumeControl::getInstance()->deinit();
+
 	const std::string controllersConfig = InputManager::getInstance()->configureEmulators(); // batocera / must be done before window->deinit while it closes joysticks
 	window->deinit();
 
@@ -230,6 +221,18 @@ void FileData::launchGame(Window* window)
 	command = Utils::String::replace(command, "%BASENAME%", basename);
 	command = Utils::String::replace(command, "%ROM_RAW%", rom_raw);
 	command = Utils::String::replace(command, "%CONTROLLERSCONFIG%", controllersConfig); // batocera
+	
+	std::string emulator = SystemConf::getInstance()->get(Utils::FileSystem::getFileName(getPath()) + ".emulator");
+	if (emulator.length() == 0)		
+		emulator = SystemConf::getInstance()->get(mSystem->getFullName() + ".emulator");
+
+	std::string core = SystemConf::getInstance()->get(Utils::FileSystem::getFileName(getPath()) + ".core");
+	if (core.length() == 0)
+		core = SystemConf::getInstance()->get(mSystem->getFullName() + ".core");
+
+	command = Utils::String::replace(command, "%EMULATOR%", emulator);
+	command = Utils::String::replace(command, "%CORE%", core);
+	command = Utils::String::replace(command, "%HOME%", Utils::FileSystem::getHomePath());
 
 	Scripting::fireEvent("game-start", rom, basename);
 
@@ -345,8 +348,8 @@ FolderData::SortType getSortTypeFromString(std::string desc) {
 
 const std::vector<FileData*> FolderData::getChildrenListToDisplay() 
 {
-	if (mSystem->isCollection())
-		return mChildren;
+//	if (mSystem->isCollection())
+//		return mChildren;
 
 	std::vector<FileData*> ret;
 

--- a/es-app/src/FileData.h
+++ b/es-app/src/FileData.h
@@ -52,9 +52,6 @@ public:
 	virtual const std::string getMarqueePath() const;
 	virtual const std::string getImagePath() const;
 
-	virtual const std::string getCore() const;
-	virtual const std::string getEmulator() const;
-
 	virtual const bool getHidden();
 	virtual const bool getFavorite();
 	virtual const bool getKidGame();

--- a/es-app/src/FileFilterIndex.cpp
+++ b/es-app/src/FileFilterIndex.cpp
@@ -296,6 +296,11 @@ void FileFilterIndex::debugPrintIndexes()
 	}
 }
 
+void FileFilterIndex::setTextFilter(const std::string text) 
+{ 
+	mTextFilter = Utils::String::toUpper(text);
+}
+
 bool FileFilterIndex::showFile(FileData* game)
 {
 	// this shouldn't happen, but just in case let's get it out of the way
@@ -318,6 +323,9 @@ bool FileFilterIndex::showFile(FileData* game)
 	}
 
 	bool keepGoing = false;
+
+	if (!mTextFilter.empty() && Utils::String::toUpper(game->getName()).find(mTextFilter) != std::string::npos)
+		keepGoing = true;
 
 	for (std::vector<FilterDataDecl>::const_iterator it = filterDataDecl.cbegin(); it != filterDataDecl.cend(); ++it ) {
 		FilterDataDecl filterData = (*it);

--- a/es-app/src/FileFilterIndex.h
+++ b/es-app/src/FileFilterIndex.h
@@ -42,7 +42,7 @@ public:
 	void clearAllFilters();
 	void debugPrintIndexes();
 	bool showFile(FileData* game);
-	bool isFiltered() { return (filterByGenre || filterByPlayers || filterByPubDev || filterByRatings || filterByFavorites || filterByHidden || filterByKidGame); };
+	bool isFiltered() { return (!mTextFilter.empty() || filterByGenre || filterByPlayers || filterByPubDev || filterByRatings || filterByFavorites || filterByHidden || filterByKidGame); };
 	bool isKeyBeingFilteredBy(std::string key, FilterIndexType type);
 	std::vector<FilterDataDecl>& getFilterDataDecls();
 
@@ -50,6 +50,9 @@ public:
 	void resetIndex();
 	void resetFilters();
 	void setUIModeFilters();
+
+	void setTextFilter(const std::string text);
+	inline const std::string getTextFilter() { return mTextFilter; }
 
 private:
 	std::vector<FilterDataDecl> filterDataDecl;
@@ -92,6 +95,8 @@ private:
 	std::vector<std::string> kidGameIndexFilteredKeys;
 
 	FileData* mRootFolder;
+
+	std::string mTextFilter;
 
 };
 

--- a/es-app/src/guis/GuiGamelistFilter.h
+++ b/es-app/src/guis/GuiGamelistFilter.h
@@ -24,12 +24,15 @@ private:
 	void applyFilters();
 	void resetAllFilters();
 	void addFiltersToMenu();
+	void addTextFilterToMenu();
 
 	std::map<FilterIndexType, std::shared_ptr< OptionListComponent<std::string> >> mFilterOptions;
 
 	MenuComponent mMenu;
 	SystemData* mSystem;
 	FileFilterIndex* mFilterIndex;
+
+	std::shared_ptr<GuiComponent> mTextFilter;
 };
 
 #endif // ES_APP_GUIS_GUI_GAME_LIST_FILTER_H

--- a/es-app/src/guis/GuiGamelistOptions.h
+++ b/es-app/src/guis/GuiGamelistOptions.h
@@ -24,7 +24,8 @@ public:
 
 private:
 	inline void addSaveFunc(const std::function<void()>& func) { mSaveFuncs.push_back(func); };
-
+	
+	void addTextFilterToMenu();
 	void openGamelistFilter();
 	void openMetaDataEd();
 	void startEditMode();
@@ -38,6 +39,8 @@ private:
 
 	typedef OptionListComponent<unsigned int> SortList;
 	std::shared_ptr<SortList> mListSort;
+
+	std::shared_ptr<GuiComponent> mTextFilter;
 
 	std::shared_ptr<OptionListComponent<std::string>> mViewMode;
 	std::shared_ptr<OptionListComponent<std::string>> mGridSize;

--- a/es-app/src/views/SystemView.cpp
+++ b/es-app/src/views/SystemView.cpp
@@ -561,7 +561,7 @@ void  SystemView::getViewElements(const std::shared_ptr<ThemeData>& theme)
 	if (sysInfoElem)
 		mSystemInfo.applyTheme(theme, "system", "systemInfo", ThemeFlags::ALL);
 
-	const ThemeData::ThemeElement* fixedBackgroundElem = theme->getElement("system", "fixedBackground", "image");
+	const ThemeData::ThemeElement* fixedBackgroundElem = theme->getElement("system", "staticBackground", "image");
 	if (fixedBackgroundElem)
 	{
 		if (mStaticBackground == nullptr)

--- a/es-app/src/views/SystemView.cpp
+++ b/es-app/src/views/SystemView.cpp
@@ -243,6 +243,17 @@ bool SystemView::input(InputConfig* config, Input input)
 				listInput(1);
 				return true;
 			}
+			if (config->isMappedTo("pagedown", input))
+			{
+				listInput(10);
+				return true;
+			}
+			if (config->isMappedTo("pageup", input))
+			{
+				listInput(-10);
+				return true;
+			}
+
 			break;
 		case HORIZONTAL:
 		case HORIZONTAL_WHEEL:
@@ -257,6 +268,17 @@ bool SystemView::input(InputConfig* config, Input input)
 				listInput(1);
 				return true;
 			}
+			if (config->isMappedTo("pagedown", input))
+			{
+				listInput(10);
+				return true;
+			}
+			if (config->isMappedTo("pageup", input))
+			{
+				listInput(-10);
+				return true;
+			}
+
 			break;
 		}
 
@@ -283,7 +305,9 @@ bool SystemView::input(InputConfig* config, Input input)
 		if(config->isMappedLike("left", input) ||
 			config->isMappedLike("right", input) ||
 			config->isMappedLike("up", input) ||
-			config->isMappedLike("down", input))
+			config->isMappedLike("down", input) ||
+			config->isMappedLike("pagedown", input) ||
+			config->isMappedLike("pageup", input))
 			listInput(0);
 		// batocera
 		//if(!UIModeController::getInstance()->isUIModeKid() && config->isMappedTo("select", input) && Settings::getInstance()->getBool("ScreenSaverControls"))

--- a/es-app/src/views/gamelist/GridGameListView.cpp
+++ b/es-app/src/views/gamelist/GridGameListView.cpp
@@ -164,12 +164,14 @@ void GridGameListView::setCursor(FileData* file)
 
 std::string GridGameListView::getQuickSystemSelectRightButton()
 {
-	return "pagedown"; //rightshoulder
+	return "r2"; //rightshoulder
+	//return "pagedown"; //rightshoulder
 }
 
 std::string GridGameListView::getQuickSystemSelectLeftButton()
 {
-	return "pageup"; //leftshoulder
+	return "l2"; //leftshoulder
+	//return "pageup"; //leftshoulder
 }
 
 bool GridGameListView::input(InputConfig* config, Input input)

--- a/es-app/src/views/gamelist/ISimpleGameListView.cpp
+++ b/es-app/src/views/gamelist/ISimpleGameListView.cpp
@@ -124,7 +124,7 @@ bool ISimpleGameListView::input(InputConfig* config, Input input)
 			}
 
 			return true;
-		}else if(config->isMappedLike(getQuickSystemSelectRightButton(), input))
+		}else if(config->isMappedLike(getQuickSystemSelectRightButton(), input) || config->isMappedLike("r2", input))
 		{
 			if(Settings::getInstance()->getBool("QuickSystemSelect"))
 			{
@@ -132,7 +132,7 @@ bool ISimpleGameListView::input(InputConfig* config, Input input)
 				ViewController::get()->goToNextGameList();
 				return true;
 			}
-		}else if(config->isMappedLike(getQuickSystemSelectLeftButton(), input))
+		}else if(config->isMappedLike(getQuickSystemSelectLeftButton(), input) || config->isMappedLike("l2", input))
 		{
 			if(Settings::getInstance()->getBool("QuickSystemSelect"))
 			{

--- a/es-core/src/Settings.cpp
+++ b/es-core/src/Settings.cpp
@@ -154,7 +154,7 @@ void Settings::setDefaults()
 	mBoolMap["CaptionsCompatibility"] = true;
 	// Audio out device for Video playback using OMX player.
 	mStringMap["OMXAudioDev"] = "both";
-	mStringMap["CollectionSystemsAuto"] = "2players,4players,favorites,recent"; // batocera
+	mStringMap["CollectionSystemsAuto"] = "all,favorites"; // batocera 2players,4players,favorites,recent
 	mStringMap["CollectionSystemsCustom"] = "";
 	mBoolMap["SortAllSystems"] = true; // batocera
 	mBoolMap["UseCustomCollectionsSystem"] = true;

--- a/es-core/src/ThemeData.cpp
+++ b/es-core/src/ThemeData.cpp
@@ -236,6 +236,9 @@ std::map<std::string, std::map<std::string, ThemeData::ElementPropertyType>> The
 	{ "menuSwitch",{
 		{ "pathOn", PATH },
 		{ "pathOff", PATH } } },
+	{ "menuTextEdit",{
+		{ "active", PATH },
+		{ "inactive", PATH } } },
 	{ "menuSlider",{
 		{ "path", PATH } } },
 	{ "menuButton",{
@@ -1175,6 +1178,15 @@ ThemeData::ThemeMenu::ThemeMenu(ThemeData* theme)
 			Icons.button = elem->get<std::string>("path");
 		if (elem->has("filledPath"))
 			Icons.button_filled = elem->get<std::string>("filledPath");
+	}
+
+	elem = theme->getElement("menu", "menutextedit", "menuTextEdit");
+	if (elem)
+	{
+		if (elem->has("active") && ResourceManager::getInstance()->fileExists(elem->get<std::string>("active")))
+			Icons.textinput_ninepatch_active = elem->get<std::string>("active");
+		if (elem->has("inactive") && ResourceManager::getInstance()->fileExists(elem->get<std::string>("inactive")))
+			Icons.textinput_ninepatch = elem->get<std::string>("inactive");
 	}
 
 	elem = theme->getElement("menu", "menuswitch", "menuSwitch");

--- a/es-core/src/ThemeData.cpp
+++ b/es-core/src/ThemeData.cpp
@@ -184,8 +184,9 @@ std::map<std::string, std::map<std::string, ThemeData::ElementPropertyType>> The
 		{ "default", PATH },
 		{ "path", PATH },
 		{ "delay", FLOAT },
+		{ "effect", STRING },
 	 	{ "visible", BOOLEAN },
-	 	{ "zIndex", FLOAT },
+	 	{ "zIndex", FLOAT },		
 		{ "showSnapshotNoVideo", BOOLEAN },
 		{ "showSnapshotDelay", BOOLEAN } } },
 	{ "carousel", {

--- a/es-core/src/ThemeData.h
+++ b/es-core/src/ThemeData.h
@@ -121,6 +121,8 @@ struct IconElement
 	std::string option_arrow;
 	std::string arrow;
 	std::string knob;
+	std::string textinput_ninepatch;
+	std::string textinput_ninepatch_active;
 };
 
 class ThemeData
@@ -136,7 +138,7 @@ public:
 		MenuElement Text{ 0x777777FF, 0xFFFFFFFF, 0x878787FF, 0xC6C7C6FF, 0x878787FF, true, "", "", nullptr };
 		MenuElement TextSmall{ 0x777777FF, 0xFFFFFFFF, 0x878787FF, 0xC6C7C6FF, 0x878787FF, true, "", "", nullptr };
 		MenuElement Footer{ 0xC6C6C6FF, 0xC6C6C6FF, 0xC6C6C6FF, 0xFFFFFFFF, 0xC6C6C6FF, true, "", "", nullptr };
-		IconElement Icons{ ":/button.png", ":/button_filled.png", ":/on.svg", ":/off.svg", ":/option_arrow.svg", ":/arrow.svg", ":/slider_knob.svg" };
+		IconElement Icons{ ":/button.png", ":/button_filled.png", ":/on.svg", ":/off.svg", ":/option_arrow.svg", ":/arrow.svg", ":/slider_knob.svg", ":/textinput_ninepatch.png", ":/textinput_ninepatch_active.png" };
 
 		std::string getMenuIcon(const std::string name)
 		{

--- a/es-core/src/components/GridTileComponent.h
+++ b/es-core/src/components/GridTileComponent.h
@@ -78,6 +78,9 @@ public:
 private:
 	void	resetProperties();
 	void	createVideo();
+	
+	void	startVideo();
+	void	stopVideo();
 
 	void resize();
 	GridTileProperties getCurrentProperties();

--- a/es-core/src/components/ImageGridComponent.h
+++ b/es-core/src/components/ImageGridComponent.h
@@ -192,7 +192,21 @@ bool ImageGridComponent<T>::input(InputConfig* config, Input input)
 			dir[0 ^ idx] = -1;
 		else if(config->isMappedLike("right", input))
 			dir[0 ^ idx] = 1;
-
+		else  if (config->isMappedTo("pageup", input))
+		{
+			if (isVertical())
+				dir[1 ^ idx] = -10;
+			else
+				dir[0 ^ idx] = -10;
+		}
+		else if (config->isMappedTo("pagedown", input))
+		{
+			if (isVertical())
+				dir[1 ^ idx] = 10;
+			else
+				dir[0 ^ idx] = 10;
+		}
+		
 		if(dir != Vector2i::Zero())
 		{
 			if (isVertical())
@@ -203,7 +217,9 @@ bool ImageGridComponent<T>::input(InputConfig* config, Input input)
 			return true;
 		}
 	}else{
-		if(config->isMappedLike("up", input) || config->isMappedLike("down", input) || config->isMappedLike("left", input) || config->isMappedLike("right", input))
+		if(config->isMappedLike("up", input) || config->isMappedLike("down", input) || 
+			config->isMappedLike("left", input) || config->isMappedLike("right", input) ||
+			config->isMappedTo("pagedown", input) || config->isMappedTo("pageup", input))
 		{
 			stopScrolling();
 		}

--- a/es-core/src/components/MenuComponent.cpp
+++ b/es-core/src/components/MenuComponent.cpp
@@ -10,6 +10,8 @@
 MenuComponent::MenuComponent(Window* window, const char* title, const std::shared_ptr<Font>& titleFont) : GuiComponent(window),
 	mBackground(window), mGrid(window, Vector2i(1, 3))
 {
+	mMaxHeight = 0;
+
 	auto theme = ThemeData::getMenuTheme();
 
 	addChild(&mBackground);
@@ -149,7 +151,8 @@ void MenuComponent::updateSize()
 		return;
 	}
 
-	const float maxHeight = Renderer::getScreenHeight() * 0.75f;
+	const float maxHeight = mMaxHeight <= 0 ? Renderer::getScreenHeight() * 0.75f : mMaxHeight;
+
 	float height = TITLE_HEIGHT + mList->getTotalRowHeight() + getButtonGridHeight() + 2;
 	if(height > maxHeight)
 	{

--- a/es-core/src/components/MenuComponent.h
+++ b/es-core/src/components/MenuComponent.h
@@ -39,6 +39,15 @@ public:
 
 	float getButtonGridHeight() const;
 
+	void setMaxHeight(float maxHeight) 
+	{ 
+		if (mMaxHeight == maxHeight)
+			return;
+
+		mMaxHeight = maxHeight; 
+		updateSize();
+	}
+
 private:
 	void updateSize();
 	void updateGrid();
@@ -50,6 +59,8 @@ private:
 	std::shared_ptr<ComponentList> mList;
 	std::shared_ptr<ComponentGrid> mButtonGrid;
 	std::vector< std::shared_ptr<ButtonComponent> > mButtons;
+
+	float mMaxHeight;
 };
 
 #endif // ES_CORE_COMPONENTS_MENU_COMPONENT_H

--- a/es-core/src/components/TextEditComponent.h
+++ b/es-core/src/components/TextEditComponent.h
@@ -62,6 +62,8 @@ private:
 
 	std::shared_ptr<Font> mFont;
 	std::unique_ptr<TextCache> mTextCache;
+
+	int mBlinkTime;
 };
 
 #endif // ES_CORE_COMPONENTS_TEXT_EDIT_COMPONENT_H

--- a/es-core/src/components/VideoPlayerComponent.cpp
+++ b/es-core/src/components/VideoPlayerComponent.cpp
@@ -170,7 +170,8 @@ void VideoPlayerComponent::startVideo()
 				// We need to specify the layer of 10000 or above to ensure the video is displayed on top
 				// of our SDL display
 
-				const char* argv[] = { "", "--layer", "10010", "--loop", "--no-osd", "--aspect-mode", "letterbox", "--vol", "0", "-o", "both","--win", buf1, "--orientation", buf2, "", "", "", "", "", "", "", "", "", "", "", NULL };
+				//const char* argv[] = { "", "--layer", "10010", "--loop", "--no-osd", "--aspect-mode", "letterbox", "--vol", "0", "-o", "both","--win", buf1, "--orientation", buf2, "", "", "", "", "", "", "", "", "", "", "", NULL };
+				const char* argv[] = { "", "--layer", "10010", "--loop", "--no-osd", "--aspect-mode", "letterbox", "--vol", "0", "-o", "both","--win", buf1, "--orientation", buf2, "", "", "", "", NULL };
 
 				// check if we want to mute the audio
 				if (!Settings::getInstance()->getBool("VideoAudio") || (float)VolumeControl::getInstance()->getVolume() == 0)
@@ -201,6 +202,7 @@ void VideoPlayerComponent::startVideo()
 						argv[15] = "--subtitles";
 						argv[16] = subtitlePath.c_str();
 						argv[17] = mPlayingVideoPath.c_str();
+						/*
 						argv[18] = "--font";
 						argv[19] = Settings::getInstance()->getString("SubtitleFont").c_str();
 						argv[20] = "--italic-font";
@@ -208,7 +210,7 @@ void VideoPlayerComponent::startVideo()
 						argv[22] = "--font-size";
 						argv[23] = std::to_string(Settings::getInstance()->getInt("SubtitleSize")).c_str();
 						argv[24] = "--align";
-						argv[25] = Settings::getInstance()->getString("SubtitleAlignment").c_str();
+						argv[25] = Settings::getInstance()->getString("SubtitleAlignment").c_str();*/
 					}
 					else
 					{

--- a/es-core/src/components/VideoPlayerComponent.cpp
+++ b/es-core/src/components/VideoPlayerComponent.cpp
@@ -5,6 +5,7 @@
 #include "utils/StringUtil.h"
 #include "AudioManager.h"
 #include "Settings.h"
+#include "math/Misc.h"
 #include <fcntl.h>
 #include <unistd.h>
 #include <wait.h>
@@ -118,40 +119,40 @@ void VideoPlayerComponent::startVideo()
 				{
 					case 0:
 					{
-						const int x1 = (int)(Renderer::getScreenOffsetX() + x);
-						const int y1 = (int)(Renderer::getScreenOffsetY() + y);
-						const int x2 = (int)(x1 + mSize.x());
-						const int y2 = (int)(y1 + mSize.y());
+						const int x1 = (int)Math::round(Renderer::getScreenOffsetX() + x);
+						const int y1 = (int)Math::round(Renderer::getScreenOffsetY() + y);
+						const int x2 = (int)Math::round(x1 + mSize.x());
+						const int y2 = (int)Math::round(y1 + mSize.y());
 						sprintf(buf1, "%d,%d,%d,%d", x1, y1, x2, y2);
 					}
 					break;
 
 					case 1:
 					{
-						const int x1 = (int)(Renderer::getScreenWidth() - Renderer::getScreenOffsetY() - y - mSize.y());
-						const int y1 = (int)(Renderer::getScreenOffsetX() + x);
-						const int x2 = (int)(x1 + mSize.y());
-						const int y2 = (int)(y1 + mSize.x());
+						const int x1 = (int)Math::round((Renderer::getScreenWidth() - Renderer::getScreenOffsetY() - y - mSize.y());
+						const int y1 = (int)Math::round(Renderer::getScreenOffsetX() + x);
+						const int x2 = (int)Math::round(x1 + mSize.y());
+						const int y2 = (int)Math::round(y1 + mSize.x());
 						sprintf(buf1, "%d,%d,%d,%d", x1, y1, x2, y2);
 					}
 					break;
 
 					case 2:
 					{
-						const int x1 = (int)(Renderer::getScreenWidth()  - Renderer::getScreenOffsetX() - x - mSize.x());
-						const int y1 = (int)(Renderer::getScreenHeight() - Renderer::getScreenOffsetY() - y - mSize.y());
-						const int x2 = (int)(x1 + mSize.x());
-						const int y2 = (int)(y1 + mSize.y());
+						const int x1 = (int)Math::round(Renderer::getScreenWidth()  - Renderer::getScreenOffsetX() - x - mSize.x());
+						const int y1 = (int)Math::round(Renderer::getScreenHeight() - Renderer::getScreenOffsetY() - y - mSize.y());
+						const int x2 = (int)Math::round(x1 + mSize.x());
+						const int y2 = (int)Math::round(y1 + mSize.y());
 						sprintf(buf1, "%d,%d,%d,%d", x1, y1, x2, y2);
 					}
 					break;
 
 					case 3:
 					{
-						const int x1 = (int)(Renderer::getScreenOffsetY() + y);
-						const int y1 = (int)(Renderer::getScreenHeight() - Renderer::getScreenOffsetX() - x - mSize.x());
-						const int x2 = (int)(x1 + mSize.y());
-						const int y2 = (int)(y1 + mSize.x());
+						const int x1 = (int)Math::round(Renderer::getScreenOffsetY() + y);
+						const int y1 = (int)Math::round(Renderer::getScreenHeight() - Renderer::getScreenOffsetX() - x - mSize.x());
+						const int x2 = (int)Math::round(x1 + mSize.y());
+						const int y2 = (int)Math::round(y1 + mSize.x());
 						sprintf(buf1, "%d,%d,%d,%d", x1, y1, x2, y2);
 					}
 					break;

--- a/es-core/src/components/VideoVlcComponent.h
+++ b/es-core/src/components/VideoVlcComponent.h
@@ -28,6 +28,16 @@ struct VideoContext
 	bool				hasFrame;
 };
 
+
+namespace VideoVlcFlags
+{
+	enum VideoVlcEffect
+	{
+		NONE,
+		BUMP
+	};
+}
+
 class VideoVlcComponent : public VideoComponent
 {
 	// Structure that groups together the configuration of the video component
@@ -59,6 +69,8 @@ public:
 	void setMaxSize(float width, float height);
 	void setMinSize(float width, float height);
 
+	virtual void applyTheme(const std::shared_ptr<ThemeData>& theme, const std::string& view, const std::string& element, unsigned int properties);
+
 private:
 	// Calculates the correct mSize from our resizing information (set by setResize/setMaxSize).
 	// Used internally whenever the resizing parameters or texture change.
@@ -75,6 +87,8 @@ private:
 	void setupContext();
 	void freeContext();
 
+	void setEffect(VideoVlcFlags::VideoVlcEffect effect) { mEffect = effect; }
+
 private:
 	static libvlc_instance_t*		mVLC;
 	libvlc_media_t*					mMedia;
@@ -84,6 +98,8 @@ private:
 
 	std::string					    mSubtitlePath;
 	std::string					    mSubtitleTmpFile;
+
+	VideoVlcFlags::VideoVlcEffect	mEffect;
 };
 
 #endif // ES_CORE_COMPONENTS_VIDEO_VLC_COMPONENT_H

--- a/es-core/src/guis/GuiTextEditPopup.cpp
+++ b/es-core/src/guis/GuiTextEditPopup.cpp
@@ -27,6 +27,7 @@ GuiTextEditPopup::GuiTextEditPopup(Window* window, const std::string& title, con
 
 	std::vector< std::shared_ptr<ButtonComponent> > buttons;
 	buttons.push_back(std::make_shared<ButtonComponent>(mWindow, acceptBtnText, acceptBtnText, [this, okCallback] { okCallback(mText->getValue()); delete this; }));
+	buttons.push_back(std::make_shared<ButtonComponent>(mWindow, _("RESET"), _("RESET"), [this, okCallback] { okCallback(""); delete this; }));
 	buttons.push_back(std::make_shared<ButtonComponent>(mWindow, _("CANCEL"), _("DISCARD CHANGES"), [this] { delete this; })); // batocera
 
 	mButtonGrid = makeButtonGrid(mWindow, buttons);

--- a/es-core/src/guis/GuiTextEditPopupKeyboard.cpp
+++ b/es-core/src/guis/GuiTextEditPopupKeyboard.cpp
@@ -64,7 +64,10 @@ GuiTextEditPopupKeyboard::GuiTextEditPopupKeyboard(Window* window, const std::st
 		mText->stopEditing();
 	});
 
-	space->setSize(space->getSize().x() * 3, space->getSize().y());
+	if (Renderer::isSmallScreen())
+		space->setSize(space->getSize().x(), space->getSize().y());
+	else
+		space->setSize(space->getSize().x() * 3, space->getSize().y());
 
 	buttons.push_back(space);
 	buttons.push_back(std::make_shared<ButtonComponent>(mWindow, _("DELETE"), _("DELETE A CHAR"), [this] {
@@ -72,6 +75,9 @@ GuiTextEditPopupKeyboard::GuiTextEditPopupKeyboard(Window* window, const std::st
 		mText->textInput("\b");
 		mText->stopEditing();
 	}));
+
+	buttons.push_back(std::make_shared<ButtonComponent>(mWindow, _("RESET"), _("RESET"), [this, okCallback] { okCallback(""); delete this; }));
+
 	buttons.push_back(std::make_shared<ButtonComponent>(mWindow, _("CANCEL"), _("DISCARD CHANGES"), [this] { delete this; }));
 
 	// Add buttons
@@ -239,10 +245,10 @@ bool GuiTextEditPopupKeyboard::input(InputConfig* config, Input input)
 
 	return false;
 }
-
+/*
 void GuiTextEditPopupKeyboard::update(int deltatime) {
 
-}
+}*/
 
 // Shifts the keys when user hits the shift button.
 void GuiTextEditPopupKeyboard::shiftKeys() 

--- a/es-core/src/guis/GuiTextEditPopupKeyboard.h
+++ b/es-core/src/guis/GuiTextEditPopupKeyboard.h
@@ -13,7 +13,7 @@ public:
 		const std::function<void(const std::string&)>& okCallback, bool multiLine, const std::string acceptBtnText = "OK");
 
 	bool input(InputConfig* config, Input input);
-	void update(int deltatime) override;
+	//void update(int deltatime) override;
 	void onSizeChanged();
 	std::vector<HelpPrompt> getHelpPrompts() override;
 

--- a/resources/search.svg
+++ b/resources/search.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!-- Generator: Adobe Illustrator 16.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" id="Capa_1" x="0px" y="0px" width="30.239px" height="30.239px" viewBox="0 0 30.239 30.239" style="enable-background:new 0 0 30.239 30.239;" xml:space="preserve">
+<g>
+	<path fill="#fff" d="M20.194,3.46c-4.613-4.613-12.121-4.613-16.734,0c-4.612,4.614-4.612,12.121,0,16.735   c4.108,4.107,10.506,4.547,15.116,1.34c0.097,0.459,0.319,0.897,0.676,1.254l6.718,6.718c0.979,0.977,2.561,0.977,3.535,0   c0.978-0.978,0.978-2.56,0-3.535l-6.718-6.72c-0.355-0.354-0.794-0.577-1.253-0.674C24.743,13.967,24.303,7.57,20.194,3.46z    M18.073,18.074c-3.444,3.444-9.049,3.444-12.492,0c-3.442-3.444-3.442-9.048,0-12.492c3.443-3.443,9.048-3.443,12.492,0   C21.517,9.026,21.517,14.63,18.073,18.074z"/>
+</g>
+</svg>


### PR DESCRIPTION
- Filter : Add text search filter in gamelist options 
- StringUtil.toUpper/toLower -> Has problems with accents
- Settings : Changed default collections to "all,favorites" instead of "2players,4players,favorites,recent" ( "all games" list will be really useful combined to text search )
- Vlc Component : fix Gridview don't pass size for OptimizeVideo setting
- OMX VideoPlayerComponent : fix Position/Size should be rounded instead of Truncated.
- GridView / Other views : add use of l2 / r2 to navigate in systems. 
- SystemView : use pagedown/pageup to scroll 10 systems