### PR TITLE
ScreenSaver : Display game text / system + fading transition

### DIFF
--- a/es-app/src/ApiSystem.cpp
+++ b/es-app/src/ApiSystem.cpp
@@ -508,6 +508,7 @@ void ApiSystem::launchExternalWindow_after(Window *window)
 	VolumeControl::getInstance()->init();
 	AudioManager::getInstance()->init();
 	window->normalizeNextUpdate();
+	window->reactivateGui();
 
 	AudioManager::getInstance()->playRandomMusic();
 

--- a/es-app/src/FileData.cpp
+++ b/es-app/src/FileData.cpp
@@ -284,6 +284,8 @@ void FileData::launchGame(Window* window)
 	gameToUpdate->metadata.set("lastplayed", Utils::Time::DateTime(Utils::Time::now()));
 	CollectionSystemManager::get()->refreshCollectionSystems(gameToUpdate);
 
+	window->reactivateGui();
+
 	// batocera
 	AudioManager::getInstance()->playRandomMusic();
 

--- a/es-app/src/SystemScreenSaver.h
+++ b/es-app/src/SystemScreenSaver.h
@@ -3,10 +3,34 @@
 #define ES_APP_SYSTEM_SCREEN_SAVER_H
 
 #include "Window.h"
+#include "GuiComponent.h"
 
 class ImageComponent;
 class Sound;
 class VideoComponent;
+class TextComponent;
+
+class ImageScreenSaver : GuiComponent
+{
+public:
+	ImageScreenSaver(Window* window);
+	~ImageScreenSaver();
+
+	void setGame(FileData* mCurrentGame);
+	void setImage(const std::string path);
+	bool hasImage();
+
+	void render(const Transform4x4f& transform) override;
+	void update(int deltaTime) override;
+
+	void setOpacity(unsigned char opacity) override;
+
+private:
+	ImageComponent*		mImage;	
+	ImageComponent*		mMarquee;	
+	TextComponent*		mLabelGame;
+	TextComponent*		mLabelSystem;
+};
 
 // Screensaver implementation for main window
 class SystemScreenSaver : public Window::ScreenSaver
@@ -36,8 +60,6 @@ private:
 	void pickRandomGameListImage(std::string& path);
 	void pickRandomCustomImage(std::string& path);
 
-	void input(InputConfig* config, Input input);
-
 	enum STATE {
 		STATE_INACTIVE,
 		STATE_FADE_OUT_WINDOW,
@@ -51,7 +73,10 @@ private:
 	VideoComponent*		mVideoScreensaver;
 	bool			mImagesCounted;
 	unsigned long		mImageCount;
-	ImageComponent*		mImageScreensaver;
+
+	std::shared_ptr<ImageScreenSaver>		mFadingImageScreensaver;
+	std::shared_ptr<ImageScreenSaver>		mImageScreensaver;
+
 	Window*			mWindow;
 	STATE			mState;
 	float			mOpacity;
@@ -60,8 +85,10 @@ private:
 	std::string		mGameName;
 	std::string		mSystemName;
 	int 			mVideoChangeTime;
-	std::shared_ptr<Sound>	mBackgroundAudio;
-	bool			mStopBackgroundAudio;
+	
+	//std::shared_ptr<Sound>	mBackgroundAudio;
+	bool			mLoadingNext;
+
 };
 
 #endif // ES_APP_SYSTEM_SCREEN_SAVER_H

--- a/es-app/src/guis/GuiGeneralScreensaverOptions.cpp
+++ b/es-app/src/guis/GuiGeneralScreensaverOptions.cpp
@@ -13,36 +13,31 @@ GuiGeneralScreensaverOptions::GuiGeneralScreensaverOptions(Window* window, const
 	auto theme = ThemeData::getMenuTheme();
 
 	// screensaver time
-	auto screensaver_time = std::make_shared<SliderComponent>(mWindow, 0.f, 30.f, 1.f, "m");
+	auto screensaver_time = std::make_shared<SliderComponent>(mWindow, 0.f, 120.0f, 1.f, "m");
 	screensaver_time->setValue((float)(Settings::getInstance()->getInt("ScreenSaverTime") / (1000 * 60)));
-	addWithLabel("SCREENSAVER AFTER", screensaver_time);
+	addWithLabel(_("SCREENSAVER AFTER"), screensaver_time);
 	addSaveFunc([screensaver_time] {
 	    Settings::getInstance()->setInt("ScreenSaverTime", (int)Math::round(screensaver_time->getValue()) * (1000 * 60));
 	    PowerSaver::updateTimeouts();
 	});
 	
-	// Allow ScreenSaver Controls - ScreenSaverControls
-	auto ss_controls = std::make_shared<SwitchComponent>(mWindow);
-	ss_controls->setState(Settings::getInstance()->getBool("ScreenSaverControls"));
-	addWithLabel("SCREENSAVER CONTROLS", ss_controls);
-	addSaveFunc([ss_controls] { Settings::getInstance()->setBool("ScreenSaverControls", ss_controls->getState()); });	
-
 	// screensaver behavior
-	auto screensaver_behavior = std::make_shared< OptionListComponent<std::string> >(mWindow, "SCREENSAVER BEHAVIOR", false);
+	auto screensaver_behavior = std::make_shared< OptionListComponent<std::string> >(mWindow, _("SCREENSAVER BEHAVIOR"), false);
 	std::vector<std::string> screensavers;
 	screensavers.push_back("dim");
 	screensavers.push_back("black");
 	screensavers.push_back("random video");
 	screensavers.push_back("slideshow");
 	for(auto it = screensavers.cbegin(); it != screensavers.cend(); it++)
-		screensaver_behavior->add(*it, *it, Settings::getInstance()->getString("ScreenSaverBehavior") == *it);
-	addWithLabel("SCREENSAVER BEHAVIOR", screensaver_behavior);
+		screensaver_behavior->add(_(it->c_str()), *it, Settings::getInstance()->getString("ScreenSaverBehavior") == *it);
+	addWithLabel(_("SCREENSAVER BEHAVIOR"), screensaver_behavior);
 	addSaveFunc([this, screensaver_behavior] {
-		if (Settings::getInstance()->getString("ScreenSaverBehavior") != "random video" && screensaver_behavior->getSelected() == "random video") {
+		if (Settings::getInstance()->getString("ScreenSaverBehavior") != "random video"
+			&& screensaver_behavior->getSelected() == "random video") {
 			// if before it wasn't risky but now there's a risk of problems, show warning
 			mWindow->pushGui(new GuiMsgBox(mWindow,
-			"The \"Random Video\" screensaver shows videos from your gamelist.\n\nIf you do not have videos, or if in several consecutive attempts the games it selects don't have videos it will default to black.\n\nMore options in the \"UI Settings\" > \"Video Screensaver\" menu.",
-				"OK", [] { return; }));
+				_("THE \"RANDOM VIDEO\" SCREENSAVER SHOWS VIDEOS FROM YOUR GAMELIST.\nIF YOU DON'T HAVE VIDEOS, OR IF NONE OF THEM CAN BE PLAYED AFTER A FEW ATTEMPTS, IT WILL DEFAULT TO \"BLACK\".\nMORE OPTIONS IN THE \"UI SETTINGS\" -> \"RANDOM VIDEO SCREENSAVER SETTINGS\" MENU."),
+				_("OK"), [] { return; }));
 		}
 		Settings::getInstance()->setString("ScreenSaverBehavior", screensaver_behavior->getSelected());
 		PowerSaver::updateTimeouts();
@@ -52,16 +47,22 @@ GuiGeneralScreensaverOptions::GuiGeneralScreensaverOptions(Window* window, const
 
 	// show filtered menu
 	row.elements.clear();
-	row.addElement(std::make_shared<TextComponent>(mWindow, "VIDEO SCREENSAVER SETTINGS", theme->Text.font, theme->Text.color), true);
+	row.addElement(std::make_shared<TextComponent>(mWindow, _("RANDOM VIDEO SCREENSAVER SETTINGS"), theme->Text.font, theme->Text.color), true);
 	row.addElement(makeArrow(mWindow), false);
 	row.makeAcceptInputHandler(std::bind(&GuiGeneralScreensaverOptions::openVideoScreensaverOptions, this));
 	addRow(row);
 
 	row.elements.clear();
-	row.addElement(std::make_shared<TextComponent>(mWindow, "SLIDESHOW SCREENSAVER SETTINGS", theme->Text.font, theme->Text.color), true);
+	row.addElement(std::make_shared<TextComponent>(mWindow, _("SLIDESHOW SCREENSAVER SETTINGS"), theme->Text.font, theme->Text.color), true);
 	row.addElement(makeArrow(mWindow), false);
 	row.makeAcceptInputHandler(std::bind(&GuiGeneralScreensaverOptions::openSlideshowScreensaverOptions, this));
 	addRow(row);
+
+	// Allow ScreenSaver Controls - ScreenSaverControls
+	auto ss_controls = std::make_shared<SwitchComponent>(mWindow);
+	ss_controls->setState(Settings::getInstance()->getBool("ScreenSaverControls"));
+	addWithLabel(_("SCREENSAVER CONTROLS"), ss_controls);
+	addSaveFunc([ss_controls] { Settings::getInstance()->setBool("ScreenSaverControls", ss_controls->getState()); });
 }
 
 GuiGeneralScreensaverOptions::~GuiGeneralScreensaverOptions()
@@ -69,10 +70,10 @@ GuiGeneralScreensaverOptions::~GuiGeneralScreensaverOptions()
 }
 
 void GuiGeneralScreensaverOptions::openVideoScreensaverOptions() {
-	mWindow->pushGui(new GuiVideoScreensaverOptions(mWindow, "VIDEO SCREENSAVER"));
+	mWindow->pushGui(new GuiVideoScreensaverOptions(mWindow, _("VIDEO SCREENSAVER").c_str()));
 }
 
 void GuiGeneralScreensaverOptions::openSlideshowScreensaverOptions() {
-    mWindow->pushGui(new GuiSlideshowScreensaverOptions(mWindow, "SLIDESHOW SCREENSAVER"));
+    mWindow->pushGui(new GuiSlideshowScreensaverOptions(mWindow, _("SLIDESHOW SCREENSAVER").c_str()));
 }
 

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -269,7 +269,7 @@ void GuiMenu::addVersionInfo()
 
 void GuiMenu::openScreensaverOptions() 
 {
-	mWindow->pushGui(new GuiGeneralScreensaverOptions(mWindow, "SCREENSAVER SETTINGS"));
+	mWindow->pushGui(new GuiGeneralScreensaverOptions(mWindow, _("SCREENSAVER SETTINGS").c_str()));
 }
 
 // new screensaver options for Batocera
@@ -1706,6 +1706,8 @@ void GuiMenu::openUISettings()
 		}
 	});
 
+	s->addEntry(_("SCREENSAVER SETTINGS"), true, std::bind(&GuiMenu::openScreensaverOptions, this));
+/*
 	// screensaver time
 	auto screensaver_time = std::make_shared<SliderComponent>(mWindow, 0.f, 120.f, 1.f, "m");
 	screensaver_time->setValue(
@@ -1718,8 +1720,7 @@ void GuiMenu::openUISettings()
 
 	// Batocera screensavers: added "random video" (aka "demo mode") and slideshow at the same time,
 	// for those who don't scrape videos and stick with pictures
-	auto screensaver_behavior = std::make_shared<OptionListComponent<std::string> >(mWindow,
-		_("TRANSITION STYLE"), false);
+	auto screensaver_behavior = std::make_shared<OptionListComponent<std::string> >(mWindow,_("TRANSITION STYLE"), false);
 	std::vector<std::string> screensavers;
 	screensavers.push_back("dim");
 	screensavers.push_back("black");
@@ -1745,7 +1746,7 @@ void GuiMenu::openUISettings()
 
 	// SLIDESHOW SCREENSAVER SETTINGS
 	s->addEntry(_("SLIDESHOW SCREENSAVER SETTINGS"), true, std::bind(&GuiMenu::openSlideshowScreensaverOptions, this));
-
+*/
 	// clock
 	auto clock = std::make_shared<SwitchComponent>(mWindow);
 	clock->setState(Settings::getInstance()->getBool("DrawClock"));

--- a/es-app/src/guis/GuiSlideshowScreensaverOptions.cpp
+++ b/es-app/src/guis/GuiSlideshowScreensaverOptions.cpp
@@ -24,6 +24,12 @@ GuiSlideshowScreensaverOptions::GuiSlideshowScreensaverOptions(Window* window, c
 		Settings::getInstance()->setInt("ScreenSaverSwapImageTimeout", playNextTimeout);
 		PowerSaver::updateTimeouts();
 	});
+	
+	// SHOW GAME NAME
+	auto ss_controls = std::make_shared<SwitchComponent>(mWindow);
+	ss_controls->setState(Settings::getInstance()->getBool("SlideshowScreenSaverGameName"));
+	addWithLabel(row, _("SHOW GAME NAME"), ss_controls);
+	addSaveFunc([ss_controls] { Settings::getInstance()->setBool("SlideshowScreenSaverGameName", ss_controls->getState()); });
 
 	// stretch
 	auto sss_stretch = std::make_shared<SwitchComponent>(mWindow);
@@ -33,13 +39,14 @@ GuiSlideshowScreensaverOptions::GuiSlideshowScreensaverOptions(Window* window, c
 		Settings::getInstance()->setBool("SlideshowScreenSaverStretch", sss_stretch->getState());
 	});
 
+	/*
 	// background audio file
 	auto sss_bg_audio_file = std::make_shared<TextComponent>(mWindow, "", theme->TextSmall.font, theme->Text.color);
 	addEditableTextComponent(row, _("BACKGROUND AUDIO"), sss_bg_audio_file, Settings::getInstance()->getString("SlideshowScreenSaverBackgroundAudioFile"));
 	addSaveFunc([sss_bg_audio_file] {
 		Settings::getInstance()->setString("SlideshowScreenSaverBackgroundAudioFile", sss_bg_audio_file->getValue());
 	});
-
+	*/
 	// image source
 	auto sss_custom_source = std::make_shared<SwitchComponent>(mWindow);
 	sss_custom_source->setState(Settings::getInstance()->getBool("SlideshowScreenSaverCustomImageSource"));
@@ -67,6 +74,7 @@ GuiSlideshowScreensaverOptions::GuiSlideshowScreensaverOptions(Window* window, c
 	addSaveFunc([sss_image_filter] {
 		Settings::getInstance()->setString("SlideshowScreenSaverImageFilter", sss_image_filter->getValue());
 	});
+
 }
 
 GuiSlideshowScreensaverOptions::~GuiSlideshowScreensaverOptions()

--- a/es-app/src/views/SystemView.cpp
+++ b/es-app/src/views/SystemView.cpp
@@ -329,12 +329,15 @@ bool SystemView::input(InputConfig* config, Input input)
 			setCursor(SystemData::getRandomSystem());
 			return true;
 		}
+#ifndef WIN32
 		// batocera
 		if(config->isMappedTo("select", input))
 		{
 			GuiMenu::openQuitMenu_batocera_static(mWindow, true);        
 			return true;
 		}
+#endif
+
 	}else{
 		if(config->isMappedLike("left", input) ||
 			config->isMappedLike("right", input) ||
@@ -343,13 +346,16 @@ bool SystemView::input(InputConfig* config, Input input)
 			config->isMappedLike("pagedown", input) ||
 			config->isMappedLike("pageup", input))
 			listInput(0);
+
+#ifdef WIN32
 		// batocera
-		//if(!UIModeController::getInstance()->isUIModeKid() && config->isMappedTo("select", input) && Settings::getInstance()->getBool("ScreenSaverControls"))
-		//{
-		//	mWindow->startScreenSaver();
-		//	mWindow->renderScreenSaver();
-		//	return true;
-		//}
+		if(!UIModeController::getInstance()->isUIModeKid() && config->isMappedTo("select", input) && Settings::getInstance()->getBool("ScreenSaverControls"))
+		{
+			mWindow->startScreenSaver();
+			mWindow->renderScreenSaver();
+			return true;
+		}
+#endif
 	}
 
 	return GuiComponent::input(config, input);

--- a/es-core/src/Settings.cpp
+++ b/es-core/src/Settings.cpp
@@ -132,11 +132,12 @@ void Settings::setDefaults()
 
 	mIntMap["ScreenSaverSwapImageTimeout"] = 10000;
 	mBoolMap["SlideshowScreenSaverStretch"] = false;
-	mStringMap["SlideshowScreenSaverBackgroundAudioFile"] = "/userdata/music/slideshow_bg.wav"; // batocera
+	// mStringMap["SlideshowScreenSaverBackgroundAudioFile"] = "/userdata/music/slideshow_bg.wav"; // batocera
 	mBoolMap["SlideshowScreenSaverCustomImageSource"] = false;
 	mStringMap["SlideshowScreenSaverImageDir"] = "/userdata/screenshots"; // batocera
 	mStringMap["SlideshowScreenSaverImageFilter"] = ".png,.jpg";
 	mBoolMap["SlideshowScreenSaverRecurse"] = false;
+	mBoolMap["SlideshowScreenSaverGameName"] = true;	
 
 	// This setting only applies to raspberry pi but set it for all platforms so
 	// we don't get a warning if we encounter it on a different platform

--- a/es-core/src/ThemeData.cpp
+++ b/es-core/src/ThemeData.cpp
@@ -51,6 +51,7 @@ std::map<std::string, std::map<std::string, ThemeData::ElementPropertyType>> The
 		{ "folderImage", PATH },
 		{ "showVideoAtDelay", FLOAT },
 		{ "scrollDirection", STRING },
+		{ "scrollSound", PATH },
 		{ "centerSelection", BOOLEAN },
 		{ "scrollLoop", BOOLEAN } } },
 	{ "gridtile", {

--- a/es-core/src/Window.cpp
+++ b/es-core/src/Window.cpp
@@ -176,6 +176,15 @@ bool Window::init()
 	return true;
 }
 
+void Window::reactivateGui()
+{
+	for (auto i = mGuiStack.cbegin(); i != mGuiStack.cend(); i++)
+		(*i)->onShow();
+
+	if (peekGui())
+		peekGui()->updateHelpPrompts();
+}
+
 void Window::deinit()
 {
 	// Hide all GUI elements on uninitialisation - this disable
@@ -199,16 +208,16 @@ void Window::input(InputConfig* config, Input input)
 {
 	if (mScreenSaver) {
 		if (mScreenSaver->isScreenSaverActive() && Settings::getInstance()->getBool("ScreenSaverControls") &&
-			(Settings::getInstance()->getString("ScreenSaverBehavior") == "random video"))
+			((Settings::getInstance()->getString("ScreenSaverBehavior") == "slideshow") || 			
+			(Settings::getInstance()->getString("ScreenSaverBehavior") == "random video")))
 		{
-			if (mScreenSaver->getCurrentGame() != NULL && (config->isMappedLike("right", input) || config->isMappedTo("start", input) || config->isMappedTo("select", input)))
+			if (mScreenSaver->getCurrentGame() != nullptr && (config->isMappedLike("right", input) || config->isMappedTo("start", input) || config->isMappedTo("select", input)))
 			{
 				if (config->isMappedLike("right", input) || config->isMappedTo("select", input))
 				{
-					if (input.value != 0) {
-						// handle screensaver control
+					if (input.value != 0) // handle screensaver control
 						mScreenSaver->nextVideo();
-					}
+					
 					return;
 				}
 				else if (config->isMappedTo("start", input) && input.value != 0)

--- a/es-core/src/Window.h
+++ b/es-core/src/Window.h
@@ -80,6 +80,7 @@ public:
 	void unRegisterNotificationComponent(AsyncNotificationComponent* pc);
 
 	void postToUiThread(const std::function<void(Window*)>& func);
+	void reactivateGui();
 
 private:
 	void processPostedFunctions();

--- a/es-core/src/components/ImageGridComponent.h
+++ b/es-core/src/components/ImageGridComponent.h
@@ -79,6 +79,7 @@ public:
 	
 protected:
 	virtual void onCursorChanged(const CursorState& state) override;	
+	virtual void onScroll(int /*amt*/) { if (!mScrollSound.empty()) Sound::get(mScrollSound)->play(); }
 
 private:
 	// TILES
@@ -104,6 +105,8 @@ private:
 	Vector2f mTileSize;
 	Vector2i mGridDimension;
 	Vector2f mGridSizeOverride;
+
+	std::string mScrollSound;
 
 	std::shared_ptr<ThemeData> mTheme;
 	std::vector< std::shared_ptr<GridTileComponent> > mTiles;
@@ -461,7 +464,7 @@ void ImageGridComponent<T>::applyTheme(const std::shared_ptr<ThemeData>& theme, 
 		if (elem->has("showVideoAtDelay"))
 		{
 			mVideoDelay = elem->get<float>("showVideoAtDelay");
-			mAllowVideo = true;
+			mAllowVideo = (mVideoDelay >= 0);
 		}
 		else
 			mAllowVideo = false;
@@ -516,6 +519,9 @@ void ImageGridComponent<T>::applyTheme(const std::shared_ptr<ThemeData>& theme, 
 			}
 		}
 	}
+
+	if (elem->has("scrollSound"))
+		mScrollSound = elem->get<std::string>("scrollSound");
 
 	// We still need to manually get the grid tile size here,
 	// so we can recalculate the new grid dimension, and THEN (re)build the tiles


### PR DESCRIPTION
- Restored screensaver old submenu system ( more readable ) + allow "start" to run games.
- Fix onShow not called when returning back from games & kodi & game runned from screensaver -> Display can be black, or back flickering when changing system.
- GridView : Add sound support imagegrid.scrollSound