### PR TITLE
 GridView : Support for marquee using + misc things

### DIFF
--- a/es-app/src/CollectionSystemManager.cpp
+++ b/es-app/src/CollectionSystemManager.cpp
@@ -462,12 +462,17 @@ void CollectionSystemManager::setEditMode(std::string collectionName)
 	// if it's bundled, this needs to be the bundle system
 	mEditingCollectionSystemData = sysData;
 
-	mWindow->displayNotificationMessage(_("Editing the collection. Add/remove games with Y."), 10000);
+	char strbuf[512];
+	snprintf(strbuf, 512, _("Editing the '%s' Collection. Add/remove games with Y.").c_str(), Utils::String::toUpper(collectionName).c_str());
+	mWindow->displayNotificationMessage(strbuf, 10000);
 }
 
 void CollectionSystemManager::exitEditMode()
 {
-	mWindow->displayNotificationMessage(_("Finished editing the collection."), 4000);
+	char strbuf[512];
+	snprintf(strbuf, 512, _("Finished editing the '%s' Collection.").c_str(), mEditingCollection.c_str());
+	mWindow->displayNotificationMessage(strbuf, 4000);
+
 	mIsEditingCustom = false;
 	mEditingCollection = "Favorites";
 }

--- a/es-app/src/FileFilterIndex.cpp
+++ b/es-app/src/FileFilterIndex.cpp
@@ -51,7 +51,7 @@ void FileFilterIndex::importIndex(FileFilterIndex* indexToImport)
 		{ &pubDevIndexAllKeys, &(indexToImport->pubDevIndexAllKeys) },
 		{ &ratingsIndexAllKeys, &(indexToImport->ratingsIndexAllKeys) },
 		{ &favoritesIndexAllKeys, &(indexToImport->favoritesIndexAllKeys) },
-		{ &hiddenIndexAllKeys, &(indexToImport->hiddenIndexAllKeys) },
+//		{ &hiddenIndexAllKeys, &(indexToImport->hiddenIndexAllKeys) },
 		{ &kidGameIndexAllKeys, &(indexToImport->kidGameIndexAllKeys) },
 	};
 
@@ -81,7 +81,7 @@ void FileFilterIndex::resetIndex()
 	clearIndex(pubDevIndexAllKeys);
 	clearIndex(ratingsIndexAllKeys);
 	clearIndex(favoritesIndexAllKeys);
-	clearIndex(hiddenIndexAllKeys);
+	//clearIndex(hiddenIndexAllKeys);
 	clearIndex(kidGameIndexAllKeys);
 }
 
@@ -186,7 +186,7 @@ void FileFilterIndex::addToIndex(FileData* game)
 	managePubDevEntryInIndex(game);
 	manageRatingsEntryInIndex(game);
 	manageFavoritesEntryInIndex(game);
-	manageHiddenEntryInIndex(game);
+	// manageHiddenEntryInIndex(game);
 	manageKidGameEntryInIndex(game);
 }
 
@@ -197,7 +197,7 @@ void FileFilterIndex::removeFromIndex(FileData* game)
 	managePubDevEntryInIndex(game, true);
 	manageRatingsEntryInIndex(game, true);
 	manageFavoritesEntryInIndex(game, true);
-	manageHiddenEntryInIndex(game, true);
+	// manageHiddenEntryInIndex(game, true);
 	manageKidGameEntryInIndex(game, true);
 }
 
@@ -288,9 +288,9 @@ void FileFilterIndex::debugPrintIndexes()
 	for (auto x: favoritesIndexAllKeys) {
 		LOG(LogInfo) << "Favorites Index: " << x.first << ": " << x.second;
 	}	
-	for (auto x : hiddenIndexAllKeys) {
-		LOG(LogInfo) << "Hidden Index: " << x.first << ": " << x.second;
-	}	
+//	for (auto x : hiddenIndexAllKeys) {
+//		LOG(LogInfo) << "Hidden Index: " << x.first << ": " << x.second;
+//	}	
 	for (auto x : kidGameIndexAllKeys) {
 		LOG(LogInfo) << "KidGames Index: " << x.first << ": " << x.second;
 	}
@@ -360,10 +360,10 @@ bool FileFilterIndex::showFile(FileData* game)
 
 bool FileFilterIndex::isKeyBeingFilteredBy(std::string key, FilterIndexType type)
 {
-	const FilterIndexType filterTypes[7] = { FAVORITES_FILTER, GENRE_FILTER, PLAYER_FILTER, PUBDEV_FILTER, RATINGS_FILTER,HIDDEN_FILTER, KIDGAME_FILTER };
-	std::vector<std::string> filterKeysList[7] = { favoritesIndexFilteredKeys, genreIndexFilteredKeys, playersIndexFilteredKeys, pubDevIndexFilteredKeys, ratingsIndexFilteredKeys, hiddenIndexFilteredKeys, kidGameIndexFilteredKeys };
+	const FilterIndexType filterTypes[6] = { FAVORITES_FILTER, GENRE_FILTER, PLAYER_FILTER, PUBDEV_FILTER, RATINGS_FILTER, KIDGAME_FILTER }; // ,HIDDEN_FILTER
+	std::vector<std::string> filterKeysList[6] = { favoritesIndexFilteredKeys, genreIndexFilteredKeys, playersIndexFilteredKeys, pubDevIndexFilteredKeys, ratingsIndexFilteredKeys, kidGameIndexFilteredKeys }; // hiddenIndexFilteredKeys, 
 
-	for (int i = 0; i < 7; i++)
+	for (int i = 0; i < 6; i++)
 	{
 		if (filterTypes[i] == type)
 		{
@@ -485,7 +485,7 @@ void FileFilterIndex::manageFavoritesEntryInIndex(FileData* game, bool remove)
 
 	manageIndexEntry(&favoritesIndexAllKeys, key, remove);
 }
-
+/*
 void FileFilterIndex::manageHiddenEntryInIndex(FileData* game, bool remove)
 {
 	// flag for including unknowns
@@ -498,7 +498,7 @@ void FileFilterIndex::manageHiddenEntryInIndex(FileData* game, bool remove)
 
 	manageIndexEntry(&hiddenIndexAllKeys, key, remove);
 }
-
+*/
 void FileFilterIndex::manageKidGameEntryInIndex(FileData* game, bool remove)
 {
 	// flag for including unknowns

--- a/es-app/src/FileFilterIndex.h
+++ b/es-app/src/FileFilterIndex.h
@@ -63,7 +63,7 @@ private:
 	void managePubDevEntryInIndex(FileData* game, bool remove = false);
 	void manageRatingsEntryInIndex(FileData* game, bool remove = false);
 	void manageFavoritesEntryInIndex(FileData* game, bool remove = false);
-	void manageHiddenEntryInIndex(FileData* game, bool remove = false);
+	//void manageHiddenEntryInIndex(FileData* game, bool remove = false);
 	void manageKidGameEntryInIndex(FileData* game, bool remove = false);
 
 	void manageIndexEntry(std::map<std::string, int>* index, std::string key, bool remove);
@@ -83,7 +83,7 @@ private:
 	std::map<std::string, int> pubDevIndexAllKeys;
 	std::map<std::string, int> ratingsIndexAllKeys;
 	std::map<std::string, int> favoritesIndexAllKeys;
-	std::map<std::string, int> hiddenIndexAllKeys;
+	//std::map<std::string, int> hiddenIndexAllKeys;
 	std::map<std::string, int> kidGameIndexAllKeys;
 
 	std::vector<std::string> genreIndexFilteredKeys;
@@ -91,7 +91,7 @@ private:
 	std::vector<std::string> pubDevIndexFilteredKeys;
 	std::vector<std::string> ratingsIndexFilteredKeys;
 	std::vector<std::string> favoritesIndexFilteredKeys;
-	std::vector<std::string> hiddenIndexFilteredKeys;
+	//std::vector<std::string> hiddenIndexFilteredKeys;
 	std::vector<std::string> kidGameIndexFilteredKeys;
 
 	FileData* mRootFolder;

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -160,7 +160,7 @@ void GuiMenu::openScraperSettings()
 		auto thumbSource = std::make_shared< OptionListComponent<std::string> >(mWindow, _("PREFERED THUMBNAIL SOURCE"), false);
 		thumbSource->add(_("NONE"), "", thumbSourceName.empty());
 		thumbSource->add(_("SCREENSHOT"), "ss", thumbSourceName == "ss");
-		imageSource->add(_("TITLE SCREENSHOT"), "sstitle", thumbSourceName == "sstitle");
+		thumbSource->add(_("TITLE SCREENSHOT"), "sstitle", thumbSourceName == "sstitle");
 		thumbSource->add(_("BOX 2D"), "box-2D", thumbSourceName == "box-2D");
 		thumbSource->add(_("BOX 3D"), "box-3D", thumbSourceName == "box-3D");
 		thumbSource->add(_("MIX"), "mixrbv1", thumbSourceName == "mixrbv1");
@@ -1600,7 +1600,7 @@ void GuiMenu::openUISettings()
 	auto UImodeSelection = std::make_shared< OptionListComponent<std::string> >(mWindow, _("UI MODE"), false);
 	std::vector<std::string> UImodes = UIModeController::getInstance()->getUIModes();
 	for (auto it = UImodes.cbegin(); it != UImodes.cend(); it++)
-		UImodeSelection->add(*it, *it, Settings::getInstance()->getString("UIMode") == *it);
+		UImodeSelection->add(_(it->c_str()), *it, Settings::getInstance()->getString("UIMode") == *it);
 	s->addWithLabel(_("UI MODE"), UImodeSelection);
 	s->addSaveFunc([UImodeSelection, window]
 	{
@@ -1797,10 +1797,10 @@ void GuiMenu::openUISettings()
 	auto enable_filter = std::make_shared<SwitchComponent>(mWindow);
 	enable_filter->setState(!Settings::getInstance()->getBool("ForceDisableFilters"));
 	s->addWithLabel(_("ENABLE FILTERS"), enable_filter);
-	s->addSaveFunc([enable_filter] {
+	s->addSaveFunc([enable_filter, s] {
 		bool filter_is_enabled = !Settings::getInstance()->getBool("ForceDisableFilters");
-		Settings::getInstance()->setBool("ForceDisableFilters", !enable_filter->getState());
-		if (enable_filter->getState() != filter_is_enabled) ViewController::get()->ReloadAndGoToStart();
+		if (Settings::getInstance()->setBool("ForceDisableFilters", !enable_filter->getState()))
+			s->setVariable("reloadAll", true);		
 	});
 	
 #if !defined(WIN32) || defined(_DEBUG)

--- a/es-app/src/scrapers/Scraper.cpp
+++ b/es-app/src/scrapers/Scraper.cpp
@@ -332,23 +332,22 @@ void ImageDownloadHandle::update()
 
 	if (mStatus == ASYNC_IN_PROGRESS)
 	{
-		if (!mReq->saveContent(mSavePath))
+		int ret = mReq->saveContent(mSavePath, true);
+		if (ret == 2)
 		{
-			setError("Failed to save image. Disk full?");
+			setError("Failed to save media : The server response is invalid");
+			return;
+		}
+		else if (ret == 1)
+		{
+			setError("Failed to save image on disk. Disk full?");
 			return;
 		}
 	
 		// It's an image ?
 		std::string ext = Utils::String::toLower(Utils::FileSystem::getExtension(mSavePath));
 		if (ext == ".jpg" || ext == ".jpeg" || ext == ".png" || ext == ".bmp" || ext == ".gif")
-		{
-			// resize it
-			if (!resizeImage(mSavePath, mMaxWidth, mMaxHeight))
-			{
-				setError("Error saving resized image. Out of memory? Disk full?");
-				return;
-			}
-		}
+			resizeImage(mSavePath, mMaxWidth, mMaxHeight);
 	}
 
 	setStatus(ASYNC_DONE);

--- a/es-app/src/scrapers/ScreenScraper.cpp
+++ b/es-app/src/scrapers/ScreenScraper.cpp
@@ -253,6 +253,8 @@ std::vector<std::string> ScreenScraperRequest::getRipList(std::string imageSourc
 		ripList = { "box-3D", "box-2D" };
 	else if (imageSource == "wheel")
 		ripList = { "wheel", "screenmarqueesmall", "screenmarquee" };
+	else if (imageSource == "marquee")
+		ripList = { "wheel", "wheelsteel", "screenmarqueesmall", "screenmarquee" };
 
 	return ripList;
 }
@@ -380,11 +382,15 @@ void ScreenScraperRequest::processGame(const pugi::xml_document& xmldoc, std::ve
 
 			if (Settings::getInstance()->getBool("ScrapeMarquee"))
 			{
-				pugi::xml_node art = findMedia(media_list, "marquee", region);
-				if (art)
-					result.marqueeUrl = Utils::String::replace(art.text().get(), " ", "%20");
-				else
-					LOG(LogDebug) << "Failed to find media XML node for video";
+				ripList = getRipList("marquee");
+				if (!ripList.empty())
+				{
+					pugi::xml_node art = findMedia(media_list, ripList, region);
+					if (art)
+						result.marqueeUrl = Utils::String::replace(art.text().get(), " ", "%20");
+					else
+						LOG(LogDebug) << "Failed to find media XML node for video";
+				}
 			}
 
 			if (Settings::getInstance()->getBool("ScrapeVideos"))

--- a/es-app/src/views/SystemView.cpp
+++ b/es-app/src/views/SystemView.cpp
@@ -109,11 +109,11 @@ void SystemView::populate()
 			{
 				// no logo in theme; use text
 				TextComponent* text = new TextComponent(mWindow,
-					(*it)->getName(),
+					(*it)->getFullName(),
 					Renderer::isSmallScreen() ? Font::get(FONT_SIZE_MEDIUM) : Font::get(FONT_SIZE_LARGE),
 					0x000000FF,
 					ALIGN_CENTER);
-
+								
 				text->setSize(mCarousel.logoSize * mCarousel.logoScale);
 				text->applyTheme((*it)->getTheme(), "system", "logoText", ThemeFlags::FONT_PATH | ThemeFlags::FONT_SIZE | ThemeFlags::COLOR | ThemeFlags::FORCE_UPPERCASE | ThemeFlags::LINE_SPACING | ThemeFlags::TEXT);
 				e.data.logo = std::shared_ptr<GuiComponent>(text);

--- a/es-app/src/views/gamelist/GridGameListView.cpp
+++ b/es-app/src/views/gamelist/GridGameListView.cpp
@@ -224,9 +224,9 @@ void GridGameListView::populateList(const std::vector<FileData*>& files)
 					continue;
 
 				if (showFavoriteIcon)
-					mGrid.add(_U("\uF006 ") + (*it)->getName(), getImagePath(*it), (*it)->getVideoPath(), *it);
+					mGrid.add(_U("\uF006 ") + (*it)->getName(), getImagePath(*it), (*it)->getVideoPath(), (*it)->getMarqueePath(), *it);
 				else
-					mGrid.add((*it)->getName(), getImagePath(*it), (*it)->getVideoPath(), *it);
+					mGrid.add((*it)->getName(), getImagePath(*it), (*it)->getVideoPath(), (*it)->getMarqueePath(), *it);
 			}
 		}
 
@@ -239,12 +239,12 @@ void GridGameListView::populateList(const std::vector<FileData*>& files)
 
 				if (showFavoriteIcon)
 				{
-					mGrid.add(_U("\uF006 ") + (*it)->getName(), getImagePath(*it), (*it)->getVideoPath(), *it);
+					mGrid.add(_U("\uF006 ") + (*it)->getName(), getImagePath(*it), (*it)->getVideoPath(), (*it)->getMarqueePath(), *it);
 					continue;
 				}
 			}
 
-			mGrid.add((*it)->getName(), getImagePath(*it), (*it)->getVideoPath(), *it);
+			mGrid.add((*it)->getName(), getImagePath(*it), (*it)->getVideoPath(), (*it)->getMarqueePath(), *it);
 		}
 	}
 	else
@@ -492,7 +492,7 @@ void GridGameListView::addPlaceholder()
 {
 	// empty grid - add a placeholder
 	FileData* placeholder = new FileData(PLACEHOLDER, "<No Entries Found>", this->mRoot->getSystem());
-	mGrid.add(placeholder->getName(), "", "", placeholder);
+	mGrid.add(placeholder->getName(), "", "", "", placeholder);
 }
 
 void GridGameListView::launch(FileData* game)

--- a/es-core/src/HttpReq.cpp
+++ b/es-core/src/HttpReq.cpp
@@ -318,15 +318,16 @@ std::string HttpReq::getContent()
 		mStream.flush();
 		mStream.close();
 	}
+	
+	std::ifstream ifs(mStreamPath, std::ios_base::in | std::ios_base::binary);
+	if (ifs.bad())
+		return "";
 
-	std::ifstream t(mStreamPath);
-	t.seekg(0, std::ios::end);
-	size_t size = t.tellg();
-	std::string buffer(size, ' ');
-	t.seekg(0);
-	t.read(&buffer[0], size);
+	std::stringstream ofs;
+	ofs << ifs.rdbuf();
+	ifs.close();
 
-	return buffer; // mContent.str();
+	return ofs.str(); 
 }
 
 void HttpReq::onError(const char* msg)

--- a/es-core/src/HttpReq.h
+++ b/es-core/src/HttpReq.h
@@ -74,7 +74,6 @@ private:
 	std::string   mStreamPath;
 	std::ofstream mStream;
 
-	//std::stringstream mContent;
 	std::string mErrorMsg;
 
 	int mPercent;

--- a/es-core/src/HttpReq.h
+++ b/es-core/src/HttpReq.h
@@ -48,7 +48,7 @@ public:
 	std::string getContent(); // mStatus must be REQ_SUCCESS
 
 
-	bool saveContent(const std::string filename);
+	int saveContent(const std::string filename, bool checkMedia = false);
 
 	static std::string urlEncode(const std::string &s);
 	static bool isUrl(const std::string& s);

--- a/es-core/src/ThemeData.cpp
+++ b/es-core/src/ThemeData.cpp
@@ -80,6 +80,8 @@ std::map<std::string, std::map<std::string, ThemeData::ElementPropertyType>> The
 		{ "forceUppercase", BOOLEAN },
 		{ "lineSpacing", FLOAT },
 		{ "value", STRING },
+		{ "reflexion", NORMALIZED_PAIR },
+		{ "reflexionOnFrame", BOOLEAN },
 		{ "glowColor", COLOR },
 		{ "glowSize", FLOAT },
 		{ "glowOffset", NORMALIZED_PAIR },

--- a/es-core/src/components/GridTileComponent.h
+++ b/es-core/src/components/GridTileComponent.h
@@ -21,7 +21,9 @@ struct GridTileProperties
 	std::string mImageSizeMode;
 	std::string mSelectionMode;
 
+	Vector2f mLabelPos;
 	Vector2f mLabelSize;
+
 	unsigned int mLabelColor;
 	unsigned int mLabelBackColor;
 
@@ -32,6 +34,10 @@ struct GridTileProperties
 	unsigned int	mFontSize;
 
 	Vector2f		mMirror;
+
+
+	Vector2f mMarqueePos;
+	Vector2f mMarqueeSize;
 };
 
 class GridTileComponent : public GuiComponent
@@ -56,7 +62,8 @@ public:
 	void setVideo(const std::string& path, float defaultDelay = -1.0);
 
 	void setImage(const std::string& path);
-	// void setImage(const std::shared_ptr<TextureResource>& texture, std::string name);
+	void setMarquee(const std::string& path);
+
 	void setSelected(bool selected, bool allowAnimation = true, Vector3f* pPosition = NULL, bool force=false);
 	void setVisible(bool visible);
 
@@ -78,6 +85,7 @@ public:
 private:
 	void	resetProperties();
 	void	createVideo();
+	void	createMarquee();
 	
 	void	startVideo();
 	void	stopVideo();
@@ -97,6 +105,7 @@ private:
 	GridTileProperties mDefaultProperties;
 	GridTileProperties mSelectedProperties;	
 
+	std::string mCurrentMarquee;
 	std::string mCurrentPath;
 	std::string mVideoPath;
 
@@ -109,6 +118,8 @@ private:
 	Vector3f mAnimPosition;
 
 	VideoComponent* mVideo;
+	ImageComponent* mMarquee;
+
 	bool mVideoPlaying;
 	bool mShown;
 };

--- a/es-core/src/components/ImageComponent.cpp
+++ b/es-core/src/components/ImageComponent.cpp
@@ -165,7 +165,7 @@ void ImageComponent::setImage(std::string path, bool tile, MaxSizeInfo maxSize)
 			mTexture = texture;
 	}
 
-	if (mLoadingTexture == nullptr);
+	if (mLoadingTexture == nullptr)
 		resize();
 }
 

--- a/es-core/src/components/ImageGridComponent.h
+++ b/es-core/src/components/ImageGridComponent.h
@@ -29,6 +29,7 @@ enum ImageSource
 struct ImageGridData
 {
 	std::string texturePath;
+	std::string marqueePath;
 	std::string videoPath;
 };
 
@@ -54,7 +55,7 @@ public:
 
 	ImageGridComponent(Window* window);
 
-	void add(const std::string& name, const std::string& imagePath, const std::string& videoPath, const T& obj);
+	void add(const std::string& name, const std::string& imagePath, const std::string& videoPath, const std::string& marqueePath, const T& obj);
 
 	bool input(InputConfig* config, Input input) override;
 	void update(int deltaTime) override;
@@ -164,13 +165,14 @@ ImageGridComponent<T>::ImageGridComponent(Window* window) : IList<ImageGridData,
 }
 
 template<typename T>
-void ImageGridComponent<T>::add(const std::string& name, const std::string& imagePath, const std::string& videoPath, const T& obj)
+void ImageGridComponent<T>::add(const std::string& name, const std::string& imagePath, const std::string& videoPath, const std::string& marqueePath, const T& obj)
 {
 	typename IList<ImageGridData, T>::Entry entry;
 	entry.name = name;
 	entry.object = obj;
 	entry.data.texturePath = imagePath;
 	entry.data.videoPath = videoPath;
+	entry.data.marqueePath = marqueePath;
 
 	static_cast<IList< ImageGridData, T >*>(this)->add(entry);
 	mEntriesDirty = true;
@@ -710,6 +712,7 @@ void ImageGridComponent<T>::updateTiles(bool allowAnimation, bool updateSelected
 			tile->setSelected(false, allowAnimation);
 			tile->setLabel("");
 			tile->setImage(mDefaultGameTexture);
+			tile->setMarquee("");
 			tile->setVisible(false);
 		}
 		return;
@@ -806,11 +809,20 @@ void ImageGridComponent<T>::updateTileAtPos(int tilePos, int imgPos, bool allowA
 		else
 			tile->setImage(mDefaultGameTexture);		
 		
+		// Marquee
+		std::string marqueePath = mEntries.at(imgPos).data.marqueePath;
+
+		if (!marqueePath.empty() && ResourceManager::getInstance()->fileExists(marqueePath))
+			tile->setMarquee(marqueePath);
+		else
+			tile->setMarquee("");
+
+		// Video
 		if (mAllowVideo && imgPos == mCursor)
 		{			
 			std::string videoPath = mEntries.at(imgPos).data.videoPath;
 
-			if (ResourceManager::getInstance()->fileExists(videoPath))
+			if (!videoPath.empty() && ResourceManager::getInstance()->fileExists(videoPath))
 				tile->setVideo(videoPath, mVideoDelay);
 			else if (mEntries.at(imgPos).object->getType() == 2)
 				tile->setVideo("");

--- a/es-core/src/components/TextComponent.h
+++ b/es-core/src/components/TextComponent.h
@@ -75,7 +75,11 @@ private:
 	unsigned int mGlowColor;
 	unsigned int mGlowSize;
 	Vector2f	 mGlowOffset;
-	Vector4f	mPadding;
+	Vector4f	 mPadding;
+
+
+	Vector2f	mReflection;
+	bool		mReflectOnBorders;
 };
 
 #endif // ES_CORE_COMPONENTS_TEXT_COMPONENT_H

--- a/es-core/src/guis/GuiTextEditPopupKeyboard.cpp
+++ b/es-core/src/guis/GuiTextEditPopupKeyboard.cpp
@@ -235,13 +235,8 @@ bool GuiTextEditPopupKeyboard::input(InputConfig* config, Input input)
 	}
 
 	// For Shifting (Y)
-	if (config->isMappedTo("y", input) && input.value) {
-		if (mShift) mShift = false;
-		else mShift = true;
+	if (config->isMappedTo("y", input) && input.value) 
 		shiftKeys();
-	}
-
-	
 
 	return false;
 }

--- a/es-core/src/resources/Font.cpp
+++ b/es-core/src/resources/Font.cpp
@@ -461,34 +461,38 @@ void Font::renderGradientTextCache(TextCache* cache, unsigned int colorTop, unsi
 		std::vector<Renderer::Vertex> vxs;
 		vxs.resize(it->verts.size());
 
+		float maxY = -1;
+
+		for (int i = 0; i < it->verts.size(); i += 6)
+			if (maxY == -1 || maxY < it->verts[i + 2].pos.y())
+				maxY = it->verts[i + 2].pos.y();
+
 		for (int i = 0; i < it->verts.size(); i += 6)
 		{
+			float topOffset = it->verts[i + 1].pos.y();
+			float bottomOffset = it->verts[i + 2].pos.y();
+			
+			float topPercent = (maxY == 0 ? 1.0 : topOffset / maxY);
+			float bottomPercent = (maxY == 0 ? 1.0 : bottomOffset / maxY);
+
+			const unsigned int colorT = Renderer::mixColors(colorTop, colorBottom, topPercent);
+			const unsigned int colorB = Renderer::mixColors(colorTop, colorBottom, bottomPercent);
+		
 			vxs[i + 1] = it->verts[i + 1];
-			vxs[i + 1].col = colorTop;
+			vxs[i + 1].col = colorT;
 
 			vxs[i + 2] = it->verts[i + 2];
-			vxs[i + 2].col = colorBottom;
+			vxs[i + 2].col = colorB;
 
 			vxs[i + 3] = it->verts[i + 3];
-			vxs[i + 3].col = colorTop;
+			vxs[i + 3].col = colorT;
 
 			vxs[i + 4] = it->verts[i + 4];
-			vxs[i + 4].col = colorBottom;
+			vxs[i + 4].col = colorB;
 
 			// make duplicates of first and last vertex so this can be rendered as a triangle strip
 			vxs[i + 0] = vxs[i + 1];
 			vxs[i + 5] = vxs[i + 4];
-
-			/*
-			vertices[1] = { { glyphStartX                                       , y - glyph->bearing.y()                                          }, { glyph->texPos.x(),                      glyph->texPos.y()                      }, convertedColor };
-			vertices[2] = { { glyphStartX                                       , y - glyph->bearing.y() + (glyph->texSize.y() * textureSize.y()) }, { glyph->texPos.x(),                      glyph->texPos.y() + glyph->texSize.y() }, convertedColor };
-			vertices[3] = { { glyphStartX + glyph->texSize.x() * textureSize.x(), y - glyph->bearing.y()                                          }, { glyph->texPos.x() + glyph->texSize.x(), glyph->texPos.y()                      }, convertedColor };
-			vertices[4] = { { glyphStartX + glyph->texSize.x() * textureSize.x(), y - glyph->bearing.y() + (glyph->texSize.y() * textureSize.y()) }, { glyph->texPos.x() + glyph->texSize.x(), glyph->texPos.y() + glyph->texSize.y() }, convertedColor };
-
-			// make duplicates of first and last vertex so this can be rendered as a triangle strip
-			vertices[0] = vertices[1];
-			vertices[5] = vertices[4];
-			*/
 		}
 
 		Renderer::bindTexture(*it->textureIdPtr);

--- a/es-core/src/resources/Font.cpp
+++ b/es-core/src/resources/Font.cpp
@@ -440,13 +440,63 @@ void Font::renderTextCache(TextCache* cache)
 	{
 		assert(*it->textureIdPtr != 0);
 
-		auto vertexList = *it;
-
 		Renderer::bindTexture(*it->textureIdPtr);
 		Renderer::drawTriangleStrips(&it->verts[0], it->verts.size());
 		Renderer::bindTexture(0);
 	}
 }
+
+void Font::renderGradientTextCache(TextCache* cache, unsigned int colorTop, unsigned int colorBottom, bool horz)
+{
+	if (cache == NULL)
+	{
+		LOG(LogError) << "Attempted to draw NULL TextCache!";
+		return;
+	}
+
+	for (auto it = cache->vertexLists.cbegin(); it != cache->vertexLists.cend(); it++)
+	{
+		assert(*it->textureIdPtr != 0);
+
+		std::vector<Renderer::Vertex> vxs;
+		vxs.resize(it->verts.size());
+
+		for (int i = 0; i < it->verts.size(); i += 6)
+		{
+			vxs[i + 1] = it->verts[i + 1];
+			vxs[i + 1].col = colorTop;
+
+			vxs[i + 2] = it->verts[i + 2];
+			vxs[i + 2].col = colorBottom;
+
+			vxs[i + 3] = it->verts[i + 3];
+			vxs[i + 3].col = colorTop;
+
+			vxs[i + 4] = it->verts[i + 4];
+			vxs[i + 4].col = colorBottom;
+
+			// make duplicates of first and last vertex so this can be rendered as a triangle strip
+			vxs[i + 0] = vxs[i + 1];
+			vxs[i + 5] = vxs[i + 4];
+
+			/*
+			vertices[1] = { { glyphStartX                                       , y - glyph->bearing.y()                                          }, { glyph->texPos.x(),                      glyph->texPos.y()                      }, convertedColor };
+			vertices[2] = { { glyphStartX                                       , y - glyph->bearing.y() + (glyph->texSize.y() * textureSize.y()) }, { glyph->texPos.x(),                      glyph->texPos.y() + glyph->texSize.y() }, convertedColor };
+			vertices[3] = { { glyphStartX + glyph->texSize.x() * textureSize.x(), y - glyph->bearing.y()                                          }, { glyph->texPos.x() + glyph->texSize.x(), glyph->texPos.y()                      }, convertedColor };
+			vertices[4] = { { glyphStartX + glyph->texSize.x() * textureSize.x(), y - glyph->bearing.y() + (glyph->texSize.y() * textureSize.y()) }, { glyph->texPos.x() + glyph->texSize.x(), glyph->texPos.y() + glyph->texSize.y() }, convertedColor };
+
+			// make duplicates of first and last vertex so this can be rendered as a triangle strip
+			vertices[0] = vertices[1];
+			vertices[5] = vertices[4];
+			*/
+		}
+
+		Renderer::bindTexture(*it->textureIdPtr);
+		Renderer::drawTriangleStrips(&vxs[0], vxs.size());
+		Renderer::bindTexture(0);
+	}
+}
+
 
 Vector2f Font::sizeText(std::string text, float lineSpacing)
 {

--- a/es-core/src/resources/Font.h
+++ b/es-core/src/resources/Font.h
@@ -49,7 +49,9 @@ public:
 	Vector2f sizeText(std::string text, float lineSpacing = 1.5f); // Returns the expected size of a string when rendered.  Extra spacing is applied to the Y axis.
 	TextCache* buildTextCache(const std::string& text, float offsetX, float offsetY, unsigned int color);
 	TextCache* buildTextCache(const std::string& text, Vector2f offset, unsigned int color, float xLen, Alignment alignment = ALIGN_LEFT, float lineSpacing = 1.5f);
+	
 	void renderTextCache(TextCache* cache);
+	void renderGradientTextCache(TextCache* cache, unsigned int colorTop, unsigned int colorBottom, bool horz = false);
 	
 	std::string wrapText(std::string text, float xLen); // Inserts newlines into text to make it wrap properly.
 	Vector2f sizeWrappedText(std::string text, float xLen, float lineSpacing = 1.5f); // Returns the expected size of a string after wrapping is applied.


### PR DESCRIPTION
- GridView : Support for marquee using <image name="gridtile.marquee">element.
- GridView : fixed <text name="gridtile"> positionning. <pos> element is now supported (but optionnal).
- GuiTextEditPopupKeyboard : Y button does not work to run Shift switch
- TextComponent : Support for reflexion
- Screenscraper : take wheel as preference when marquee is ON 
- Screenscraper : check invalid responses when downloading medias 
- Collection edition : Display editing collection name in notifications.
- Screenscraper : TITLE SCREENSHOT was duplicated in image choice.
- Scraper : Thumbnail preview don't work anymore ( related to httpreq recent changes )