### PR TITLE
Game specific configuration : change naming convention

### DIFF
--- a/es-app/src/FileData.cpp
+++ b/es-app/src/FileData.cpp
@@ -40,6 +40,15 @@ const std::string FileData::getPath() const
 	return Utils::FileSystem::resolveRelativePath(mPath, getSystemEnvData()->mStartPath, true);	
 }
 
+const std::string FileData::getConfigurationName()
+{
+	std::string gameConf = Utils::FileSystem::getFileName(getPath());
+	gameConf = Utils::String::replace(gameConf, "=", "");
+	gameConf = Utils::String::replace(gameConf, "#", "");
+	gameConf = getSourceFileData()->getSystem()->getName() + std::string("[\"") + gameConf + std::string("\"]");
+	return gameConf;
+}
+
 inline SystemEnvironmentData* FileData::getSystemEnvData() const
 { 
 	return mSystem->getSystemEnvData(); 
@@ -225,7 +234,7 @@ void FileData::launchGame(Window* window)
 	command = Utils::String::replace(command, "%ROM_RAW%", rom_raw);
 	command = Utils::String::replace(command, "%CONTROLLERSCONFIG%", controllersConfig); // batocera
 	
-	std::string emulator = SystemConf::getInstance()->get(Utils::FileSystem::getFileName(getPath()) + ".emulator");
+	std::string emulator = SystemConf::getInstance()->get(getConfigurationName() + ".emulator");
 	if (emulator.length() == 0)		
 		emulator = SystemConf::getInstance()->get(mSystem->getName() + ".emulator");
 
@@ -236,7 +245,7 @@ void FileData::launchGame(Window* window)
 			emulator = emul->begin()->first;
 	}
 
-	std::string core = SystemConf::getInstance()->get(Utils::FileSystem::getFileName(getPath()) + ".core");
+	std::string core = SystemConf::getInstance()->get(getConfigurationName() + ".core");
 	if (core.length() == 0)
 		core = SystemConf::getInstance()->get(mSystem->getName() + ".core");
 

--- a/es-app/src/FileData.h
+++ b/es-app/src/FileData.h
@@ -56,6 +56,8 @@ public:
 	virtual const bool getFavorite();
 	virtual const bool getKidGame();
 
+	const std::string FileData::getConfigurationName();
+
 	inline bool isPlaceHolder() { return mType == PLACEHOLDER; };
 
 	virtual inline void refreshMetadata() { return; };

--- a/es-app/src/guis/GuiGamelistOptions.cpp
+++ b/es-app/src/guis/GuiGamelistOptions.cpp
@@ -242,7 +242,9 @@ GuiGamelistOptions::GuiGamelistOptions(Window* window, SystemData* system, bool 
 
 	// batocera
 	if (UIModeController::getInstance()->isUIModeFull() && !(mSystem->isCollection() && file->getType() == FOLDER))
-		mMenu.addEntry(_("ADVANCED GAME OPTIONS"), true, [this, file, system] { GuiMenu::popGameConfigurationGui(mWindow, Utils::FileSystem::getFileName(file->getPath()), file->getSourceFileData()->getSystem(), ""); });
+		mMenu.addEntry(_("ADVANCED GAME OPTIONS"), true, [this, file, system] { 	
+		GuiMenu::popGameConfigurationGui(mWindow, Utils::FileSystem::getFileName(file->getFileName()), file->getConfigurationName(), file->getSourceFileData()->getSystem(), "");
+	});
 	/*
 	// Game List Update
 	mMenu.addEntry(_("UPDATE GAMES LISTS"), false, [this, window]

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -2219,8 +2219,9 @@ void GuiMenu::popSystemConfigurationGui(Window* mWindow, SystemData *systemData,
   popSpecificConfigurationGui(mWindow, systemData->getFullName(), systemData->getName(), systemData, previouslySelectedEmulator);
 }
 
-void GuiMenu::popGameConfigurationGui(Window* mWindow, std::string romFilename, SystemData *systemData, std::string previouslySelectedEmulator) {
-  popSpecificConfigurationGui(mWindow, romFilename, romFilename, systemData, previouslySelectedEmulator);
+void GuiMenu::popGameConfigurationGui(Window* mWindow, std::string title, std::string romFilename, SystemData *systemData, std::string previouslySelectedEmulator)
+{
+  popSpecificConfigurationGui(mWindow, title, romFilename, systemData, previouslySelectedEmulator);
 }
 
 void GuiMenu::popSpecificConfigurationGui(Window* mWindow, std::string title, std::string configName, SystemData *systemData, std::string previouslySelectedEmulator) {

--- a/es-app/src/guis/GuiMenu.h
+++ b/es-app/src/guis/GuiMenu.h
@@ -45,7 +45,7 @@ public:
 	static void openQuitMenu_batocera_static(Window *window, bool forceWin32Menu=false); // batocera
 
 	static void popSystemConfigurationGui(Window* mWindow, SystemData *systemData, std::string previouslySelectedEmulator);
-	static void popGameConfigurationGui(Window* mWindow, std::string romFilename, SystemData *systemData, std::string previouslySelectedEmulator);
+	static void popGameConfigurationGui(Window* mWindow, std::string title, std::string romFilename, SystemData *systemData, std::string previouslySelectedEmulator);
 
 private:
 	void addEntry(std::string name, bool add_arrow, const std::function<void()>& func, const std::string iconName = "");


### PR DESCRIPTION
Used to avoid conflicts between same rom name in different system + avoid problems reading batocera.conf when = or # caracters are found.

See FileData::getConfigurationName() for new naming rules which are :
systemname.filename (without spaces without = without #)

This PR is to merge only when script are to be adapted.