### PR TITLE
Removed "auto" from shaders, new default is "none".

### DIFF
--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -851,10 +851,14 @@ void GuiMenu::openGamesSettings_batocera()
 		false);
 	std::string currentShader = SystemConf::getInstance()->get("global.shaderset");
 	if (currentShader.empty()) {
-		currentShader = std::string("auto");
+		currentShader = std::string("none");
+	}
+	if (currentShader == "auto") { // Batocera 5.24: no "auto" shaders any longer
+		currentShader = std::string("none");
+		SystemConf::getInstance()->set("global.shaderset", currentShader);
+		SystemConf::getInstance()->saveSystemConf();
 	}
 
-	shaders_choices->add(_("AUTO"), "auto", currentShader == "auto");
 	shaders_choices->add(_("NONE"), "none", currentShader == "none");
 	shaders_choices->add(_("SCANLINES"), "scanlines", currentShader == "scanlines");
 	shaders_choices->add(_("RETRO"), "retro", currentShader == "retro");
@@ -2317,10 +2321,14 @@ void GuiMenu::popSpecificConfigurationGui(Window* mWindow, std::string title, st
 									     false);
   std::string currentShader = SystemConf::getInstance()->get(configName + ".shaderset");
   if (currentShader.empty()) {
-    currentShader = std::string("auto");
+    currentShader = std::string("none");
+  }
+  if (currentShader == "auto") { // Batocera 5.24: no "auto" shaders any longer
+    currentShader = std::string("none");
+    SystemConf::getInstance()->set(configName + ".shaderset", currentShader);
+    SystemConf::getInstance()->saveSystemConf();
   }
 
-  shaders_choices->add(_("AUTO"), "auto", currentShader == "auto");
   shaders_choices->add(_("NONE"), "none", currentShader == "none");
   shaders_choices->add(_("SCANLINES"), "scanlines", currentShader == "scanlines");
   shaders_choices->add(_("RETRO"), "retro", currentShader == "retro");


### PR DESCRIPTION
The shader set "auto" is removed as it's basically the same as "none" now -- see https://github.com/batocera-linux/batocera.linux/pull/987 
So, this PR removes the option and ensures a graceful transition from "auto" shader sets to "none" from Batocera 5.23 and earlier versions.