### PR TITLE
Theming Fixes

### DIFF
--- a/es-app/src/components/RatingComponent.cpp
+++ b/es-app/src/components/RatingComponent.cpp
@@ -115,18 +115,18 @@ void RatingComponent::render(const Transform4x4f& parentTrans)
 
 	Renderer::setMatrix(trans);
 
-	if (mFilledTexture->bind())
-	{
-		Renderer::drawTriangleStrips(&mVertices[0], 4);
-		Renderer::bindTexture(0);
-	}
-
 	if (mUnfilledTexture->bind())
 	{
 		Renderer::drawTriangleStrips(&mVertices[4], 4);
 		Renderer::bindTexture(0);
 	}
 
+	if (mFilledTexture->bind())
+	{
+		Renderer::drawTriangleStrips(&mVertices[0], 4);
+		Renderer::bindTexture(0);
+	}
+	
 	renderChildren(trans);
 }
 

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -1312,6 +1312,9 @@ void GuiMenu::openThemeConfiguration(GuiSettings* s, std::shared_ptr<OptionListC
 			for (auto it = themeColorSets.begin(); it != themeColorSets.end(); it++)
 				item->add(it->displayName, it->name, it == selectedColorSet);
 
+			if (selectedColorSet == themeColorSets.end())
+				item->selectFirstItem();
+
 			if (!themeColorSets.empty())
 			{
 				std::string displayName = theme->getVariable("subset." + subset);

--- a/es-app/src/views/SystemView.cpp
+++ b/es-app/src/views/SystemView.cpp
@@ -101,7 +101,11 @@ void SystemView::populate()
 							logo->setImage(path, (elem->has("tile") && elem->get<bool>("tile")), MaxSizeInfo(mCarousel.logoSize * mCarousel.logoScale));
 					}
 
-					logo->setRotateByTargetSize(true);
+					// If logosize is defined for full width/height, don't rotate by target size
+					// ex : <logoSize>1 .05< / logoSize>
+					if (mCarousel.size.x() != mCarousel.logoSize.x() & mCarousel.size.y() != mCarousel.logoSize.y())
+						logo->setRotateByTargetSize(true);
+					
 					e.data.logo = std::shared_ptr<GuiComponent>(logo);
 				}
 			}

--- a/es-core/src/components/ImageComponent.cpp
+++ b/es-core/src/components/ImageComponent.cpp
@@ -373,8 +373,9 @@ void ImageComponent::render(const Transform4x4f& parentTrans)
 	}
 
 	Transform4x4f trans = parentTrans * getTransform();
-
-	if (!Renderer::isVisibleOnScreen(trans.translation().x(), trans.translation().y(), mSize.x(), mSize.y()))
+	
+	// Don't use soft clip if rotation applied : let renderer do the work
+	if (mRotation == 0 && !Renderer::isVisibleOnScreen(trans.translation().x(), trans.translation().y(), mSize.x(), mSize.y()))
 		return;
 
 	Renderer::setMatrix(trans);


### PR DESCRIPTION
Fix : Theme subset selection can be empty & lead to a crash
Fix : VERTICAL_WHEEL carousel logo position on some themes using rotation by logo size + ensure loading order for themes <= 4
Fix : Rating Component drawing on some themes.
Fix : ImageComponent clipping with rotation
