### PR TITLE
Misc fixes

### DIFF
--- a/es-app/src/FileData.cpp
+++ b/es-app/src/FileData.cpp
@@ -227,11 +227,27 @@ void FileData::launchGame(Window* window)
 	
 	std::string emulator = SystemConf::getInstance()->get(Utils::FileSystem::getFileName(getPath()) + ".emulator");
 	if (emulator.length() == 0)		
-		emulator = SystemConf::getInstance()->get(mSystem->getFullName() + ".emulator");
+		emulator = SystemConf::getInstance()->get(mSystem->getName() + ".emulator");
+
+	if (emulator.length() == 0)
+	{
+		auto emul = mSystem->getEmulators();
+		if (emul != nullptr && emul->size() > 0)
+			emulator = emul->begin()->first;
+	}
 
 	std::string core = SystemConf::getInstance()->get(Utils::FileSystem::getFileName(getPath()) + ".core");
 	if (core.length() == 0)
-		core = SystemConf::getInstance()->get(mSystem->getFullName() + ".core");
+		core = SystemConf::getInstance()->get(mSystem->getName() + ".core");
+
+	if (core.length() == 0)
+	{
+		auto emul = mSystem->getEmulators();
+		if (emul != nullptr && emul->find(emulator) != emul->cend())
+			core = emul->find(emulator)->first;
+		if (emul != nullptr && emul->size() > 0 && emul->begin()->second->begin() != emul->begin()->second->cend())
+			core = *emul->begin()->second->begin();
+	}
 
 	command = Utils::String::replace(command, "%EMULATOR%", emulator);
 	command = Utils::String::replace(command, "%CORE%", core);

--- a/es-app/src/guis/GuiGameScraper.cpp
+++ b/es-app/src/guis/GuiGameScraper.cpp
@@ -77,8 +77,12 @@ GuiGameScraper::GuiGameScraper(Window* window, ScraperSearchParams params, std::
 	mSearch->setAcceptCallback([this, doneFunc](const ScraperSearchResult& result) { doneFunc(result); close(); });
 	mSearch->setCancelCallback([&] { delete this; });
 
-	setSize(Renderer::getScreenWidth() * 0.95f, Renderer::getScreenHeight() * 0.747f);
-	setPosition((Renderer::getScreenWidth() - mSize.x()) / 2, (Renderer::getScreenHeight() - mSize.y()) / 2);
+	if (Renderer::isSmallScreen())
+		setSize(Renderer::getScreenWidth(), Renderer::getScreenHeight());
+	else
+		setSize(Renderer::getScreenWidth() * 0.90f, Renderer::getScreenHeight() * 0.85f);
+		
+	setPosition((Renderer::getScreenWidth() - mSize.x()) / 2, (Renderer::getScreenHeight() - mSize.y()) / 2);	
 
 	mGrid.resetCursor();
 	mSearch->search(params); // start the search

--- a/es-app/src/guis/GuiMetaDataEd.cpp
+++ b/es-app/src/guis/GuiMetaDataEd.cpp
@@ -251,6 +251,8 @@ void GuiMetaDataEd::save()
 
 void GuiMetaDataEd::fetch()
 {
+	mScraperParams.nameOverride = mScraperParams.game->getName();
+
 	GuiGameScraper* scr = new GuiGameScraper(mWindow, mScraperParams, std::bind(&GuiMetaDataEd::fetchDone, this, std::placeholders::_1));
 	mWindow->pushGui(scr);
 }
@@ -261,6 +263,10 @@ void GuiMetaDataEd::fetchDone(const ScraperSearchResult& result)
 	{
 		auto key = mEditors.at(i)->getTag();
 		if (isStatistic(key))
+			continue;
+
+		// Don't override favorite & hidden values, as they are not statistics
+		if (key == "favorite" || key == "hidden")
 			continue;
 
 		mEditors.at(i)->setValue(result.mdl.get(key));

--- a/es-app/src/guis/GuiUpdate.cpp
+++ b/es-app/src/guis/GuiUpdate.cpp
@@ -63,7 +63,7 @@ public:
 			GuiUpdate::state = GuiUpdateState::State::UPDATE_READY;
 
 			mWndNotification->updateTitle(_U("\uF019 ") + _("UPDATE IS READY"));
-			mWndNotification->updateText("REBOOT SYSTEM TO APPLY");
+			mWndNotification->updateText(_("REBOOT SYSTEM TO APPLY"));
 
 			std::this_thread::yield();
 			std::this_thread::sleep_for(std::chrono::hours(12));

--- a/es-app/src/scrapers/ScreenScraper.h
+++ b/es-app/src/scrapers/ScreenScraper.h
@@ -21,7 +21,7 @@ public:
 
 	// Settings for the scraper
 	static const struct ScreenScraperConfig {
-		std::string getGameSearchUrl(const std::string gameName) const;
+		std::string getGameSearchUrl(const std::string gameName, bool jeuRecherche=false) const;
 
 		// Access to the API
 		const std::string API_DEV_U = { 91, 32, 7, 17 };

--- a/es-app/src/views/SystemView.cpp
+++ b/es-app/src/views/SystemView.cpp
@@ -245,12 +245,29 @@ bool SystemView::input(InputConfig* config, Input input)
 			}
 			if (config->isMappedTo("pagedown", input))
 			{
-				listInput(10);
+				int cursor = mCursor + 10;
+				if (cursor < 0)
+					cursor += (int)mEntries.size();
+
+				if (cursor >= (int)mEntries.size())
+					cursor -= (int)mEntries.size();
+
+				auto sd = mEntries.at(cursor).object;
+				ViewController::get()->goToSystemView(sd, true);
+				//listInput(10);
 				return true;
 			}
 			if (config->isMappedTo("pageup", input))
 			{
-				listInput(-10);
+				int cursor = mCursor - 10;
+				if (cursor < 0)
+					cursor += (int)mEntries.size();
+				if (cursor >= (int)mEntries.size())
+					cursor -= (int)mEntries.size();
+
+				auto sd = mEntries.at(cursor).object;
+				ViewController::get()->goToSystemView(sd, true);
+				//listInput(-10);
 				return true;
 			}
 
@@ -270,12 +287,29 @@ bool SystemView::input(InputConfig* config, Input input)
 			}
 			if (config->isMappedTo("pagedown", input))
 			{
-				listInput(10);
+				int cursor = mCursor + 10;
+				if (cursor < 0)
+					cursor += (int)mEntries.size();
+
+				if (cursor >= (int)mEntries.size())
+					cursor -= (int)mEntries.size();
+
+				auto sd = mEntries.at(cursor).object;
+				ViewController::get()->goToSystemView(sd, true);
+				//listInput(10);
 				return true;
 			}
 			if (config->isMappedTo("pageup", input))
 			{
-				listInput(-10);
+				int cursor = mCursor - 10;
+				if (cursor < 0)
+					cursor += (int)mEntries.size();
+				if (cursor >= (int)mEntries.size())
+					cursor -= (int)mEntries.size();
+
+				auto sd = mEntries.at(cursor).object;
+				ViewController::get()->goToSystemView(sd, true);
+				//listInput(-10);
 				return true;
 			}
 

--- a/es-core/src/AudioManager.cpp
+++ b/es-core/src/AudioManager.cpp
@@ -278,6 +278,13 @@ void AudioManager::setSongName(std::string song)
 	if (song == mCurrentSong)
 		return;
 
+	std::string ext = Utils::String::toLower(Utils::FileSystem::getExtension(song));
+	if (ext != ".mp3")
+	{
+		mCurrentSong = Utils::FileSystem::getStem(song.c_str());
+		return;
+	}
+
 	LOG(LogDebug) << "AudioManager::setSongName";
 
 	// First, start with an ID3 v1 tag	


### PR DESCRIPTION
- ScreenScraper : Use "jeuRecherche" instead of jeuInfos when using manual Metadata/Scrape function -> "jeuRecherche" can return multiple results.
- GuiGameScraper : Fixed size on small screens (GPI)
- Update : REBOOT SYSTEM TO APPLY message was not localisable 
- SystemView : moving -10/+10 in system list creates big lags -> Move directly to system without animating.
- AudioManager : don't try to load IDV3 if file ext is not mp3 & avoid trying idv3 reading on ogg or wav files ( Darknior crashes ? )
- Game launch : fixed %EMULATOR% & %CORE% command line variables ( usable on WIN32 version )







