### PR TITLE
Scraper : Add missing & fix existing systems

### DIFF
--- a/es-app/CMakeLists.txt
+++ b/es-app/CMakeLists.txt
@@ -59,6 +59,7 @@ set(ES_HEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/src/scrapers/GamesDBJSONScraper.h
     ${CMAKE_CURRENT_SOURCE_DIR}/src/scrapers/GamesDBJSONScraperResources.h
     ${CMAKE_CURRENT_SOURCE_DIR}/src/scrapers/ScreenScraper.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/scrapers/md5.h
 
     # Views
     ${CMAKE_CURRENT_SOURCE_DIR}/src/views/gamelist/BasicGameListView.h
@@ -132,6 +133,7 @@ set(ES_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/scrapers/GamesDBJSONScraper.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/scrapers/GamesDBJSONScraperResources.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/scrapers/ScreenScraper.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/src/scrapers/md5.cpp
 
     # Views
     ${CMAKE_CURRENT_SOURCE_DIR}/src/views/gamelist/BasicGameListView.cpp

--- a/es-app/src/PlatformId.cpp
+++ b/es-app/src/PlatformId.cpp
@@ -1,100 +1,143 @@
 #include "PlatformId.h"
 
+#include <map>
 #include <string.h>
 
 namespace PlatformIds
 {
-	const char* PlatformNames[PLATFORM_COUNT + 1] = {
-		"unknown", // nothing set
+	static std::map<std::string, PlatformId> Platforms =
+	{
+		{ "unknown",				PLATFORM_UNKNOWN },
+		{ "3do",					THREEDO },
+		{ "amiga",					AMIGA },
+		{ "amstradcpc",				AMSTRAD_CPC },
+		{ "apple2",					APPLE_II },
+		{ "arcade",					ARCADE },
+		{ "atari800",				ATARI_800 },
+		{ "atari2600",				ATARI_2600 },
+		{ "atari5200",				ATARI_5200 },
+		{ "atari7800",				ATARI_7800 },
+		{ "atarilynx",				ATARI_LYNX },
+		{ "atarist",				ATARI_ST },
+		{ "atarijaguar",			ATARI_JAGUAR },
+		{ "atarijaguarcd",			ATARI_JAGUAR_CD },
+		{ "atarixe",				ATARI_XE },
+		{ "colecovision",			COLECOVISION },
+		{ "c64",					COMMODORE_64 },
+		{ "intellivision",			INTELLIVISION },
+		{ "macintosh",				MAC_OS },
+		{ "xbox",					XBOX },
+		{ "xbox360",				XBOX_360 },
+		{ "msx",					MSX },
+		{ "neogeo",					NEOGEO },
+		{ "ngp", 					NEOGEO_POCKET },
+		{ "ngpc",					NEOGEO_POCKET_COLOR },
+		{ "n3ds",					NINTENDO_3DS },
+		{ "n64", 					NINTENDO_64 },
+		{ "nds", 					NINTENDO_DS },
+		{ "fds", 					FAMICOM_DISK_SYSTEM },
+		{ "nes", 					NINTENDO_ENTERTAINMENT_SYSTEM },
+		{ "gb", 					GAME_BOY },
+		{ "gba", 					GAME_BOY_ADVANCE },
+		{ "gbc", 					GAME_BOY_COLOR },
+		{ "gc", 					NINTENDO_GAMECUBE },
+		{ "wii",					NINTENDO_WII },
+		{ "wiiu",					NINTENDO_WII_U },
+		{ "virtualboy",				NINTENDO_VIRTUAL_BOY },
+		{ "gameandwatch",			NINTENDO_GAME_AND_WATCH },
+		{ "pc",						PC },
+		{ "sega32x",				SEGA_32X },
+		{ "segacd",					SEGA_CD },
+		{ "dreamcast",				SEGA_DREAMCAST },
+		{ "gamegear",				SEGA_GAME_GEAR },
+		{ "genesis",				SEGA_GENESIS },
+		{ "mastersystem",			SEGA_MASTER_SYSTEM },
+		{ "megadrive",				SEGA_MEGA_DRIVE },
+		{ "saturn",					SEGA_SATURN },
+		{ "sg-1000",				SEGA_SG1000 },
+		{ "psx",					PLAYSTATION },
+		{ "ps2",					PLAYSTATION_2 },
+		{ "ps3",					PLAYSTATION_3 },
+		{ "ps4",					PLAYSTATION_4 },
+		{ "psvita",					PLAYSTATION_VITA },
+		{ "psp",					PLAYSTATION_PORTABLE },
+		{ "snes",					SUPER_NINTENDO },
+		{ "scummvm",				SCUMMVM },
+		{ "x68000",					SHARP_X6800 },
+		{ "pcengine",				TURBOGRAFX_16 }, // (aka PC Engine) HuCards onlyy
+		{ "pcenginecd",				TURBOGRAFX_CD }, // (aka PC Engine) CD-ROMs onlynly
+		{ "wonderswan",				WONDERSWAN },
+		{ "wonderswancolor",		WONDERSWAN_COLOR },
+		{ "zxspectrum",				ZX_SPECTRUM },
+		{ "videopac",				VIDEOPAC_ODYSSEY2 },
+		{ "vectrex",				VECTREX },
+		{ "trs-80",					TRS80_COLOR_COMPUTER },
+		{ "coco",					TANDY },		
+		{ "supergrafx",				SUPERGRAFX },
+		{ "amigacd32",				AMIGACD32 },
+		{ "amigacdtv",				AMIGACDTV },
+		{ "atomiswave",				ATOMISWAVE },
+		{ "cavestory",				CAVESTORY },
+		{ "gx4000",					GX4000 },
+		{ "lutro",					LUTRO },
+		{ "moonlight",				MOONLIGHT },
+		{ "naomi",					NAOMI },
+		{ "neogeocd",				NEOGEO_CD },
+		{ "pcfx",					PCFX },
+		{ "pokemini",				POKEMINI },
+		{ "prboom",					PRBOOM },
+		{ "satellaview",			SATELLAVIEW },
+		{ "sufami",					SUFAMITURBO },
+		{ "zx81",					ZX81 },
 
-		"3do",
-		"amiga",
-		"amstradcpc",
-		"apple2",
-		"arcade",
-		"atari800",
-		"atari2600",
-		"atari5200",
-		"atari7800",
-		"atarilynx",
-		"atarist",
-		"atarijaguar",
-		"atarijaguarcd",
-		"atarixe",
-		"colecovision",
-		"c64", // commodore 64
-		"intellivision",
-		"macintosh",
-		"xbox",
-		"xbox360",
-		"msx",
-		"neogeo",
-		"ngp", // neo geo pocket
-		"ngpc", // neo geo pocket color
-		"n3ds", // nintendo 3DS
-		"n64", // nintendo 64
-		"nds", // nintendo DS
-		"fds", // Famicom Disk System
-		"nes", // nintendo entertainment system
-		"gb", // game boy
-		"gba", // game boy advance
-		"gbc", // game boy color
-		"gc", // gamecube
-		"wii",
-		"wiiu",
-		"virtualboy",
-		"gameandwatch",
-		"pc",
-		"sega32x",
-		"segacd",
-		"dreamcast",
-		"gamegear",
-		"genesis", // sega genesis
-		"mastersystem", // sega master system
-		"megadrive", // sega megadrive
-		"saturn", // sega saturn
-		"sg-1000",
-		"psx",
-		"ps2",
-		"ps3",
-		"ps4",
-		"psvita",
-		"psp", // playstation portable
-		"snes", // super nintendo entertainment system
-		"scummvm",
-		"x6800",
-		"pcengine", // (aka turbografx-16) HuCards only
-		"pcenginecd", // (aka turbografx-16) CD-ROMs only
-		"wonderswan",
-		"wonderswancolor",
-		"zxspectrum",
-		"videopac",
-		"vectrex",
-		"trs-80",
-		"coco",
-		"odyssey2",
-		"supergrafx",
+		// batocera specific names
+		{ "gb2players", 			GAME_BOY },
+		{ "gbc2players", 			GAME_BOY_COLOR },
+		{ "3ds",					NINTENDO_3DS },
+		{ "sg1000",					SEGA_SG1000 },
+		{ "odyssey2",				VIDEOPAC_ODYSSEY2 },
+		{ "oricatmos",				ORICATMOS },
 
-		"ignore", // do not allow scraping for this system
-		"invalid"
+		// windows specific systems & names
+		{ "windows",				MOONLIGHT },
+		{ "vpinball",				VISUALPINBALL },
+		{ "fpinball",				FUTUREPINBALL },
+		{ "o2em",					VIDEOPAC_ODYSSEY2 },
+
+		// Misc systems
+		{ "channelf",				CHANNELF },
+		{ "oric",					ORICATMOS },
+		{ "thomson",				THOMSON_TO_MO },
+		{ "samcoupe",				SAMCOUPE },
+		{ "OpenBOR",				OPENBOR },
+		{ "uzebox",					UZEBOX },
+		{ "apple2gs",				APPLE2GS },
+		{ "Spectravideo",			SPECTRAVIDEO },
+		{ "palm",					PALMOS },
+		{ "daphne",					DAPHNEE },
+
+		{ "ignore",					PLATFORM_IGNORE },
+		{ "invalid",				PLATFORM_COUNT }
 	};
 
 	PlatformId getPlatformId(const char* str)
 	{
-		if(str == NULL)
+		if (str == nullptr)
 			return PLATFORM_UNKNOWN;
 
-		for(unsigned int i = 1; i < PLATFORM_COUNT; i++)
-		{
-			if(strcmp(PlatformNames[i], str) == 0)
-				return (PlatformId)i;
-		}
+		auto it = Platforms.find(str);
+		if (it != Platforms.end())
+			return (*it).second;
 
 		return PLATFORM_UNKNOWN;
 	}
 
-	const char* getPlatformName(PlatformId id)
+	std::string getPlatformName(PlatformId id)
 	{
-		return PlatformNames[id];
+		for (auto& it : Platforms)
+			if (it.second == id)
+				return it.first;
+
+		return "unknown";
 	}
 }

--- a/es-app/src/PlatformId.cpp
+++ b/es-app/src/PlatformId.cpp
@@ -73,6 +73,7 @@ namespace PlatformIds
 		"trs-80",
 		"coco",
 		"odyssey2",
+		"supergrafx",
 
 		"ignore", // do not allow scraping for this system
 		"invalid"

--- a/es-app/src/PlatformId.h
+++ b/es-app/src/PlatformId.h
@@ -2,6 +2,8 @@
 #ifndef ES_APP_PLATFORM_ID_H
 #define ES_APP_PLATFORM_ID_H
 
+#include <string>
+
 namespace PlatformIds
 {
 	enum PlatformId : unsigned int
@@ -72,16 +74,46 @@ namespace PlatformIds
 		VIDEOPAC_ODYSSEY2,
 		VECTREX,
 		TRS80_COLOR_COMPUTER,
-		TANDY,
-		ODYSSEY2,
+		TANDY,		
 		SUPERGRAFX,
+		AMIGACD32,
+		AMIGACDTV,
+		ATOMISWAVE,
+		CAVESTORY,
+		GX4000,
+		LUTRO,
+		MOONLIGHT,
+		NAOMI,
+		NEOGEO_CD,
+		PCFX,
+		POKEMINI,
+		PRBOOM,
+		SATELLAVIEW,
+		SUFAMITURBO,
+		ZX81,
+
+		// Windows Specific
+		VISUALPINBALL,
+		FUTUREPINBALL,
+
+		// Misc systems
+		CHANNELF,
+		ORICATMOS,
+		THOMSON_TO_MO,
+		SAMCOUPE,
+		OPENBOR,
+		UZEBOX,
+		APPLE2GS,
+		SPECTRAVIDEO,
+		PALMOS,
+		DAPHNEE,
 
 		PLATFORM_IGNORE, // do not allow scraping for this system
 		PLATFORM_COUNT
 	};
 
-	PlatformId getPlatformId(const char* str);
-	const char* getPlatformName(PlatformId id);
+	PlatformId		getPlatformId(const char* str);
+	std::string		getPlatformName(PlatformId id);
 }
 
 #endif // ES_APP_PLATFORM_ID_H

--- a/es-app/src/PlatformId.h
+++ b/es-app/src/PlatformId.h
@@ -74,6 +74,7 @@ namespace PlatformIds
 		TRS80_COLOR_COMPUTER,
 		TANDY,
 		ODYSSEY2,
+		SUPERGRAFX,
 
 		PLATFORM_IGNORE, // do not allow scraping for this system
 		PLATFORM_COUNT

--- a/es-app/src/guis/GuiScraperStart.cpp
+++ b/es-app/src/guis/GuiScraperStart.cpp
@@ -28,22 +28,22 @@ GuiScraperStart::GuiScraperStart(Window* window) : GuiComponent(window),
 
 		if (Settings::getInstance()->getString("Scraper") == "ScreenScraper")
 		{
-			if (!Settings::getInstance()->getString("ScrapperImageSrc").empty() && g->metadata.get("image").empty())
+			if (!Settings::getInstance()->getString("ScrapperImageSrc").empty() && !Utils::FileSystem::exists(g->metadata.get("image")))
 				return true;
 
-			if (Settings::getInstance()->getString("ScrapperThumbSrc").empty() && g->metadata.get("thumbnail").empty())
+			if (Settings::getInstance()->getString("ScrapperThumbSrc").empty() && !Utils::FileSystem::exists(g->metadata.get("thumbnail")))
 				return true;
 
-			if (Settings::getInstance()->getBool("ScrapeVideos") && g->metadata.get("video").empty())
+			if (Settings::getInstance()->getBool("ScrapeVideos") && !Utils::FileSystem::exists(g->metadata.get("video")))
 				return true;
 
-			if (Settings::getInstance()->getBool("ScrapeMarquee") && g->metadata.get("marquee").empty())
+			if (Settings::getInstance()->getBool("ScrapeMarquee") && !Utils::FileSystem::exists(g->metadata.get("marquee")))
 				return true;
 
 			return false;
 		}
 		else
-			return g->metadata.get("image").empty(); 
+			return !Utils::FileSystem::exists(g->metadata.get("image"));
 
 	}, true);
 

--- a/es-app/src/scrapers/GamesDBJSONScraper.cpp
+++ b/es-app/src/scrapers/GamesDBJSONScraper.cpp
@@ -96,9 +96,24 @@ const std::map<PlatformId, std::string> gamesdb_new_platformid_map{
 	{ VIDEOPAC_ODYSSEY2, "4927" },
 	{ VECTREX, "4939" },
 	{ TRS80_COLOR_COMPUTER, "4941" },
-	{ TANDY, "4941" },
-	{ ODYSSEY2, "4927" },
-	{ SUPERGRAFX, "34" } // The code is TurboGrafx 16, but they manage SUPERGRAFX into this one....
+	{ TANDY, "4941" },	
+	{ SUPERGRAFX, "34" }, // The code is TurboGrafx 16, but they manage SUPERGRAFX into this one....
+
+	{ AMIGACD32, "4947" },
+	// { AMIGACDTV, ?? },
+	// { ATOMISWAVE, ?? },
+	{ CAVESTORY, "1" },
+	// { GX4000, ?? },
+	// { LUTRO, ?? },
+	// { NAOMI, ?? },
+	{ NEOGEO_CD, "24" },
+	{ PCFX, "4930" },
+	{ POKEMINI, "4957" },
+	{ PRBOOM, "1" },
+	{ SATELLAVIEW, "6" },
+	{ SUFAMITURBO, "6" },
+//	{ ZX81, ?? },
+	{ MOONLIGHT, "1" }, // "PC"
 };
 
 void thegamesdb_generate_json_scraper_requests(const ScraperSearchParams& params,

--- a/es-app/src/scrapers/GamesDBJSONScraper.cpp
+++ b/es-app/src/scrapers/GamesDBJSONScraper.cpp
@@ -97,7 +97,8 @@ const std::map<PlatformId, std::string> gamesdb_new_platformid_map{
 	{ VECTREX, "4939" },
 	{ TRS80_COLOR_COMPUTER, "4941" },
 	{ TANDY, "4941" },
-	{ ODYSSEY2, "4927" }
+	{ ODYSSEY2, "4927" },
+	{ SUPERGRAFX, "34" } // The code is TurboGrafx 16, but they manage SUPERGRAFX into this one....
 };
 
 void thegamesdb_generate_json_scraper_requests(const ScraperSearchParams& params,

--- a/es-app/src/scrapers/GamesDBJSONScraper.h
+++ b/es-app/src/scrapers/GamesDBJSONScraper.h
@@ -28,7 +28,7 @@ class TheGamesDBJSONRequest : public ScraperHttpRequest
 	}
 
   protected:
-	void process(const std::unique_ptr<HttpReq>& req, std::vector<ScraperSearchResult>& results) override;
+	bool process(const std::unique_ptr<HttpReq>& req, std::vector<ScraperSearchResult>& results) override;
 	bool isGameRequest() { return !mRequestQueue; }
 
 	std::queue<std::unique_ptr<ScraperRequest>>* mRequestQueue;

--- a/es-app/src/scrapers/Scraper.cpp
+++ b/es-app/src/scrapers/Scraper.cpp
@@ -183,80 +183,112 @@ MDResolveHandle::MDResolveHandle(const ScraperSearchResult& result, const Scrape
 	auto tmp = Settings::getInstance()->getString("ScrapperImageSrc");
 	auto md = search.game->metadata.get("image");
 
-	if (!search.overWriteMedias && ss && !Settings::getInstance()->getString("ScrapperImageSrc").empty() && !search.game->metadata.get("image").empty())
+	if (!search.overWriteMedias && ss && !Settings::getInstance()->getString("ScrapperImageSrc").empty() && Utils::FileSystem::exists(search.game->metadata.get("image")))
 		mResult.mdl.set("image", search.game->metadata.get("image"));
 	else if (!result.imageUrl.empty())
 	{
 		std::string imgPath = getSaveAsPath(search, "image", ext);
 
-		mFuncs.push_back(new ResolvePair(
-			[this, result, imgPath] 
-			{ 
-				return downloadImageAsync(result.imageUrl, imgPath); 
-			},
+		if (!search.overWriteMedias && Utils::FileSystem::exists(imgPath))
+		{
+			mResult.mdl.set("image", imgPath);
+
+			if (mResult.thumbnailUrl.find(mResult.imageUrl) == 0)
+				mResult.thumbnailUrl = "";
+
+			mResult.imageUrl = "";
+		}
+		else
+
+			mFuncs.push_back(new ResolvePair(
+				[this, result, imgPath]
+		{
+			return downloadImageAsync(result.imageUrl, imgPath);
+		},
 			[this, imgPath]
-			{
-				mResult.mdl.set("image", imgPath);
+		{
+			mResult.mdl.set("image", imgPath);
 
-				if (mResult.thumbnailUrl.find(mResult.imageUrl) == 0)
-					mResult.thumbnailUrl = "";
+			if (mResult.thumbnailUrl.find(mResult.imageUrl) == 0)
+				mResult.thumbnailUrl = "";
 
-				mResult.imageUrl = "";
-			}, "image", result.mdl.getName()));
+			mResult.imageUrl = "";
+		}, "image", result.mdl.getName()));
 	}
 
-	if (!search.overWriteMedias && ss && !Settings::getInstance()->getString("ScrapperThumbSrc").empty() && !search.game->metadata.get("thumbnail").empty())
+	if (!search.overWriteMedias && ss && !Settings::getInstance()->getString("ScrapperThumbSrc").empty() && Utils::FileSystem::exists(search.game->metadata.get("thumbnail")))
 		mResult.mdl.set("thumbnail", search.game->metadata.get("thumbnail"));
 	else if (!result.thumbnailUrl.empty() && result.thumbnailUrl.find(result.imageUrl) != 0)
 	{
 		std::string thumbPath = getSaveAsPath(search, "thumb", ext);
 
-		mFuncs.push_back(new ResolvePair(
-			[this, result, thumbPath]
-			{
-				return downloadImageAsync(result.thumbnailUrl, thumbPath);
-			},
+		if (!search.overWriteMedias && Utils::FileSystem::exists(thumbPath))
+		{
+			mResult.mdl.set("thumbnail", thumbPath);
+			mResult.thumbnailUrl = "";
+		}
+		else
+
+			mFuncs.push_back(new ResolvePair(
+				[this, result, thumbPath]
+		{
+			return downloadImageAsync(result.thumbnailUrl, thumbPath);
+		},
 			[this, thumbPath]
-			{
-				mResult.mdl.set("thumbnail", thumbPath);
-				mResult.thumbnailUrl = "";
-			}, "thumbnail", result.mdl.getName()));
+		{
+			mResult.mdl.set("thumbnail", thumbPath);
+			mResult.thumbnailUrl = "";
+		}, "thumbnail", result.mdl.getName()));
 	}
 
-	if (!search.overWriteMedias && Settings::getInstance()->getBool("ScrapeMarquee") && !search.game->metadata.get("marquee").empty())
+	if (!search.overWriteMedias && Settings::getInstance()->getBool("ScrapeMarquee") && Utils::FileSystem::exists(search.game->metadata.get("marquee")))
 		mResult.mdl.set("marquee", search.game->metadata.get("marquee"));
 	else if (!result.marqueeUrl.empty())
 	{
 		std::string marqueePath = getSaveAsPath(search, "marquee", ext);
 
-		mFuncs.push_back(new ResolvePair(
-			[this, result, marqueePath]
-			{
-				return downloadImageAsync(result.marqueeUrl, marqueePath);
-			}, 
+		if (!search.overWriteMedias && Utils::FileSystem::exists(marqueePath))
+		{
+			mResult.mdl.set("marquee", marqueePath);
+			mResult.marqueeUrl = "";
+		}
+		else
+
+			mFuncs.push_back(new ResolvePair(
+				[this, result, marqueePath]
+		{
+			return downloadImageAsync(result.marqueeUrl, marqueePath);
+		},
 			[this, marqueePath]
-			{
-				mResult.mdl.set("marquee", marqueePath);
-				mResult.marqueeUrl = "";
-			}, "marquee", result.mdl.getName()));
+		{
+			mResult.mdl.set("marquee", marqueePath);
+			mResult.marqueeUrl = "";
+		}, "marquee", result.mdl.getName()));
 	}
 
-	if (!search.overWriteMedias && Settings::getInstance()->getBool("ScrapeVideos") && !search.game->metadata.get("video").empty())
+	if (!search.overWriteMedias && Settings::getInstance()->getBool("ScrapeVideos") && Utils::FileSystem::exists(search.game->metadata.get("video")))
 		mResult.mdl.set("video", search.game->metadata.get("video"));
 	else if (!result.videoUrl.empty())
 	{
 		std::string videoPath = getSaveAsPath(search, "video", ".mp4");
 
-		mFuncs.push_back(new ResolvePair(
-			[this, result, videoPath]
-			{
-				return downloadImageAsync(result.videoUrl, videoPath);
-			},
+		if (!search.overWriteMedias && Utils::FileSystem::exists(videoPath))
+		{
+			mResult.mdl.set("video", videoPath);
+			mResult.videoUrl = "";
+		}
+		else
+
+			mFuncs.push_back(new ResolvePair(
+				[this, result, videoPath]
+		{
+			return downloadImageAsync(result.videoUrl, videoPath);
+		},
 			[this, videoPath]
-			{
-				mResult.mdl.set("video", videoPath);
-				mResult.videoUrl = "";
-			}, "video", result.mdl.getName()));
+		{
+			mResult.mdl.set("video", videoPath);
+			mResult.videoUrl = "";
+		}, "video", result.mdl.getName()));
 	}
 
 	auto it = mFuncs.cbegin();

--- a/es-app/src/scrapers/Scraper.h
+++ b/es-app/src/scrapers/Scraper.h
@@ -95,10 +95,11 @@ public:
 	virtual void update() override;
 
 protected:
-	virtual void process(const std::unique_ptr<HttpReq>& req, std::vector<ScraperSearchResult>& results) = 0;
+	virtual bool process(const std::unique_ptr<HttpReq>& req, std::vector<ScraperSearchResult>& results) = 0;
 
 private:
 	std::unique_ptr<HttpReq> mReq;
+	int	mRetryCount;
 };
 
 // a request to get a list of results

--- a/es-app/src/scrapers/ScreenScraper.cpp
+++ b/es-app/src/scrapers/ScreenScraper.cpp
@@ -91,7 +91,8 @@ const std::map<PlatformId, unsigned short> screenscraper_platformid_map{
 	{ VECTREX, 102 },
 	{ TRS80_COLOR_COMPUTER, 144 },
 	{ TANDY, 144 },
-	{ ODYSSEY2, 104 }
+	{ ODYSSEY2, 104 },
+	{ SUPERGRAFX, 105 }
 };
 
 

--- a/es-app/src/scrapers/ScreenScraper.cpp
+++ b/es-app/src/scrapers/ScreenScraper.cpp
@@ -92,9 +92,40 @@ const std::map<PlatformId, unsigned short> screenscraper_platformid_map{
 	{ VIDEOPAC_ODYSSEY2, 104 },
 	{ VECTREX, 102 },
 	{ TRS80_COLOR_COMPUTER, 144 },
-	{ TANDY, 144 },
-	{ ODYSSEY2, 104 },
-	{ SUPERGRAFX, 105 }
+	{ TANDY, 144 },	
+	{ SUPERGRAFX, 105 },
+	
+	{ AMIGACD32, 130 },
+	{ AMIGACDTV, 129 },
+	{ ATOMISWAVE, 53 },
+	{ CAVESTORY, 135 },
+	{ GX4000, 87 },
+	{ LUTRO, 206 },
+	{ NAOMI, 56 },
+	{ NEOGEO_CD, 142 },
+	{ PCFX, 72 },
+	{ POKEMINI, 211 },
+	{ PRBOOM, 135 },
+	{ SATELLAVIEW, 107 },
+	{ SUFAMITURBO, 108 },
+	{ ZX81, 77 },
+	{ MOONLIGHT, 138 }, // "PC Windows"
+
+	// Windows
+	{ VISUALPINBALL, 198 },
+	{ FUTUREPINBALL, 199 },
+
+	// Misc
+	{ ORICATMOS, 131 },
+	{ CHANNELF, 80 },
+	{ THOMSON_TO_MO, 141 },
+	{ SAMCOUPE, 213 },
+	{ OPENBOR, 214 },
+	{ UZEBOX, 216 },
+	{ APPLE2GS, 217 },
+	{ SPECTRAVIDEO, 218 },
+	{ PALMOS, 219 },
+	{ DAPHNEE, 49 }
 };
 
 

--- a/es-app/src/scrapers/ScreenScraper.h
+++ b/es-app/src/scrapers/ScreenScraper.h
@@ -57,7 +57,7 @@ public:
 	} configuration;
 
 protected:
-	void process(const std::unique_ptr<HttpReq>& req, std::vector<ScraperSearchResult>& results) override;
+	bool process(const std::unique_ptr<HttpReq>& req, std::vector<ScraperSearchResult>& results) override;
 	std::string ensureUrl(const std::string url);
 
 	void processList(const pugi::xml_document& xmldoc, std::vector<ScraperSearchResult>& results);

--- a/es-app/src/scrapers/md5.cpp
+++ b/es-app/src/scrapers/md5.cpp
@@ -1,0 +1,369 @@
+/* MD5
+converted to C++ class by Frank Thilo (thilo@unix-ag.org)
+for bzflag (http://www.bzflag.org)
+
+based on:
+
+md5.h and md5.c
+reference implemantion of RFC 1321
+
+Copyright (C) 1991-2, RSA Data Security, Inc. Created 1991. All
+rights reserved.
+
+License to copy and use this software is granted provided that it
+is identified as the "RSA Data Security, Inc. MD5 Message-Digest
+Algorithm" in all material mentioning or referencing this software
+or this function.
+
+License is also granted to make and use derivative works provided
+that such works are identified as "derived from the RSA Data
+Security, Inc. MD5 Message-Digest Algorithm" in all material
+mentioning or referencing the derived work.
+
+RSA Data Security, Inc. makes no representations concerning either
+the merchantability of this software or the suitability of this
+software for any particular purpose. It is provided "as is"
+without express or implied warranty of any kind.
+
+These notices must be retained in any copies of any part of this
+documentation and/or software.
+
+*/
+
+/* interface header */
+#include "md5.h"
+
+/* system implementation headers */
+#include <cstdio>
+
+
+// Constants for MD5Transform routine.
+#define S11 7
+#define S12 12
+#define S13 17
+#define S14 22
+#define S21 5
+#define S22 9
+#define S23 14
+#define S24 20
+#define S31 4
+#define S32 11
+#define S33 16
+#define S34 23
+#define S41 6
+#define S42 10
+#define S43 15
+#define S44 21
+
+///////////////////////////////////////////////
+
+// F, G, H and I are basic MD5 functions.
+inline MD5::uint4 MD5::F(uint4 x, uint4 y, uint4 z) {
+	return x&y | ~x&z;
+}
+
+inline MD5::uint4 MD5::G(uint4 x, uint4 y, uint4 z) {
+	return x&z | y&~z;
+}
+
+inline MD5::uint4 MD5::H(uint4 x, uint4 y, uint4 z) {
+	return x^y^z;
+}
+
+inline MD5::uint4 MD5::I(uint4 x, uint4 y, uint4 z) {
+	return y ^ (x | ~z);
+}
+
+// rotate_left rotates x left n bits.
+inline MD5::uint4 MD5::rotate_left(uint4 x, int n) {
+	return (x << n) | (x >> (32 - n));
+}
+
+// FF, GG, HH, and II transformations for rounds 1, 2, 3, and 4.
+// Rotation is separate from addition to prevent recomputation.
+inline void MD5::FF(uint4 &a, uint4 b, uint4 c, uint4 d, uint4 x, uint4 s, uint4 ac) {
+	a = rotate_left(a + F(b, c, d) + x + ac, s) + b;
+}
+
+inline void MD5::GG(uint4 &a, uint4 b, uint4 c, uint4 d, uint4 x, uint4 s, uint4 ac) {
+	a = rotate_left(a + G(b, c, d) + x + ac, s) + b;
+}
+
+inline void MD5::HH(uint4 &a, uint4 b, uint4 c, uint4 d, uint4 x, uint4 s, uint4 ac) {
+	a = rotate_left(a + H(b, c, d) + x + ac, s) + b;
+}
+
+inline void MD5::II(uint4 &a, uint4 b, uint4 c, uint4 d, uint4 x, uint4 s, uint4 ac) {
+	a = rotate_left(a + I(b, c, d) + x + ac, s) + b;
+}
+
+//////////////////////////////////////////////
+
+// default ctor, just initailize
+MD5::MD5()
+{
+	init();
+}
+
+//////////////////////////////////////////////
+
+// nifty shortcut ctor, compute MD5 for string and finalize it right away
+MD5::MD5(const std::string &text)
+{
+	init();
+	update(text.c_str(), text.length());
+	finalize();
+}
+
+MD5::MD5(char * Input, long length)
+{
+	init();
+	update(Input, length);
+	finalize();
+}
+
+//////////////////////////////
+
+void MD5::init()
+{
+	finalized = false;
+
+	count[0] = 0;
+	count[1] = 0;
+
+	// load magic initialization constants.
+	state[0] = 0x67452301;
+	state[1] = 0xefcdab89;
+	state[2] = 0x98badcfe;
+	state[3] = 0x10325476;
+}
+
+//////////////////////////////
+
+// decodes input (unsigned char) into output (uint4). Assumes len is a multiple of 4.
+void MD5::decode(uint4 output[], const uint1 input[], size_type len)
+{
+	for (unsigned int i = 0, j = 0; j < len; i++, j += 4)
+		output[i] = ((uint4)input[j]) | (((uint4)input[j + 1]) << 8) |
+		(((uint4)input[j + 2]) << 16) | (((uint4)input[j + 3]) << 24);
+}
+
+//////////////////////////////
+
+// encodes input (uint4) into output (unsigned char). Assumes len is
+// a multiple of 4.
+void MD5::encode(uint1 output[], const uint4 input[], size_type len)
+{
+	for (size_type i = 0, j = 0; j < len; i++, j += 4) {
+		output[j] = input[i] & 0xff;
+		output[j + 1] = (input[i] >> 8) & 0xff;
+		output[j + 2] = (input[i] >> 16) & 0xff;
+		output[j + 3] = (input[i] >> 24) & 0xff;
+	}
+}
+
+//////////////////////////////
+
+// apply MD5 algo on a block
+void MD5::transform(const uint1 block[blocksize])
+{
+	uint4 a = state[0], b = state[1], c = state[2], d = state[3], x[16];
+	decode(x, block, blocksize);
+
+	/* Round 1 */
+	FF(a, b, c, d, x[0], S11, 0xd76aa478); /* 1 */
+	FF(d, a, b, c, x[1], S12, 0xe8c7b756); /* 2 */
+	FF(c, d, a, b, x[2], S13, 0x242070db); /* 3 */
+	FF(b, c, d, a, x[3], S14, 0xc1bdceee); /* 4 */
+	FF(a, b, c, d, x[4], S11, 0xf57c0faf); /* 5 */
+	FF(d, a, b, c, x[5], S12, 0x4787c62a); /* 6 */
+	FF(c, d, a, b, x[6], S13, 0xa8304613); /* 7 */
+	FF(b, c, d, a, x[7], S14, 0xfd469501); /* 8 */
+	FF(a, b, c, d, x[8], S11, 0x698098d8); /* 9 */
+	FF(d, a, b, c, x[9], S12, 0x8b44f7af); /* 10 */
+	FF(c, d, a, b, x[10], S13, 0xffff5bb1); /* 11 */
+	FF(b, c, d, a, x[11], S14, 0x895cd7be); /* 12 */
+	FF(a, b, c, d, x[12], S11, 0x6b901122); /* 13 */
+	FF(d, a, b, c, x[13], S12, 0xfd987193); /* 14 */
+	FF(c, d, a, b, x[14], S13, 0xa679438e); /* 15 */
+	FF(b, c, d, a, x[15], S14, 0x49b40821); /* 16 */
+
+											/* Round 2 */
+	GG(a, b, c, d, x[1], S21, 0xf61e2562); /* 17 */
+	GG(d, a, b, c, x[6], S22, 0xc040b340); /* 18 */
+	GG(c, d, a, b, x[11], S23, 0x265e5a51); /* 19 */
+	GG(b, c, d, a, x[0], S24, 0xe9b6c7aa); /* 20 */
+	GG(a, b, c, d, x[5], S21, 0xd62f105d); /* 21 */
+	GG(d, a, b, c, x[10], S22, 0x2441453); /* 22 */
+	GG(c, d, a, b, x[15], S23, 0xd8a1e681); /* 23 */
+	GG(b, c, d, a, x[4], S24, 0xe7d3fbc8); /* 24 */
+	GG(a, b, c, d, x[9], S21, 0x21e1cde6); /* 25 */
+	GG(d, a, b, c, x[14], S22, 0xc33707d6); /* 26 */
+	GG(c, d, a, b, x[3], S23, 0xf4d50d87); /* 27 */
+	GG(b, c, d, a, x[8], S24, 0x455a14ed); /* 28 */
+	GG(a, b, c, d, x[13], S21, 0xa9e3e905); /* 29 */
+	GG(d, a, b, c, x[2], S22, 0xfcefa3f8); /* 30 */
+	GG(c, d, a, b, x[7], S23, 0x676f02d9); /* 31 */
+	GG(b, c, d, a, x[12], S24, 0x8d2a4c8a); /* 32 */
+
+											/* Round 3 */
+	HH(a, b, c, d, x[5], S31, 0xfffa3942); /* 33 */
+	HH(d, a, b, c, x[8], S32, 0x8771f681); /* 34 */
+	HH(c, d, a, b, x[11], S33, 0x6d9d6122); /* 35 */
+	HH(b, c, d, a, x[14], S34, 0xfde5380c); /* 36 */
+	HH(a, b, c, d, x[1], S31, 0xa4beea44); /* 37 */
+	HH(d, a, b, c, x[4], S32, 0x4bdecfa9); /* 38 */
+	HH(c, d, a, b, x[7], S33, 0xf6bb4b60); /* 39 */
+	HH(b, c, d, a, x[10], S34, 0xbebfbc70); /* 40 */
+	HH(a, b, c, d, x[13], S31, 0x289b7ec6); /* 41 */
+	HH(d, a, b, c, x[0], S32, 0xeaa127fa); /* 42 */
+	HH(c, d, a, b, x[3], S33, 0xd4ef3085); /* 43 */
+	HH(b, c, d, a, x[6], S34, 0x4881d05); /* 44 */
+	HH(a, b, c, d, x[9], S31, 0xd9d4d039); /* 45 */
+	HH(d, a, b, c, x[12], S32, 0xe6db99e5); /* 46 */
+	HH(c, d, a, b, x[15], S33, 0x1fa27cf8); /* 47 */
+	HH(b, c, d, a, x[2], S34, 0xc4ac5665); /* 48 */
+
+										   /* Round 4 */
+	II(a, b, c, d, x[0], S41, 0xf4292244); /* 49 */
+	II(d, a, b, c, x[7], S42, 0x432aff97); /* 50 */
+	II(c, d, a, b, x[14], S43, 0xab9423a7); /* 51 */
+	II(b, c, d, a, x[5], S44, 0xfc93a039); /* 52 */
+	II(a, b, c, d, x[12], S41, 0x655b59c3); /* 53 */
+	II(d, a, b, c, x[3], S42, 0x8f0ccc92); /* 54 */
+	II(c, d, a, b, x[10], S43, 0xffeff47d); /* 55 */
+	II(b, c, d, a, x[1], S44, 0x85845dd1); /* 56 */
+	II(a, b, c, d, x[8], S41, 0x6fa87e4f); /* 57 */
+	II(d, a, b, c, x[15], S42, 0xfe2ce6e0); /* 58 */
+	II(c, d, a, b, x[6], S43, 0xa3014314); /* 59 */
+	II(b, c, d, a, x[13], S44, 0x4e0811a1); /* 60 */
+	II(a, b, c, d, x[4], S41, 0xf7537e82); /* 61 */
+	II(d, a, b, c, x[11], S42, 0xbd3af235); /* 62 */
+	II(c, d, a, b, x[2], S43, 0x2ad7d2bb); /* 63 */
+	II(b, c, d, a, x[9], S44, 0xeb86d391); /* 64 */
+
+	state[0] += a;
+	state[1] += b;
+	state[2] += c;
+	state[3] += d;
+
+	// Zeroize sensitive information.
+	memset(x, 0, sizeof x);
+}
+
+//////////////////////////////
+
+// MD5 block update operation. Continues an MD5 message-digest
+// operation, processing another message block
+void MD5::update(const unsigned char input[], size_type length)
+{
+	// compute number of bytes mod 64
+	size_type index = count[0] / 8 % blocksize;
+
+	// Update number of bits
+	if ((count[0] += (length << 3)) < (length << 3))
+		count[1]++;
+	count[1] += (length >> 29);
+
+	// number of bytes we need to fill in buffer
+	size_type firstpart = 64 - index;
+
+	size_type i;
+
+	// transform as many times as possible.
+	if (length >= firstpart)
+	{
+		// fill buffer first, transform
+		memcpy(&buffer[index], input, firstpart);
+		transform(buffer);
+
+		// transform chunks of blocksize (64 bytes)
+		for (i = firstpart; i + blocksize <= length; i += blocksize)
+			transform(&input[i]);
+
+		index = 0;
+	}
+	else
+		i = 0;
+
+	// buffer remaining input
+	memcpy(&buffer[index], &input[i], length - i);
+}
+
+//////////////////////////////
+
+// for convenience provide a verson with signed char
+void MD5::update(const char input[], size_type length)
+{
+	update((const unsigned char*)input, length);
+}
+
+//////////////////////////////
+
+// MD5 finalization. Ends an MD5 message-digest operation, writing the
+// the message digest and zeroizing the context.
+MD5& MD5::finalize()
+{
+	static unsigned char padding[64] = {
+		0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+		0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+		0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+	};
+
+	if (!finalized) {
+		// Save number of bits
+		unsigned char bits[8];
+		encode(bits, count, 8);
+
+		// pad out to 56 mod 64.
+		size_type index = count[0] / 8 % 64;
+		size_type padLen = (index < 56) ? (56 - index) : (120 - index);
+		update(padding, padLen);
+
+		// Append length (before padding)
+		update(bits, 8);
+
+		// Store state in digest
+		encode(digest, state, 16);
+
+		// Zeroize sensitive information.
+		memset(buffer, 0, sizeof buffer);
+		memset(count, 0, sizeof count);
+
+		finalized = true;
+	}
+
+	return *this;
+}
+
+//////////////////////////////
+
+// return hex representation of digest as string
+std::string MD5::hexdigest() const
+{
+	if (!finalized)
+		return "";
+
+	char buf[33];
+	for (int i = 0; i<16; i++)
+		sprintf(buf + i * 2, "%02x", digest[i]);
+	buf[32] = 0;
+
+	return std::string(buf);
+}
+
+//////////////////////////////
+
+std::ostream& operator<<(std::ostream& out, MD5 md5)
+{
+	return out << md5.hexdigest();
+}
+
+//////////////////////////////
+
+std::string md5(const std::string str)
+{
+	MD5 md5 = MD5(str);
+
+	return md5.hexdigest();
+}

--- a/es-app/src/scrapers/md5.h
+++ b/es-app/src/scrapers/md5.h
@@ -1,0 +1,95 @@
+/* MD5
+converted to C++ class by Frank Thilo (thilo@unix-ag.org)
+for bzflag (http://www.bzflag.org)
+
+based on:
+
+md5.h and md5.c
+reference implementation of RFC 1321
+
+Copyright (C) 1991-2, RSA Data Security, Inc. Created 1991. All
+rights reserved.
+
+License to copy and use this software is granted provided that it
+is identified as the "RSA Data Security, Inc. MD5 Message-Digest
+Algorithm" in all material mentioning or referencing this software
+or this function.
+
+License is also granted to make and use derivative works provided
+that such works are identified as "derived from the RSA Data
+Security, Inc. MD5 Message-Digest Algorithm" in all material
+mentioning or referencing the derived work.
+
+RSA Data Security, Inc. makes no representations concerning either
+the merchantability of this software or the suitability of this
+software for any particular purpose. It is provided "as is"
+without express or implied warranty of any kind.
+
+These notices must be retained in any copies of any part of this
+documentation and/or software.
+
+*/
+
+#ifndef BZF_MD5_H
+#define BZF_MD5_H
+
+#include <cstring>
+#include <iostream>
+
+
+// a small class for calculating MD5 hashes of strings or byte arrays
+// it is not meant to be fast or secure
+//
+// usage: 1) feed it blocks of uchars with update()
+//      2) finalize()
+//      3) get hexdigest() string
+//      or
+//      MD5(std::string).hexdigest()
+//
+// assumes that char is 8 bit and int is 32 bit
+class MD5
+{
+public:
+	typedef unsigned int size_type; // must be 32bit
+
+	MD5();
+	MD5(const std::string& text);
+	MD5(char* Input, long length);
+
+	void update(const unsigned char *buf, size_type length);
+	void update(const char *buf, size_type length);
+	MD5& finalize();
+	std::string hexdigest() const;
+	friend std::ostream& operator<<(std::ostream&, MD5 md5);
+
+private:
+	void init();
+	typedef unsigned char uint1; //  8bit
+	typedef unsigned int uint4;  // 32bit
+	enum { blocksize = 64 }; // VC6 won't eat a const static int here
+
+	void transform(const uint1 block[blocksize]);
+	static void decode(uint4 output[], const uint1 input[], size_type len);
+	static void encode(uint1 output[], const uint4 input[], size_type len);
+
+	bool finalized;
+	uint1 buffer[blocksize]; // bytes that didn't fit in last 64 byte chunk
+	uint4 count[2];   // 64bit counter for number of bits (lo, hi)
+	uint4 state[4];   // digest so far
+	uint1 digest[16]; // the result
+
+					  // low level logic operations
+	static inline uint4 F(uint4 x, uint4 y, uint4 z);
+	static inline uint4 G(uint4 x, uint4 y, uint4 z);
+	static inline uint4 H(uint4 x, uint4 y, uint4 z);
+	static inline uint4 I(uint4 x, uint4 y, uint4 z);
+	static inline uint4 rotate_left(uint4 x, int n);
+	static inline void FF(uint4 &a, uint4 b, uint4 c, uint4 d, uint4 x, uint4 s, uint4 ac);
+	static inline void GG(uint4 &a, uint4 b, uint4 c, uint4 d, uint4 x, uint4 s, uint4 ac);
+	static inline void HH(uint4 &a, uint4 b, uint4 c, uint4 d, uint4 x, uint4 s, uint4 ac);
+	static inline void II(uint4 &a, uint4 b, uint4 c, uint4 d, uint4 x, uint4 s, uint4 ac);
+};
+
+std::string md5(const std::string str);
+
+#endif

--- a/es-core/src/HttpReq.cpp
+++ b/es-core/src/HttpReq.cpp
@@ -94,6 +94,8 @@ std::string _regGetString(HKEY hKey, const std::string &strPath, const std::stri
 HttpReq::HttpReq(const std::string& url)
 	: mStatus(REQ_IN_PROGRESS), mHandle(NULL)
 {
+	mUrl = url;
+
 	mPercent = -1;
 	mHandle = curl_easy_init();
 

--- a/es-core/src/HttpReq.h
+++ b/es-core/src/HttpReq.h
@@ -55,6 +55,8 @@ public:
 
 	int getPercent() { return mPercent; }
 
+	std::string getUrl() { return mUrl; }
+
 private:
 	static size_t write_content(void* buff, size_t size, size_t nmemb, void* req_ptr);
 	//static int update_progress(void* req_ptr, double dlTotal, double dlNow, double ulTotal, double ulNow);
@@ -75,6 +77,7 @@ private:
 	std::ofstream mStream;
 
 	std::string mErrorMsg;
+	std::string mUrl;
 
 	int mPercent;
 };

--- a/es-core/src/resources/TextureData.cpp
+++ b/es-core/src/resources/TextureData.cpp
@@ -70,8 +70,8 @@ bool TextureData::initSVGFromMemory(const unsigned char* fileData, size_t length
 	else
 		mSourceWidth = (mSourceHeight * svgImage->width) / svgImage->height; // FCA : Always compute width using source aspect ratio
 
-	mWidth = (int)mSourceWidth;
-	mHeight = (int)mSourceHeight;
+	mWidth = (size_t)Math::round(mSourceWidth);
+	mHeight = (size_t)Math::round(mSourceHeight);
 
 	if (mWidth == 0)
 	{
@@ -111,8 +111,13 @@ bool TextureData::initSVGFromMemory(const unsigned char* fileData, size_t length
 
 	unsigned char* dataRGBA = new unsigned char[mWidth * mHeight * 4];
 
+	double scale = ((float)((int)mHeight)) / svgImage->height;
+	double scaleV = ((float)((int)mWidth)) / svgImage->width;
+	if (scaleV < scale)
+		scale = scaleV;
+
 	NSVGrasterizer* rast = nsvgCreateRasterizer();
-	nsvgRasterize(rast, svgImage, 0, 0, mHeight / svgImage->height, dataRGBA, (int)mWidth, (int)mHeight, (int)mWidth * 4);
+	nsvgRasterize(rast, svgImage, 0, 0, scale, dataRGBA, (int)mWidth, (int)mHeight, (int)mWidth * 4);
 	nsvgDeleteRasterizer(rast);
 
 	ImageIO::flipPixelsVert(dataRGBA, mWidth, mHeight);

--- a/es-core/src/utils/FileSystemUtil.cpp
+++ b/es-core/src/utils/FileSystemUtil.cpp
@@ -672,6 +672,17 @@ namespace Utils
 
 		bool exists(const std::string& _path)
 		{
+			if (_path.empty())
+				return false;
+
+#ifdef WIN32
+			DWORD dwAttr = GetFileAttributes(_path.c_str());
+			if (0xFFFFFFFF == dwAttr)
+				return false;
+
+			return true;
+#endif
+
 			std::string path = getGenericPath(_path);
 			struct stat64 info;
 


### PR DESCRIPTION
supergrafx, amigacd32, amigacdtv, atomiswave, cavestory, gx4000, lutro, moonlight, naomi, neogeocd, pcfx, pokemini, prboom, satellaview, sufami, zx81, gb2players, gbc2players, 3ds, sg1000, odyssey2, oricatmos, windows, vpinball, fpinball, o2em, channelf, oric, thomson, samcoupe, OpenBOR, uzebox, apple2gs, Spectravideo, palm, daphne.
+ Screenscraper : Use md5 checksum in screenscraper requests 
+ Screenscraper : Handle "maximum threads per minute" error with delayed retry.
+ Scrapers : Optimize scraper incremental mode.
+ Fix SVG proportions


