### PR TITLE
Fixed a bug preventing bezels install.

### DIFF
--- a/es-app/src/guis/GuiBezelInstallStart.cpp
+++ b/es-app/src/guis/GuiBezelInstallStart.cpp
@@ -142,7 +142,7 @@ void GuiBezelInstallStart::start(std::string SelectedBezel)
 	snprintf(trstring, 256, _("'%s' ADDED TO DOWNLOAD QUEUE").c_str(), SelectedBezel.c_str()); // batocera
 	mWindow->displayNotificationMessage(_U("\uF019 ") + std::string(trstring));
 
-	ContentInstaller::Enqueue(mWindow, ContentInstaller::CONTENT_THEME, SelectedBezel);	
+	ContentInstaller::Enqueue(mWindow, ContentInstaller::CONTENT_BEZEL, SelectedBezel);
 	delete this;	
 }
 


### PR DESCRIPTION
The last feature on bezels (install bezels through a download queue) had a wrong copy/paste from the theme install code with a bezel seen as `CONTENT_THEME` (and not `CONTENT_BEZEL` see https://github.com/batocera-linux/batocera-emulationstation/commit/922ff532f9150d11705b486fd18167e8616be274#r35337420). That means the script for downloading the theme with a bezel name was failing - and a misleading error was presented to the user (theme not found).