### PR TITLE
Theming Added <view name="screen" > to manage fixed components.

### DIFF
--- a/es-app/src/SystemData.cpp
+++ b/es-app/src/SystemData.cpp
@@ -16,6 +16,7 @@
 #include "Window.h"
 #include "LocaleES.h"
 #include "utils/StringUtil.h"
+#include "views/ViewController.h"
 
 using namespace Utils;
 
@@ -354,7 +355,10 @@ bool SystemData::loadConfig(Window* window)
 	}
 
 	if (SystemData::sSystemVector.size() > 0)
-		ThemeData::setDefaultTheme(SystemData::sSystemVector.at(0)->getTheme().get());
+	{
+		auto theme = SystemData::sSystemVector.at(0)->getTheme();
+		ViewController::get()->onThemeChanged(theme);		
+	}
 
 	return true;
 }

--- a/es-app/src/SystemScreenSaver.h
+++ b/es-app/src/SystemScreenSaver.h
@@ -88,10 +88,11 @@ private:
 	unsigned long countGameListNodes(const char *nodeName);
 	void countVideos();
 	void countImages();
-	void pickGameListNode(unsigned long index, const char *nodeName, std::string& path);
-	void pickRandomVideo(std::string& path);
-	void pickRandomGameListImage(std::string& path);
-	void pickRandomCustomImage(std::string& path);
+
+	std::string pickGameListNode(unsigned long index, const char *nodeName);
+	std::string pickRandomVideo();
+	std::string pickRandomGameListImage();
+	std::string pickRandomCustomImage();
 
 	enum STATE {
 		STATE_INACTIVE,

--- a/es-app/src/scrapers/ScreenScraper.cpp
+++ b/es-app/src/scrapers/ScreenScraper.cpp
@@ -13,6 +13,14 @@
 
 using namespace PlatformIds;
 
+std::string ScreenScraperRequest::ensureUrl(const std::string url)
+{
+	return Utils::String::replace(
+		Utils::String::replace(url, " ", "%20") ,
+		"#screenscraperserveur#", "https://www.screenscraper.fr/");
+}
+
+
 /**
 	List of systems and their IDs from
 	https://www.screenscraper.fr/api/systemesListe.php?devid=xxx&devpassword=yyy&softname=zzz&output=XML
@@ -348,7 +356,7 @@ void ScreenScraperRequest::processGame(const pugi::xml_document& xmldoc, std::ve
 				{
 					// Sending a 'softname' containing space will make the image URLs returned by the API also contain the space. 
 					//  Escape any spaces in the URL here
-					result.imageUrl = Utils::String::replace(art.text().get(), " ", "%20");
+					result.imageUrl = ensureUrl(art.text().get());
 
 					// Get the media type returned by ScreenScraper
 					std::string media_type = art.attribute("format").value();
@@ -372,7 +380,7 @@ void ScreenScraperRequest::processGame(const pugi::xml_document& xmldoc, std::ve
 					if (art)
 					{
 						// Ask for the same image, but with a smaller size, for the thumbnail displayed during scraping
-						result.thumbnailUrl = Utils::String::replace(art.text().get(), " ", "%20");
+						result.thumbnailUrl = ensureUrl(art.text().get());
 					}
 					else
 						LOG(LogDebug) << "Failed to find media XML node for thumbnail";
@@ -386,7 +394,7 @@ void ScreenScraperRequest::processGame(const pugi::xml_document& xmldoc, std::ve
 				{
 					pugi::xml_node art = findMedia(media_list, ripList, region);
 					if (art)
-						result.marqueeUrl = Utils::String::replace(art.text().get(), " ", "%20");
+						result.marqueeUrl = ensureUrl(art.text().get());
 					else
 						LOG(LogDebug) << "Failed to find media XML node for video";
 				}
@@ -396,7 +404,7 @@ void ScreenScraperRequest::processGame(const pugi::xml_document& xmldoc, std::ve
 			{
 				pugi::xml_node art = findMedia(media_list, "video", region);
 				if (art)
-					result.videoUrl = Utils::String::replace(art.text().get(), " ", "%20");
+					result.videoUrl = ensureUrl(art.text().get());
 				else
 					LOG(LogDebug) << "Failed to find media XML node for video";
 			}

--- a/es-app/src/scrapers/ScreenScraper.h
+++ b/es-app/src/scrapers/ScreenScraper.h
@@ -58,6 +58,7 @@ public:
 
 protected:
 	void process(const std::unique_ptr<HttpReq>& req, std::vector<ScraperSearchResult>& results) override;
+	std::string ensureUrl(const std::string url);
 
 	void processList(const pugi::xml_document& xmldoc, std::vector<ScraperSearchResult>& results);
 	void processGame(const pugi::xml_document& xmldoc, std::vector<ScraperSearchResult>& results);

--- a/es-app/src/views/ViewController.cpp
+++ b/es-app/src/views/ViewController.cpp
@@ -611,7 +611,7 @@ void ViewController::reloadGameListView(IGameListView* view, bool reloadTheme)
 	}
 	
 	if (SystemData::sSystemVector.size() > 0 && reloadTheme)
-		ThemeData::setDefaultTheme(SystemData::sSystemVector.at(0)->getTheme().get());
+		ViewController::get()->onThemeChanged(SystemData::sSystemVector.at(0)->getTheme());
 
 	// Redisplay the current view
 	if (mCurrentView)
@@ -669,7 +669,7 @@ void ViewController::reloadAll(Window* window)
 	}
 
 	if (SystemData::sSystemVector.size() > 0)
-		ThemeData::setDefaultTheme(SystemData::sSystemVector.at(0)->getTheme().get());
+		ViewController::get()->onThemeChanged(SystemData::sSystemVector.at(0)->getTheme());
 
 	// Rebuild SystemListView
 	mSystemListView.reset();
@@ -714,4 +714,11 @@ HelpStyle ViewController::getHelpStyle()
 		return GuiComponent::getHelpStyle();
 
 	return mCurrentView->getHelpStyle();
+}
+
+
+void ViewController::onThemeChanged(const std::shared_ptr<ThemeData>& theme)
+{
+	ThemeData::setDefaultTheme(theme.get());
+	mWindow->onThemeChanged(theme);
 }

--- a/es-app/src/views/ViewController.h
+++ b/es-app/src/views/ViewController.h
@@ -87,6 +87,8 @@ public:
 	std::shared_ptr<SystemView> getSystemListView();
 	void removeGameListView(SystemData* system);
 
+	void onThemeChanged(const std::shared_ptr<ThemeData>& theme);
+
 private:
 	ViewController(Window* window);
 	static ViewController* sInstance;

--- a/es-app/src/views/gamelist/DetailedGameListView.cpp
+++ b/es-app/src/views/gamelist/DetailedGameListView.cpp
@@ -127,6 +127,9 @@ void DetailedGameListView::createVideo()
 #endif
 		mVideo = new VideoVlcComponent(mWindow, "");
 
+	// Default is IMAGE in Recalbox themes -> video view does not exist
+	mVideo->setSnapshotSource(IMAGE);
+
 	mVideo->setOrigin(0.5f, 0.5f);
 	mVideo->setPosition(mSize.x() * 0.25f, mSize.y() * 0.4f);
 	mVideo->setSize(mSize.x() * (0.5f - 2 * padding), mSize.y() * 0.4f);
@@ -317,7 +320,15 @@ void DetailedGameListView::updateInfoPanel()
 			if (!mVideo->setVideo(file->getVideoPath()))
 				mVideo->setDefaultVideo();
 
-			mVideo->setImage(imagePath);
+			std::string snapShot = imagePath;
+
+			auto src = mVideo->getSnapshotSource();
+			if (src == MARQUEE && !file->getMarqueePath().empty())
+				snapShot = file->getMarqueePath();
+			if (src == THUMBNAIL && !file->getThumbnailPath().empty())
+				snapShot = file->getThumbnailPath();
+
+			mVideo->setImage(snapShot);
 		}
 
 		if (mImage != nullptr)

--- a/es-app/src/views/gamelist/VideoGameListView.cpp
+++ b/es-app/src/views/gamelist/VideoGameListView.cpp
@@ -38,6 +38,9 @@ VideoGameListView::VideoGameListView(Window* window, FolderData* root) :
 	mVideo = new VideoVlcComponent(window, getTitlePath());
 #endif
 
+	// Default is thumbnail in Retropie themes & video view
+	mVideo->setSnapshotSource(THUMBNAIL);
+
 	mList.setPosition(mSize.x() * (0.50f + padding), mList.getPosition().y());
 	mList.setSize(mSize.x() * (0.50f - padding), mList.getSize().y());
 	mList.setAlignment(TextListComponent<FileData*>::ALIGN_LEFT);
@@ -253,8 +256,17 @@ void VideoGameListView::updateInfoPanel()
 			mVideo->setDefaultVideo();
 		}
 		mVideoPlaying = true;
+		
+		std::string snapShot = file->getThumbnailPath();
 
-		mVideo->setImage(file->getThumbnailPath()/*, false, mVideo->getMaxSizeInfo()*/); // Too slow on pi
+		auto src = mVideo->getSnapshotSource();
+		if (src == MARQUEE && !file->getMarqueePath().empty())
+			snapShot = file->getMarqueePath();
+		if (src == IMAGE && !file->getImagePath().empty())
+			snapShot = file->getImagePath();
+
+		mVideo->setImage(snapShot);
+
 		mMarquee.setImage(file->getMarqueePath()/*, false, mMarquee.getMaxSizeInfo()*/); // Too slow on pi
 		mImage.setImage(file->getImagePath(), false, mImage.getMaxSizeInfo());
 

--- a/es-core/src/HelpStyle.cpp
+++ b/es-core/src/HelpStyle.cpp
@@ -8,20 +8,10 @@ HelpStyle::HelpStyle()
 	origin = Vector2f(0.0f, 0.0f);
 	iconColor = 0x777777FF;
 	textColor = 0x777777FF;
-
-	clockPosition = Vector2f(-1, -1);
-	clockColor = 0x777777FF;
+	font = nullptr;
 
 	if (FONT_SIZE_SMALL != 0)
-	{
 		font = Font::get(FONT_SIZE_SMALL);
-		clockFont = Font::get(FONT_SIZE_SMALL);
-	}
-	else
-	{
-		font = nullptr;
-		clockFont = nullptr;
-	}
 }
 
 void HelpStyle::applyTheme(const std::shared_ptr<ThemeData>& theme, const std::string& view)
@@ -36,19 +26,13 @@ void HelpStyle::applyTheme(const std::shared_ptr<ThemeData>& theme, const std::s
 			origin = elem->get<Vector2f>("origin");
 
 		if (elem->has("textColor"))
-		{
 			textColor = elem->get<unsigned int>("textColor");
-			clockColor = textColor;
-		}
 
 		if (elem->has("iconColor"))
 			iconColor = elem->get<unsigned int>("iconColor");
 
 		if (elem->has("fontPath") || elem->has("fontSize"))
-		{
 			font = Font::getFromTheme(elem, ThemeFlags::ALL, font);
-			clockFont = font;
-		}
 
 		if (elem->has("iconUpDown"))
 			iconMap["up/down"] = elem->get<std::string>("iconUpDown");
@@ -83,21 +67,4 @@ void HelpStyle::applyTheme(const std::shared_ptr<ThemeData>& theme, const std::s
 		if (elem->has("iconSelect"))
 			iconMap["select"] = elem->get<std::string>("iconSelect");
 	}
-
-	elem = theme->getElement(view, "clock", "clock");
-	if (elem)
-	{
-		if (elem->has("pos"))
-			clockPosition = elem->get<Vector2f>("pos") * Vector2f((float)Renderer::getScreenWidth(), (float)Renderer::getScreenHeight());
-		else
-			clockPosition = Vector2f(-1, -1);
-
-		if (elem->has("fontPath") || elem->has("fontSize"))
-			clockFont = Font::getFromTheme(elem, ThemeFlags::ALL, font);
-
-		if (elem->has("textColor"))
-			clockColor = elem->get<unsigned int>("textColor");
-	}
-	else
-		clockPosition = Vector2f(-1, -1);
 }

--- a/es-core/src/HelpStyle.h
+++ b/es-core/src/HelpStyle.h
@@ -18,11 +18,7 @@ struct HelpStyle
 	unsigned int textColor;
 	std::shared_ptr<Font> font;
 	std::map<std::string, std::string> iconMap;
-
-	Vector2f clockPosition;
-	std::shared_ptr<Font> clockFont;
-	unsigned int clockColor;
-
+	
 	HelpStyle(); // default values
 	void applyTheme(const std::shared_ptr<ThemeData>& theme, const std::string& view);
 };

--- a/es-core/src/HttpReq.cpp
+++ b/es-core/src/HttpReq.cpp
@@ -378,9 +378,13 @@ int HttpReq::saveContent(const std::string filename, bool checkMedia)
 	if (!Utils::FileSystem::exists(mStreamPath))
 		return false;
 
-	if (checkMedia && Utils::FileSystem::getFileSize(mStreamPath) < 300)
+	if (checkMedia && Utils::FileSystem::getFileSize(mStreamPath) < 1024)
 	{
 		auto data = Utils::String::toUpper(getContent());
+		
+		if (data.find("<!DOCTYPE HTML") != std::string::npos)
+			return 2;
+		
 		if (data.find("NOMEDIA") != std::string::npos || data.find("ERREUR") != std::string::npos || data.find("ERROR") != std::string::npos || data.find("PROBL") != std::string::npos)
 			return 2;
 	}

--- a/es-core/src/ThemeData.cpp
+++ b/es-core/src/ThemeData.cpp
@@ -12,7 +12,7 @@
 #include "SystemConf.h"
 #include <algorithm>
 
-std::vector<std::string> ThemeData::sSupportedViews { { "system" }, { "basic" }, { "detailed" }, { "grid" }, { "video" }, { "menu" } };
+std::vector<std::string> ThemeData::sSupportedViews { { "system" }, { "basic" }, { "detailed" }, { "grid" }, { "video" }, { "menu" }, { "screen" } };
 std::vector<std::string> ThemeData::sSupportedFeatures { { "video" }, { "carousel" }, { "z-index" }, { "visible" } };
 
 std::map<std::string, std::map<std::string, ThemeData::ElementPropertyType>> ThemeData::sElementMap {
@@ -79,6 +79,7 @@ std::map<std::string, std::map<std::string, ThemeData::ElementPropertyType>> The
 		{ "fontSize", FLOAT },
 		{ "color", COLOR },
 		{ "alignment", STRING },
+		{ "verticalAlignment", STRING },
 		{ "forceUppercase", BOOLEAN },
 		{ "lineSpacing", FLOAT },
 		{ "value", STRING },
@@ -196,6 +197,7 @@ std::map<std::string, std::map<std::string, ThemeData::ElementPropertyType>> The
 		{ "effect", STRING },
 	 	{ "visible", BOOLEAN },
 	 	{ "zIndex", FLOAT },		
+		{ "snapshotSource", STRING }, // image, thumbnail, marquee
 		{ "showSnapshotNoVideo", BOOLEAN },
 		{ "showSnapshotDelay", BOOLEAN } } },
 	{ "carousel", {
@@ -231,9 +233,6 @@ std::map<std::string, std::map<std::string, ThemeData::ElementPropertyType>> The
 	{ "menuBackground", {
 		{ "path", PATH },
 		{ "fadePath", PATH },
-		{ "shaderPath", PATH },
-		{ "shaderColor", COLOR },
-		{ "shaderTiled", BOOLEAN },
 		{ "color", COLOR },
 		{ "centerColor", COLOR },
 		{ "cornerSize", NORMALIZED_PAIR } } },
@@ -1165,15 +1164,6 @@ ThemeData::ThemeMenu::ThemeMenu(ThemeData* theme)
 
 		if (elem->has("fadePath") && ResourceManager::getInstance()->fileExists(elem->get<std::string>("fadePath")))
 			Background.fadePath = elem->get<std::string>("fadePath");
-
-		if (elem->has("shaderPath") && ResourceManager::getInstance()->fileExists(elem->get<std::string>("shaderPath")))
-			Background.shaderPath = elem->get<std::string>("shaderPath");
-
-		if (elem->has("shaderColor"))
-			Background.shaderColor = elem->get<unsigned int>("shaderColor");
-
-		if (elem->has("shaderTiled"))
-			Background.shaderTiled = elem->get<bool>("shaderTiled");
 
 		if (elem->has("color"))
 		{

--- a/es-core/src/ThemeData.h
+++ b/es-core/src/ThemeData.h
@@ -118,10 +118,6 @@ struct MenuBackground
 	std::string path;
 	std::string fadePath;	
 	Vector2f cornerSize;	
-
-	std::string shaderPath;
-	unsigned int shaderColor;
-	bool shaderTiled;
 };
 
 struct IconElement 
@@ -145,7 +141,7 @@ public:
 	public:
 		ThemeMenu(ThemeData* theme);
 
-		MenuBackground Background{ 0xFFFFFFFF, 0xFFFFFFFF, ":/frame.png", ":/scroll_gradient.png", Vector2f(16, 16), "", 0xFFFFFFFF, true };
+		MenuBackground Background{ 0xFFFFFFFF, 0xFFFFFFFF, ":/frame.png", ":/scroll_gradient.png", Vector2f(16, 16) };
 		MenuElement Title{ 0x555555FF, 0x555555FF, 0x555555FF, 0xFFFFFFFF, 0x555555FF, true, "", nullptr };
 		MenuElement Text{ 0x777777FF, 0xFFFFFFFF, 0x878787FF, 0xC6C7C6FF, 0x878787FF, true, "", nullptr };
 		MenuElement TextSmall{ 0x777777FF, 0xFFFFFFFF, 0x878787FF, 0xC6C7C6FF, 0x878787FF, true, "", nullptr };

--- a/es-core/src/Window.h
+++ b/es-core/src/Window.h
@@ -21,6 +21,8 @@ struct HelpStyle;
 class TextureResource;
 class GuiInfoPopup;
 class AsyncNotificationComponent;
+class ThemeData;
+class TextComponent;
 
 class Window
 {
@@ -82,6 +84,8 @@ public:
 	void postToUiThread(const std::function<void(Window*)>& func);
 	void reactivateGui();
 
+	void onThemeChanged(const std::shared_ptr<ThemeData>& theme);
+
 private:
 	void processPostedFunctions();
 
@@ -106,9 +110,8 @@ private:
 	ScreenSaver*	mScreenSaver;
 	GuiInfoPopup*	mInfoPopup;
 	bool			mRenderScreenSaver;
-
-	std::shared_ptr<ImageComponent> mImageShader;
-
+	
+	std::vector<GuiComponent*> mScreenExtras;
 	std::vector<GuiComponent*> mGuiStack;
 
 	typedef std::pair<std::string, int> NotificationMessage;
@@ -125,11 +128,8 @@ private:
 
 	// clock // batocera
 	int mClockElapsed;
-
-	unsigned int mClockColor;
-	Vector2f mClockPos;
-	std::shared_ptr<Font> mClockFont;
-	std::unique_ptr<TextCache> mClockText;
+	
+	std::shared_ptr<TextComponent>	mClock;
 
 	// pads // batocera
 	int mplayerPads[MAX_PLAYERS];

--- a/es-core/src/components/TextComponent.h
+++ b/es-core/src/components/TextComponent.h
@@ -76,8 +76,7 @@ private:
 	unsigned int mGlowSize;
 	Vector2f	 mGlowOffset;
 	Vector4f	 mPadding;
-
-
+	
 	Vector2f	mReflection;
 	bool		mReflectOnBorders;
 };

--- a/es-core/src/components/VideoComponent.cpp
+++ b/es-core/src/components/VideoComponent.cpp
@@ -22,27 +22,30 @@ std::string getTitleFolder() {
 void writeSubtitle(const char* gameName, const char* systemName, bool always)
 {
 	FILE* file = fopen(getTitlePath().c_str(), "w");
-	int end = (int)(Settings::getInstance()->getInt("ScreenSaverSwapVideoTimeout") / (1000));
-	if (always) {
-		fprintf(file, "1\n00:00:01,000 --> 00:00:%d,000\n", end);
-	}
-	else
+	if (file)
 	{
-		fprintf(file, "1\n00:00:01,000 --> 00:00:08,000\n");
-	}
-	fprintf(file, "%s\n", gameName);
-	fprintf(file, "<i>%s</i>\n\n", systemName);
-
-	if (!always) {
-		if (end > 12)
-		{
-			fprintf(file, "2\n00:00:%d,000 --> 00:00:%d,000\n%s\n<i>%s</i>\n", end-4, end, gameName, systemName);
+		int end = (int)(Settings::getInstance()->getInt("ScreenSaverSwapVideoTimeout") / (1000));
+		if (always) {
+			fprintf(file, "1\n00:00:01,000 --> 00:00:%d,000\n", end);
 		}
-	}
+		else
+		{
+			fprintf(file, "1\n00:00:01,000 --> 00:00:08,000\n");
+		}
+		fprintf(file, "%s\n", gameName);
+		fprintf(file, "<i>%s</i>\n\n", systemName);
 
-	fflush(file);
-	fclose(file);
-	file = NULL;
+		if (!always) {
+			if (end > 12)
+			{
+				fprintf(file, "2\n00:00:%d,000 --> 00:00:%d,000\n%s\n<i>%s</i>\n", end - 4, end, gameName, systemName);
+			}
+		}
+
+		fflush(file);
+		fclose(file);
+		file = NULL;
+	}
 }
 
 void VideoComponent::setScreensaverMode(bool isScreensaver)
@@ -73,6 +76,7 @@ VideoComponent::VideoComponent(Window* window) :
 	// Setup the default configuration
 	mConfig.showSnapshotDelay 		= false;
 	mConfig.showSnapshotNoVideo		= false;
+	mConfig.snapshotSource = IMAGE;
 	mConfig.startDelay				= 0;
 	if (mWindow->getGuiStackSize() > 1) {
 		topWindow(false);
@@ -245,6 +249,17 @@ void VideoComponent::applyTheme(const std::shared_ptr<ThemeData>& theme, const s
 
 	if (elem->has("showSnapshotDelay"))
 		mConfig.showSnapshotDelay = elem->get<bool>("showSnapshotDelay");
+
+	if (elem->has("snapshotSource"))
+	{
+		auto direction = elem->get<std::string>("snapshotSource");
+		if (direction == "image")
+			mConfig.snapshotSource = IMAGE;
+		else if (direction == "marquee")
+			mConfig.snapshotSource = MARQUEE;
+		else
+			mConfig.snapshotSource = THUMBNAIL;
+	}
 
 	if(properties & ThemeFlags::ROTATION) {
 		if(elem->has("rotation"))

--- a/es-core/src/components/VideoComponent.h
+++ b/es-core/src/components/VideoComponent.h
@@ -3,6 +3,7 @@
 #define ES_CORE_COMPONENTS_VIDEO_COMPONENT_H
 
 #include "components/ImageComponent.h"
+#include "components/ImageGridComponent.h"
 #include "GuiComponent.h"
 #include "ImageIO.h"
 #include <string>
@@ -12,7 +13,14 @@ class TextureResource;
 std::string	getTitlePath();
 std::string	getTitleFolder();
 void writeSubtitle(const char* gameName, const char* systemName, bool always);
-
+/*
+enum ImageSource
+{
+	THUMBNAIL,
+	IMAGE,
+	MARQUEE
+};
+*/
 class VideoComponent : public GuiComponent
 {
 	// Structure that groups together the configuration of the video component
@@ -21,6 +29,7 @@ class VideoComponent : public GuiComponent
 		unsigned						startDelay;
 		bool							showSnapshotNoVideo;
 		bool							showSnapshotDelay;
+		ImageSource						snapshotSource;
 		std::string						defaultVideoPath;
 	};
 
@@ -94,6 +103,9 @@ public:
 
 		return MaxSizeInfo(mTargetSize, mTargetIsMax);
 	};
+
+	ImageSource getSnapshotSource() { return mConfig.snapshotSource; };
+	void setSnapshotSource(ImageSource source) { mConfig.snapshotSource = source; };
 
 private:
 	// Start the video Immediately

--- a/es-core/src/components/VideoVlcComponent.h
+++ b/es-core/src/components/VideoVlcComponent.h
@@ -73,6 +73,7 @@ public:
 	void setMinSize(float width, float height);
 
 	virtual void applyTheme(const std::shared_ptr<ThemeData>& theme, const std::string& view, const std::string& element, unsigned int properties);
+	virtual void update(int deltaTime);
 
 private:
 	// Calculates the correct mSize from our resizing information (set by setResize/setMaxSize).
@@ -103,6 +104,8 @@ private:
 	std::string					    mSubtitleTmpFile;
 
 	VideoVlcFlags::VideoVlcEffect	mEffect;
+
+	int								mElapsed;
 };
 
 #endif // ES_CORE_COMPONENTS_VIDEO_VLC_COMPONENT_H


### PR DESCRIPTION
- Theming Add <view name="screen" > to manage fixed components that are to be "statically" displayed ( crt or scanlines effects, clock )
- Clock : Complete rewrite using a text component - Now customisable in <view name="screen" > <text ="clock">
- Vlc Video : RPI only :  A lot of videos are encoded in 60fps on screenscraper. Add a limit at 30fps for transfers to opengl textures to save CPU.
- Video component : Add element <snapshotSource> (image, thumbnail, marquee) to define the image snapshot source.
- Screenscraper : Temp Fix. We sometimes receive #screenscraperserveur# in the url instead of the server.