### PR TITLE
 Renderer blur fix & support for multiple languages in Theming 

### DIFF
--- a/es-app/src/guis/GuiGameScraper.cpp
+++ b/es-app/src/guis/GuiGameScraper.cpp
@@ -16,8 +16,9 @@ GuiGameScraper::GuiGameScraper(Window* window, ScraperSearchParams params, std::
 {
 	auto theme = ThemeData::getMenuTheme();
 	mBox.setImagePath(theme->Background.path);
-	mBox.setCenterColor(theme->Background.color);
 	mBox.setEdgeColor(theme->Background.color);
+	mBox.setCenterColor(theme->Background.centerColor);
+	mBox.setCornerSize(theme->Background.cornerSize);
 
 	PowerSaver::pause();
 	addChild(&mBox);

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -1278,113 +1278,41 @@ void GuiMenu::openThemeConfiguration(GuiSettings* s, std::shared_ptr<OptionListC
 	auto themeconfig = new GuiSettings(mWindow, _("THEME CONFIGURATION").c_str());
 
 	auto themeSubSets = theme->getSubSets();
-	auto themeColorSets = ThemeData::getSubSet(themeSubSets, "colorset");
-	auto themeIconSets = ThemeData::getSubSet(themeSubSets, "iconset");
-	auto themeMenus = ThemeData::getSubSet(themeSubSets, "menu");
-	auto themeSystemviewSets = ThemeData::getSubSet(themeSubSets, "systemview");
-	auto themeGamelistViewSets = ThemeData::getSubSet(themeSubSets, "gamelistview");
-	auto themeRegions = ThemeData::getSubSet(themeSubSets, "region");
 
-	// colorset
-	std::shared_ptr<OptionListComponent<std::string>> theme_colorset = nullptr;
-	if (themeColorSets.size() > 0)
+	std::map<std::string, std::shared_ptr<OptionListComponent<std::string>>> options;
+
+	for (std::string subset : theme->getSubSetNames())
 	{
-		auto selectedColorSet = std::find(themeColorSets.cbegin(), themeColorSets.cend(), Settings::getInstance()->getString("ThemeColorSet"));
-		if (selectedColorSet == themeColorSets.end())
-			selectedColorSet = themeColorSets.begin();
+		std::string settingName = "subset." + subset;
 
-		theme_colorset = std::make_shared<OptionListComponent<std::string> >(mWindow, _("THEME COLORSET"), false);
+		if (subset == "colorset") settingName = "ThemeColorSet";
+		else if (subset == "iconset") settingName = "ThemeIconSet";
+		else if (subset == "menu") settingName = "ThemeMenu";
+		else if (subset == "systemview") settingName = "ThemeSystemView";
+		else if (subset == "gamelistview") settingName = "ThemeGamelistView";
+		else if (subset == "region") settingName = "ThemeRegionName";
 
-		for (auto it = themeColorSets.begin(); it != themeColorSets.end(); it++)
-			theme_colorset->add(*it, *it, it == selectedColorSet);
+		auto themeColorSets = ThemeData::getSubSet(themeSubSets, subset);
 
-		if (!themeColorSets.empty())
-			themeconfig->addWithLabel(_("THEME COLORSET"), theme_colorset);
-	}
+		if (themeColorSets.size() > 0)
+		{
+			auto selectedColorSet = std::find(themeColorSets.cbegin(), themeColorSets.cend(), Settings::getInstance()->getString(settingName));
+			if (selectedColorSet == themeColorSets.end())
+				selectedColorSet = themeColorSets.begin();
+			
+			std::shared_ptr<OptionListComponent<std::string>> item = std::make_shared<OptionListComponent<std::string> >(mWindow, _(("THEME "+Utils::String::toUpper(subset)).c_str()), false);
+			item->setTag(settingName);
 
-	// iconset
-	std::shared_ptr<OptionListComponent<std::string>> theme_iconset = nullptr;
-	if (themeIconSets.size() > 0)
-	{
-		auto selectedIconSet = std::find(themeIconSets.cbegin(), themeIconSets.cend(), Settings::getInstance()->getString("ThemeIconSet"));
-		if (selectedIconSet == themeIconSets.end())
-			selectedIconSet = themeIconSets.begin();
+			for (auto it = themeColorSets.begin(); it != themeColorSets.end(); it++)
+				item->add(*it, *it, it == selectedColorSet);
 
-		theme_iconset = std::make_shared<OptionListComponent<std::string> >(mWindow, _("THEME ICONSET"), false);
+			if (!themeColorSets.empty())
+				themeconfig->addWithLabel(_(("THEME " + Utils::String::toUpper(subset)).c_str()), item);
 
-		for (auto it = themeIconSets.begin(); it != themeIconSets.end(); it++)
-			theme_iconset->add(*it, *it, it == selectedIconSet);
-
-		if (!themeIconSets.empty())
-			themeconfig->addWithLabel(_("THEME ICONSET"), theme_iconset);
-	}
-
-	// menu
-	std::shared_ptr<OptionListComponent<std::string>> theme_menu = nullptr;
-	if (themeMenus.size() > 0)
-	{
-		auto selectedMenu = std::find(themeMenus.cbegin(), themeMenus.cend(), Settings::getInstance()->getString("ThemeMenu"));
-		if (selectedMenu == themeMenus.end())
-			selectedMenu = themeMenus.begin();
-
-		theme_menu = std::make_shared<OptionListComponent<std::string> >(mWindow, _("THEME MENU"), false);
-
-		for (auto it = themeMenus.begin(); it != themeMenus.end(); it++)
-			theme_menu->add(*it, *it, it == selectedMenu);
-
-		if (!themeMenus.empty())
-			themeconfig->addWithLabel(_("THEME MENU"), theme_menu);
-	}
-
-	// systemview
-	std::shared_ptr<OptionListComponent<std::string>> theme_systemview = nullptr;
-	if (themeSystemviewSets.size() > 0)
-	{
-		auto selectedSystemviewSet = std::find(themeSystemviewSets.cbegin(), themeSystemviewSets.cend(), Settings::getInstance()->getString("ThemeSystemView"));
-		if (selectedSystemviewSet == themeSystemviewSets.end())
-			selectedSystemviewSet = themeSystemviewSets.begin();
-
-		theme_systemview = std::make_shared<OptionListComponent<std::string> >(mWindow, _("THEME SYSTEMVIEW"), false);
-
-		for (auto it = themeSystemviewSets.begin(); it != themeSystemviewSets.end(); it++)
-			theme_systemview->add(*it, *it, it == selectedSystemviewSet);
-
-		if (!themeSystemviewSets.empty())
-			themeconfig->addWithLabel(_("THEME SYSTEMVIEW"), theme_systemview);
-	}
-
-	// gamelistview
-	std::shared_ptr<OptionListComponent<std::string>> theme_gamelistview = nullptr;
-	if (themeGamelistViewSets.size() > 0)
-	{
-		auto selectedGamelistViewSet = std::find(themeGamelistViewSets.cbegin(), themeGamelistViewSets.cend(), Settings::getInstance()->getString("ThemeGamelistView"));
-		if (selectedGamelistViewSet == themeGamelistViewSets.end())
-			selectedGamelistViewSet = themeGamelistViewSets.begin();
-
-		theme_gamelistview = std::make_shared<OptionListComponent<std::string> >(mWindow, _("THEME GAMELISTVIEW"), false);
-
-		for (auto it = themeGamelistViewSets.begin(); it != themeGamelistViewSets.end(); it++)
-			theme_gamelistview->add(*it, *it, it == selectedGamelistViewSet);
-
-		if (!themeGamelistViewSets.empty())
-			themeconfig->addWithLabel(_("THEME GAMELISTVIEW"), theme_gamelistview);
-	}
-
-	// themeregion
-	std::shared_ptr<OptionListComponent<std::string>> theme_region = nullptr;
-	if (themeRegions.size() > 0)
-	{
-		auto selectedRegion = std::find(themeRegions.cbegin(), themeRegions.cend(), Settings::getInstance()->getString("ThemeRegionName"));
-		if (selectedRegion == themeRegions.end())
-			selectedRegion = themeRegions.begin();
-
-		theme_region = std::make_shared<OptionListComponent<std::string> >(mWindow, _("THEME REGION"), false);
-
-		for (auto it = themeRegions.begin(); it != themeRegions.end(); it++)
-			theme_region->add(*it, *it, it == selectedRegion);
-
-		if (!themeRegions.empty())
-			themeconfig->addWithLabel(_("THEME REGION"), theme_region);
+			options[settingName]  = item;
+		}
+		else 
+			options[settingName] = nullptr;
 	}
 
 	// gamelist_style
@@ -1456,15 +1384,14 @@ void GuiMenu::openThemeConfiguration(GuiSettings* s, std::shared_ptr<OptionListC
 		themeconfig->close();		
 	});
 
-	themeconfig->addSaveFunc([this, themeconfig, theme_set, theme_colorset, theme_iconset, theme_menu, theme_systemview, theme_gamelistview, theme_region, gamelist_style, mGridSize, window]
+	//  theme_colorset, theme_iconset, theme_menu, theme_systemview, theme_gamelistview, theme_region,
+	themeconfig->addSaveFunc([this, themeconfig, theme_set, options, gamelist_style, mGridSize, window]
 	{
 		bool reloadAll = Settings::getInstance()->setString("ThemeSet", theme_set == nullptr ? "" : theme_set->getSelected());
-		reloadAll |= Settings::getInstance()->setString("ThemeColorSet", theme_colorset == nullptr ? "" : theme_colorset->getSelected());
-		reloadAll |= Settings::getInstance()->setString("ThemeIconSet", theme_iconset == nullptr ? "" : theme_iconset->getSelected());
-		reloadAll |= Settings::getInstance()->setString("ThemeMenu", theme_menu == nullptr ? "" : theme_menu->getSelected());
-		reloadAll |= Settings::getInstance()->setString("ThemeSystemView", theme_systemview == nullptr ? "" : theme_systemview->getSelected());
-		reloadAll |= Settings::getInstance()->setString("ThemeGamelistView", theme_gamelistview == nullptr ? "" : theme_gamelistview->getSelected());
-		reloadAll |= Settings::getInstance()->setString("ThemeRegionName", theme_region == nullptr ? "" : theme_region->getSelected());
+
+		for (auto option : options)			
+			reloadAll |= Settings::getInstance()->setString(option.first, option.second == nullptr ? "" : option.second->getSelected());
+	
 		reloadAll |= Settings::getInstance()->setString("GamelistViewStyle", gamelist_style == nullptr ? "" : gamelist_style->getSelected());
 
 		if (mGridSize != nullptr)
@@ -1540,6 +1467,10 @@ void GuiMenu::openUISettings()
 				Settings::getInstance()->setString("ThemeGamelistView", "");
 				Settings::getInstance()->setString("GamelistViewStyle", "");
 				Settings::getInstance()->setString("DefaultGridSize", "");
+
+				for(auto sm : Settings::getInstance()->getStringMap())
+					if (Utils::String::startsWith(sm.first, "subset."))
+						Settings::getInstance()->setString(sm.first, "");
 
 				for (auto sysIt = SystemData::sSystemVector.cbegin(); sysIt != SystemData::sSystemVector.cend(); sysIt++)
 					(*sysIt)->setSystemViewMode("automatic", Vector2f(0,0));

--- a/es-app/src/guis/GuiMetaDataEd.cpp
+++ b/es-app/src/guis/GuiMetaDataEd.cpp
@@ -34,8 +34,9 @@ GuiMetaDataEd::GuiMetaDataEd(Window* window, MetaDataList* md, const std::vector
 {
 	auto theme = ThemeData::getMenuTheme();
 	mBackground.setImagePath(theme->Background.path); // ":/frame.png"
-	mBackground.setCenterColor(theme->Background.color);
 	mBackground.setEdgeColor(theme->Background.color);
+	mBackground.setCenterColor(theme->Background.centerColor);
+	mBackground.setCornerSize(theme->Background.cornerSize);
 
 	addChild(&mBackground);
 	addChild(&mGrid);

--- a/es-app/src/guis/GuiScraperMulti.cpp
+++ b/es-app/src/guis/GuiScraperMulti.cpp
@@ -17,9 +17,10 @@ GuiScraperMulti::GuiScraperMulti(Window* window, const std::queue<ScraperSearchP
 	mSearchQueue(searches)
 {
 	auto theme = ThemeData::getMenuTheme();
-	mBackground.setImagePath(theme->Background.path); // ":/frame.png"
-	mBackground.setCenterColor(theme->Background.color);
+	mBackground.setImagePath(theme->Background.path); // ":/frame.png"	
 	mBackground.setEdgeColor(theme->Background.color);
+	mBackground.setCenterColor(theme->Background.centerColor);
+	mBackground.setCornerSize(theme->Background.cornerSize);
 
 	assert(mSearchQueue.size());
 

--- a/es-app/src/guis/GuiVideoScreensaverOptions.cpp
+++ b/es-app/src/guis/GuiVideoScreensaverOptions.cpp
@@ -19,13 +19,11 @@ GuiVideoScreensaverOptions::GuiVideoScreensaverOptions(Window* window, const cha
 		PowerSaver::updateTimeouts();
 	});
 
-//#ifdef _RPI_
+#ifdef _RPI_
 	auto ss_omx = std::make_shared<SwitchComponent>(mWindow);
 	ss_omx->setState(Settings::getInstance()->getBool("ScreenSaverOmxPlayer"));
 	addWithLabel(_("USE OMX PLAYER FOR SCREENSAVER"), ss_omx);
 	addSaveFunc([ss_omx, this] { Settings::getInstance()->setBool("ScreenSaverOmxPlayer", ss_omx->getState()); });
-//#endif
-
 	ss_omx->setOnChangedCallback([this, ss_omx, window]()
 	{
 		if (Settings::getInstance()->setBool("ScreenSaverOmxPlayer", ss_omx->getState()))
@@ -35,7 +33,8 @@ GuiVideoScreensaverOptions::GuiVideoScreensaverOptions(Window* window, const cha
 			pw->pushGui(new GuiVideoScreensaverOptions(pw, _("VIDEO SCREENSAVER").c_str()));
 		}
 	});
-
+#endif
+	   
 	// Render Video Game Name as subtitles
 	auto ss_info = std::make_shared< OptionListComponent<std::string> >(mWindow, _("SHOW GAME INFO"), false);
 	std::vector<std::string> info_type;
@@ -49,9 +48,9 @@ GuiVideoScreensaverOptions::GuiVideoScreensaverOptions(Window* window, const cha
 
 	bool advancedOptions = true;
 
-//#ifdef _RPI_
+#ifdef _RPI_
 	advancedOptions = !Settings::getInstance()->getBool("ScreenSaverOmxPlayer");
-//#endif
+#endif
 
 	if (advancedOptions)
 	{

--- a/es-core/src/LocaleES.cpp
+++ b/es-core/src/LocaleES.cpp
@@ -215,7 +215,8 @@ void EsLocale::checkLocalisationLoaded()
 				{
 					std::string	msgstr = line.substr(start + 1, end - start - 1);
 					if (!msgid.empty() && !msgstr.empty())
-						mItems[msgid] = msgstr;
+						if (idx.empty() || idx == "0")
+							mItems[msgid] = msgstr;
 
 					if (!msgid_plural.empty() && !msgstr.empty())
 					{

--- a/es-core/src/Settings.h
+++ b/es-core/src/Settings.h
@@ -24,6 +24,8 @@ public:
 	bool setFloat(const std::string& name, float value);
 	bool setString(const std::string& name, const std::string& value);
 
+	std::map<std::string, std::string>& getStringMap() { return mStringMap; }
+
 private:
 	static Settings* sInstance;
 

--- a/es-core/src/ThemeData.cpp
+++ b/es-core/src/ThemeData.cpp
@@ -548,6 +548,9 @@ void ThemeData::parseVariable(const pugi::xml_node& node)
 	if (key.empty())
 		return;
 
+	if (!parseRegion(node) || !parseLanguage(node))
+		return;
+
 	std::string val = node.text().as_string();
 	if (val.empty())
 		return;
@@ -562,10 +565,12 @@ void ThemeData::parseVariables(const pugi::xml_node& root)
 	error.setFiles(mPaths);
     
 	pugi::xml_node variables = root.child("variables");
-
 	if(!variables)
 		return;
-    
+
+	if (!parseRegion(variables) || !parseLanguage(variables))
+		return;
+
 	for(pugi::xml_node_iterator it = variables.begin(); it != variables.end(); ++it)
 		parseVariable(*it);
 }

--- a/es-core/src/ThemeData.h
+++ b/es-core/src/ThemeData.h
@@ -276,6 +276,7 @@ private:
 	bool parseRegion(const pugi::xml_node& node);
 	bool parseSubset(const pugi::xml_node& node);
 	bool isFirstSubset(const pugi::xml_node& node);
+	bool parseLanguage(const pugi::xml_node& node);
 	
 	void parseCustomViewBaseClass(const pugi::xml_node& root, ThemeView& view, std::string baseClass);
 
@@ -288,6 +289,7 @@ private:
 	std::string mSystemview;
 	std::string mGamelistview;
 	std::string mSystemThemeFolder;	
+	std::string mLanguage;
 	
 	std::map<std::string, std::string> mVariables;
 	std::map<std::string, ThemeView> mViews;

--- a/es-core/src/ThemeData.h
+++ b/es-core/src/ThemeData.h
@@ -108,8 +108,20 @@ struct MenuElement
 	unsigned int selectorGradientColor;
 	bool selectorGradientType;
 	std::string path;
-	std::string fadePath;
 	std::shared_ptr<Font> font;
+};
+
+struct MenuBackground
+{
+	unsigned int color;
+	unsigned int centerColor;
+	std::string path;
+	std::string fadePath;	
+	Vector2f cornerSize;	
+
+	std::string shaderPath;
+	unsigned int shaderColor;
+	bool shaderTiled;
 };
 
 struct IconElement 
@@ -133,11 +145,11 @@ public:
 	public:
 		ThemeMenu(ThemeData* theme);
 
-		MenuElement Background{ 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, true, ":/frame.png", ":/scroll_gradient.png", nullptr };
-		MenuElement Title{ 0x555555FF, 0x555555FF, 0x555555FF, 0xFFFFFFFF, 0x555555FF, true, "", "", nullptr };
-		MenuElement Text{ 0x777777FF, 0xFFFFFFFF, 0x878787FF, 0xC6C7C6FF, 0x878787FF, true, "", "", nullptr };
-		MenuElement TextSmall{ 0x777777FF, 0xFFFFFFFF, 0x878787FF, 0xC6C7C6FF, 0x878787FF, true, "", "", nullptr };
-		MenuElement Footer{ 0xC6C6C6FF, 0xC6C6C6FF, 0xC6C6C6FF, 0xFFFFFFFF, 0xC6C6C6FF, true, "", "", nullptr };
+		MenuBackground Background{ 0xFFFFFFFF, 0xFFFFFFFF, ":/frame.png", ":/scroll_gradient.png", Vector2f(16, 16), "", 0xFFFFFFFF, true };
+		MenuElement Title{ 0x555555FF, 0x555555FF, 0x555555FF, 0xFFFFFFFF, 0x555555FF, true, "", nullptr };
+		MenuElement Text{ 0x777777FF, 0xFFFFFFFF, 0x878787FF, 0xC6C7C6FF, 0x878787FF, true, "", nullptr };
+		MenuElement TextSmall{ 0x777777FF, 0xFFFFFFFF, 0x878787FF, 0xC6C7C6FF, 0x878787FF, true, "", nullptr };
+		MenuElement Footer{ 0xC6C6C6FF, 0xC6C6C6FF, 0xC6C6C6FF, 0xFFFFFFFF, 0xC6C6C6FF, true, "", nullptr };
 		IconElement Icons{ ":/button.png", ":/button_filled.png", ":/on.svg", ":/off.svg", ":/option_arrow.svg", ":/arrow.svg", ":/slider_knob.svg", ":/textinput_ninepatch.png", ":/textinput_ninepatch_active.png" };
 
 		std::string getMenuIcon(const std::string name)
@@ -241,7 +253,8 @@ public:
 	bool hasSubsets() { return mSubsets.size() > 0; }
 	static const std::shared_ptr<ThemeData::ThemeMenu>& getMenuTheme();
 
-	std::vector<Subset>		getSubSets() { return mSubsets; }
+	std::vector<Subset>		    getSubSets() { return mSubsets; }
+	std::vector<std::string>	getSubSetNames();
 
 	static std::vector<std::string> getSubSet(const std::vector<Subset>& subsets, const std::string& subset);
 
@@ -277,7 +290,8 @@ private:
 	bool parseSubset(const pugi::xml_node& node);
 	bool isFirstSubset(const pugi::xml_node& node);
 	bool parseLanguage(const pugi::xml_node& node);
-	
+	bool parseFilterAttributes(const pugi::xml_node& node);
+
 	void parseCustomViewBaseClass(const pugi::xml_node& root, ThemeView& view, std::string baseClass);
 
 	std::string resolveSystemVariable(const std::string& systemThemeFolder, const std::string& path);
@@ -290,7 +304,8 @@ private:
 	std::string mGamelistview;
 	std::string mSystemThemeFolder;	
 	std::string mLanguage;
-	
+	std::string mRegion;
+
 	std::map<std::string, std::string> mVariables;
 	std::map<std::string, ThemeView> mViews;
 

--- a/es-core/src/Window.cpp
+++ b/es-core/src/Window.cpp
@@ -530,16 +530,20 @@ void Window::render()
 	unsigned int screensaverTime = (unsigned int)Settings::getInstance()->getInt("ScreenSaverTime");
 	if(mTimeSinceLastInput >= screensaverTime && screensaverTime != 0)
 		startScreenSaver();
-	
-	// Always call the screensaver render function regardless of whether the screensaver is active
-	// or not because it may perform a fade on transition
-	renderScreenSaver();
 
 	if(!mRenderScreenSaver && mInfoPopup)
 		mInfoPopup->render(transform);
 
 	renderRegisteredNotificationComponents(transform);
 	
+
+	// Always call the screensaver render function regardless of whether the screensaver is active
+	// or not because it may perform a fade on transition
+	renderScreenSaver();
+
+	if (mImageShader)
+		mImageShader->render(transform);
+
 	if(mTimeSinceLastInput >= screensaverTime && screensaverTime != 0)
 	{
 		if (!isProcessing() && mAllowSleep && (!mScreenSaver || mScreenSaver->allowSleep()))
@@ -572,6 +576,21 @@ void Window::endRenderLoadingScreen()
 {
 	mSplash = nullptr;	
 
+	if (ThemeData::getMenuTheme()->Background.shaderPath.empty())
+		mImageShader = nullptr;
+	else
+	{
+		if (mImageShader == nullptr)
+			mImageShader = std::make_shared<ImageComponent>(this, true, false);
+		
+		auto theme = ThemeData::getMenuTheme()->Background;
+
+		mImageShader->setImage(theme.shaderPath, theme.shaderTiled);
+		mImageShader->setColorShift(theme.shaderColor);
+		mImageShader->setSize(Renderer::getScreenWidth(), Renderer::getScreenHeight());
+
+	}
+	
 	// Window has not way to apply Theme -> As a workaround : endRenderLoadingScreen is always called when theme changes.
 	mBackgroundOverlay->setImage(ThemeData::getMenuTheme()->Background.fadePath);
 }

--- a/es-core/src/Window.h
+++ b/es-core/src/Window.h
@@ -107,6 +107,8 @@ private:
 	GuiInfoPopup*	mInfoPopup;
 	bool			mRenderScreenSaver;
 
+	std::shared_ptr<ImageComponent> mImageShader;
+
 	std::vector<GuiComponent*> mGuiStack;
 
 	typedef std::pair<std::string, int> NotificationMessage;

--- a/es-core/src/components/AsyncNotificationComponent.cpp
+++ b/es-core/src/components/AsyncNotificationComponent.cpp
@@ -30,8 +30,9 @@ AsyncNotificationComponent::AsyncNotificationComponent(Window* window, bool acti
 
 	mFrame = new NinePatchComponent(window);
 	mFrame->setImagePath(theme->Background.path);
-	mFrame->setCenterColor(theme->Background.color);
 	mFrame->setEdgeColor(theme->Background.color);
+	mFrame->setCenterColor(theme->Background.centerColor);
+	mFrame->setCornerSize(theme->Background.cornerSize);
 	mFrame->fitTo(mSize, Vector3f::Zero(), Vector2f(-32, -32));
 	addChild(mFrame);
 

--- a/es-core/src/components/BusyComponent.cpp
+++ b/es-core/src/components/BusyComponent.cpp
@@ -20,8 +20,9 @@ BusyComponent::BusyComponent(Window* window) : GuiComponent(window),
 {
 	auto theme = ThemeData::getMenuTheme();
 	mBackground.setImagePath(theme->Background.path);
-	mBackground.setCenterColor(theme->Background.color);
 	mBackground.setEdgeColor(theme->Background.color);
+	mBackground.setCenterColor(theme->Background.centerColor);
+	mBackground.setCornerSize(theme->Background.cornerSize);
     
 	mutex = SDL_CreateMutex(); // batocera
 	mAnimation = std::make_shared<AnimatedImageComponent>(mWindow);

--- a/es-core/src/components/MenuComponent.cpp
+++ b/es-core/src/components/MenuComponent.cpp
@@ -18,8 +18,9 @@ MenuComponent::MenuComponent(Window* window, const char* title, const std::share
 	addChild(&mGrid);
 
 	mBackground.setImagePath(theme->Background.path);
-	mBackground.setCenterColor(theme->Background.color);
 	mBackground.setEdgeColor(theme->Background.color);
+	mBackground.setCenterColor(theme->Background.centerColor);
+	mBackground.setCornerSize(theme->Background.cornerSize);
 
 	// set up title
 	mTitle = std::make_shared<TextComponent>(mWindow);

--- a/es-core/src/components/NinePatchComponent.cpp
+++ b/es-core/src/components/NinePatchComponent.cpp
@@ -38,11 +38,11 @@ void NinePatchComponent::updateColors()
 	const unsigned int edgeColor   = Renderer::convertColor(mEdgeColor & 0xFFFFFF00 | (unsigned char)((mEdgeColor & 0xFF) * opacity));
 	const unsigned int centerColor = Renderer::convertColor(mCenterColor & 0xFFFFFF00 | (unsigned char)((mCenterColor & 0xFF) * opacity));
 
-	for(int i = 0; i < 6*9; ++i)
+	for(int i = 0; i < 6*9; i++)
 		mVertices[i].col = edgeColor;
 
-	for(int i = 6*4; i < 6; ++i)
-		mVertices[(6*4)+i].col = centerColor;
+	for(int i = 0; i < 6; i++)
+		mVertices[(4 * 6) + i].col = centerColor;
 }
 
 void NinePatchComponent::buildVertices()

--- a/es-core/src/guis/GuiDetectDevice.cpp
+++ b/es-core/src/guis/GuiDetectDevice.cpp
@@ -16,8 +16,9 @@ GuiDetectDevice::GuiDetectDevice(Window* window, bool firstRun, const std::funct
 {
 	auto theme = ThemeData::getMenuTheme();
 	mBackground.setImagePath(theme->Background.path);
-	mBackground.setCenterColor(theme->Background.color);
 	mBackground.setEdgeColor(theme->Background.color);
+	mBackground.setCenterColor(theme->Background.centerColor);
+	mBackground.setCornerSize(theme->Background.cornerSize);
 
 	mHoldingConfig = NULL;
 	mHoldTime = 0;

--- a/es-core/src/guis/GuiInfoPopup.cpp
+++ b/es-core/src/guis/GuiInfoPopup.cpp
@@ -51,6 +51,7 @@ GuiInfoPopup::GuiInfoPopup(Window* window, std::string message, int duration) :
 	mFrame->setImagePath(theme->Background.path);
 	mFrame->setCenterColor(mBackColor);
 	mFrame->setEdgeColor(mBackColor);
+	mFrame->setCornerSize(theme->Background.cornerSize);
 	mFrame->fitTo(mSize, Vector3f::Zero(), Vector2f(-32, -32));
 	addChild(mFrame);
 

--- a/es-core/src/guis/GuiInputConfig.cpp
+++ b/es-core/src/guis/GuiInputConfig.cpp
@@ -82,8 +82,10 @@ GuiInputConfig::GuiInputConfig(Window* window, InputConfig* target, bool reconfi
 {
 	auto theme = ThemeData::getMenuTheme();
 	mBackground.setImagePath(theme->Background.path);
-	mBackground.setCenterColor(theme->Background.color);
 	mBackground.setEdgeColor(theme->Background.color);
+	mBackground.setCenterColor(theme->Background.centerColor);
+	mBackground.setCornerSize(theme->Background.cornerSize);
+
 	mGrid.setSeparatorColor(theme->Text.separatorColor);
 
 	LOG(LogInfo) << "Configuring device " << target->getDeviceId() << " (" << target->getDeviceName() << ").";

--- a/es-core/src/guis/GuiMsgBox.cpp
+++ b/es-core/src/guis/GuiMsgBox.cpp
@@ -27,8 +27,9 @@ GuiMsgBox::GuiMsgBox(Window* window, const std::string& text,
 {
 	auto theme = ThemeData::getMenuTheme();
 	mBackground.setImagePath(theme->Background.path);
-	mBackground.setCenterColor(theme->Background.color);
 	mBackground.setEdgeColor(theme->Background.color);
+	mBackground.setCenterColor(theme->Background.centerColor);
+	mBackground.setCornerSize(theme->Background.cornerSize);
 
 	float width = Renderer::getScreenWidth() * 0.6f; // max width
 	float minWidth = Renderer::getScreenWidth() * 0.3f; // minimum width

--- a/es-core/src/guis/GuiTextEditPopup.cpp
+++ b/es-core/src/guis/GuiTextEditPopup.cpp
@@ -11,8 +11,9 @@ GuiTextEditPopup::GuiTextEditPopup(Window* window, const std::string& title, con
 {
 	auto theme = ThemeData::getMenuTheme();
 	mBackground.setImagePath(theme->Background.path);
-	mBackground.setCenterColor(theme->Background.color);
 	mBackground.setEdgeColor(theme->Background.color);
+	mBackground.setCenterColor(theme->Background.centerColor);
+	mBackground.setCornerSize(theme->Background.cornerSize);
 
 	addChild(&mBackground);
 	addChild(&mGrid);

--- a/es-core/src/guis/GuiTextEditPopupKeyboard.cpp
+++ b/es-core/src/guis/GuiTextEditPopupKeyboard.cpp
@@ -46,8 +46,9 @@ GuiTextEditPopupKeyboard::GuiTextEditPopupKeyboard(Window* window, const std::st
 {
 	auto theme = ThemeData::getMenuTheme();
 	mBackground.setImagePath(theme->Background.path);
-	mBackground.setCenterColor(theme->Background.color);
 	mBackground.setEdgeColor(theme->Background.color);
+	mBackground.setCenterColor(theme->Background.centerColor);
+	mBackground.setCornerSize(theme->Background.cornerSize);
 
 	addChild(&mBackground);
 	addChild(&mGrid);

--- a/es-core/src/renderers/Renderer_GL21.cpp
+++ b/es-core/src/renderers/Renderer_GL21.cpp
@@ -105,7 +105,7 @@ namespace Renderer
 		glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, _repeat ? GL_REPEAT : GL_CLAMP_TO_EDGE);
 
 		glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, _linear ? GL_LINEAR : GL_NEAREST);
-		glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, _linear ? GL_LINEAR : GL_NEAREST);
+		glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
 
 		glPixelStorei(GL_PACK_ALIGNMENT, 1);
 		glPixelStorei(GL_UNPACK_ALIGNMENT, 1);

--- a/es-core/src/renderers/Renderer_GLES10.cpp
+++ b/es-core/src/renderers/Renderer_GLES10.cpp
@@ -105,7 +105,7 @@ namespace Renderer
 		glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, _repeat ? GL_REPEAT : GL_CLAMP_TO_EDGE);
 
 		glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, _linear ? GL_LINEAR : GL_NEAREST);
-		glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, _linear ? GL_LINEAR : GL_NEAREST);
+		glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
 
 		glPixelStorei(GL_PACK_ALIGNMENT, 1);
 		glPixelStorei(GL_UNPACK_ALIGNMENT, 1);

--- a/resources/off.svg
+++ b/resources/off.svg
@@ -1,1 +1,59 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="43.916" height="21.959"><path fill="#fff" d="M29.291 15.69h1.934v-4.113h5.42v-1.479h-5.42V7.704h5.729V6.225h-7.662v9.465zm-9.481 0h1.936v-4.113h5.416v-1.479h-5.416V7.704h5.725V6.225h-7.66v9.465zm-7.432-1.217c-2.166 0-3.404-1.435-3.404-3.517 0-2.083 1.238-3.518 3.404-3.518 2.167 0 3.406 1.435 3.406 3.518 0 2.082-1.239 3.517-3.406 3.517m0 1.483c3.896 0 5.419-2.335 5.419-5s-1.522-4.997-5.419-4.997c-3.896 0-5.416 2.332-5.416 4.997s1.52 5 5.416 5"/><path fill="#fff" d="M39.664 1.5a2.754 2.754 0 0 1 2.752 2.752v13.455a2.754 2.754 0 0 1-2.752 2.752H4.252A2.754 2.754 0 0 1 1.5 17.707V4.252A2.754 2.754 0 0 1 4.252 1.5h35.412m0-1.5H4.252A4.265 4.265 0 0 0 0 4.252v13.455a4.265 4.265 0 0 0 4.252 4.252h35.412a4.264 4.264 0 0 0 4.252-4.252V4.252A4.265 4.265 0 0 0 39.664 0z"/></svg>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="43.916"
+   height="21.959"
+   version="1.1"
+   id="svg6"
+   sodipodi:docname="off.svg"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)">
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1017"
+     id="namedview8"
+     showgrid="false"
+     inkscape:zoom="8.1063848"
+     inkscape:cx="-38.179781"
+     inkscape:cy="10.9795"
+     inkscape:window-x="1912"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg6" />
+  <path
+     inkscape:connector-curvature="0"
+     d="m 10.433336,3.2447139 c -3.9517024,0 -7.1666696,3.4606288 -7.1666696,7.7142851 0,4.253654 3.2149672,7.714288 7.1666696,7.714288 3.9517,0 7.166664,-3.460634 7.166664,-7.714288 0,-4.2536563 -3.214964,-7.7142851 -7.166664,-7.7142851 z m 0,13.8857201 C 7.2721164,17.130434 4.7,14.361768 4.7,10.958999 c 0,-3.402771 2.5721164,-6.1714279 5.733336,-6.1714279 3.161214,0 5.733328,2.7686569 5.733328,6.1714279 0,3.402769 -2.572114,6.171435 -5.733328,6.171435 z"
+     id="path2-2"
+     style="fill:#ffffff;stroke-width:0.74354357" />
+  <path
+     inkscape:connector-curvature="0"
+     d="M 33.366664,0.159 H 10.433336 C 4.9006664,0.159 0.4,5.0035711 0.4,10.958999 0.4,16.914434 4.9006664,21.759 10.433336,21.759 H 33.366664 C 38.899336,21.759 43.4,16.914434 43.4,10.958999 43.4,5.0035711 38.899336,0.159 33.366664,0.159 Z m 0,20.057147 H 10.433336 c -4.742186,0 -8.6000024,-4.1526 -8.6000024,-9.257148 0,-5.1045428 3.8578164,-9.2571425 8.6000024,-9.2571425 h 22.933328 c 4.742186,0 8.6,4.1525997 8.6,9.2571425 0,5.104548 -3.857814,9.257148 -8.6,9.257148 z"
+     id="path4-6"
+     style="fill:#ffffff;stroke-width:0.74354357" />
+</svg>

--- a/resources/on.svg
+++ b/resources/on.svg
@@ -1,1 +1,54 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="43.916" height="21.959"><g fill="#fff"><path d="M15.754 7.461c-2.319 0-3.643 1.434-3.643 3.518 0 2.083 1.325 3.521 3.643 3.521 2.32 0 3.644-1.437 3.645-3.521 0-2.084-1.325-3.518-3.645-3.518z"/><path d="M39.664 0H4.252A4.265 4.265 0 0 0 0 4.252v13.455a4.265 4.265 0 0 0 4.252 4.252h35.412a4.264 4.264 0 0 0 4.252-4.252V4.252A4.265 4.265 0 0 0 39.664 0zm-23.91 15.979c-4.168 0-5.796-2.334-5.796-5 0-2.669 1.628-5.001 5.796-5.001 4.17 0 5.798 2.332 5.798 5.001 0 2.665-1.628 5-5.798 5zm18.203-.264h-2.332L25.72 8.602h-.027v7.113h-1.988V6.244h2.373l5.865 7.114h.027V6.244h1.987v9.471z"/></g></svg>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="43.916"
+   height="21.959"
+   version="1.1"
+   id="svg8"
+   sodipodi:docname="on.svg"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)">
+  <metadata
+     id="metadata14">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs12" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="716"
+     inkscape:window-height="405"
+     id="namedview10"
+     showgrid="false"
+     inkscape:zoom="8.1063848"
+     inkscape:cx="-18.133854"
+     inkscape:cy="10.9795"
+     inkscape:window-x="2144"
+     inkscape:window-y="126"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg8" />
+  <path
+     inkscape:connector-curvature="0"
+     d="M 10.433337,21.759 H 33.366664 C 38.899337,21.759 43.4,16.91443 43.4,10.959 43.4,5.003571 38.899337,0.159 33.366663,0.159 H 10.433337 C 4.9006667,0.159 0.4,5.003571 0.4,10.959 c 0,5.95543 4.5006667,10.8 10.033337,10.8 z M 33.366664,3.2447141 c 3.9517,0 7.166673,3.4606284 7.166673,7.7142859 0,4.253657 -3.214973,7.714287 -7.166673,7.714287 -3.9517,0 -7.166663,-3.46063 -7.166663,-7.714287 0,-4.2536575 3.214963,-7.7142859 7.166663,-7.7142859 z"
+     id="path6"
+     style="fill:#ffffff;stroke-width:0.74354357" />
+</svg>


### PR DESCRIPTION
- Renderer : upscaled image are blurred (not usable in themes like es_pixel) since Retropie's Tomaz Renderer refactoring.
- Video ScreenSaver options : OMX still visible on every platform 
- Theming : Support for "lang" attribute ( manage multiple languages in a theme )
- Themes : Support for user defined subsets.
- Themes : Support for "shaders"
- Themes : Menu background -> Support for custom corner size ( usefull for menu with shadows )

PS : Don't forget to bump my es_carbon theme to see new things....

