### PR TITLE
Fixes : Folder navigation & sortings

### DIFF
--- a/es-app/src/CollectionSystemManager.cpp
+++ b/es-app/src/CollectionSystemManager.cpp
@@ -207,10 +207,7 @@ void CollectionSystemManager::updateSystemsList()
 	}
 
 	if(mCustomCollectionsBundle->getRootFolder()->getChildren().size() > 0)
-	{
-		mCustomCollectionsBundle->getRootFolder()->sort(FileSorts::getSortType(mCollectionSystemDeclsIndex[myCollectionsName].defaultSortId));
 		SystemData::sSystemVector.push_back(mCustomCollectionsBundle);
-	}
 
 	// add auto enabled ones
 	addEnabledCollectionsToDisplayedSystems(&mAutoCollectionSystemsData, &map);
@@ -298,7 +295,6 @@ void CollectionSystemManager::updateCollectionSystem(FileData* file, CollectionS
 
 		curSys->updateDisplayedGameCount();
 
-		rootFolder->sort(FileSorts::getSortType(mCollectionSystemDeclsIndex[name].defaultSortId));
 		if (name == "recent")
 		{
 			trimCollectionCount(rootFolder, LAST_PLAYED_MAX);
@@ -519,7 +515,6 @@ bool CollectionSystemManager::toggleGameInCollection(FileData* file)
 				rootFolder->addChild(newGame);
 				sysData->addToIndex(newGame);
 				ViewController::get()->getGameListView(systemViewToUpdate)->onFileChanged(newGame, FILE_METADATA_CHANGED);
-				rootFolder->sort(FileSorts::getSortType(mEditingCollectionSystemData->decl.defaultSortId));
 				ViewController::get()->onFileChanged(systemViewToUpdate->getRootFolder(), FILE_SORTED);
 				// add to bundle index as well, if needed
 				if (systemViewToUpdate != sysData)
@@ -792,7 +787,6 @@ void CollectionSystemManager::populateAutoCollection(CollectionSystemData* sysDa
 			}
 		}
 	}
-	rootFolder->sort(FileSorts::getSortType(sysDecl.defaultSortId));
 	if (sysDecl.type == AUTO_LAST_PLAYED)
 		trimCollectionCount(rootFolder, LAST_PLAYED_MAX);
 	sysData->isPopulated = true;
@@ -846,7 +840,6 @@ void CollectionSystemManager::populateCustomCollection(CollectionSystemData* sys
 			LOG(LogInfo) << "Couldn't find game referenced at '" << gameKey << "' for system config '" << path << "'";
 		}
 	}
-	rootFolder->sort(FileSorts::getSortType(sysDecl.defaultSortId));
 	updateCollectionFolderMetadata(newSys);
 }
 

--- a/es-app/src/FileData.cpp
+++ b/es-app/src/FileData.cpp
@@ -125,8 +125,27 @@ const bool FileData::getKidGame()
 	return metadata.get("kidgame") != "false";
 }
 
+static std::shared_ptr<bool> showFilenames;
+
+void FileData::resetSettings() 
+{
+	showFilenames = nullptr;
+}
+
 const std::string FileData::getName()
 {
+	if (showFilenames == nullptr)
+		showFilenames = std::make_shared<bool>(Settings::getInstance()->getBool("ShowFilenames"));
+
+	// Faster than accessing map each time
+	if (*showFilenames)
+	{
+		if (mSystem != nullptr && !mSystem->hasPlatformId(PlatformIds::ARCADE) && !mSystem->hasPlatformId(PlatformIds::NEOGEO))
+			return Utils::FileSystem::getStem(getPath());
+		else
+			return getDisplayName();
+	}
+
 	return metadata.getName();
 }
 
@@ -437,7 +456,16 @@ const std::vector<FileData*> FolderData::getChildrenListToDisplay()
 		ret.push_back(*it);
 	}
 
-	
+	unsigned int currentSortId = sys->getSortId();
+	if (currentSortId > FileSorts::getSortTypes().size())
+		currentSortId = 0;
+
+	const FileSorts::SortType& sort = FileSorts::getSortTypes().at(currentSortId);
+	std::sort(ret.begin(), ret.end(), sort.comparisonFunction);
+
+	if (!sort.ascending)
+		std::reverse(ret.begin(), ret.end());
+
 	return ret;
 }
 
@@ -464,20 +492,7 @@ FileData* FolderData::findUniqueGameForFolder()
 
 std::vector<FileData*> FolderData::getFlatGameList(bool displayedOnly, SystemData* system) const 
 {
-	std::vector<FileData*> ret = getFilesRecursive(GAME, displayedOnly, system);
-
-	unsigned int currentSortId = system->getSortId();
-	if (currentSortId < 0 || currentSortId >FileSorts::getSortTypes().size())
-		currentSortId = 0;
-
-	auto sort = FileSorts::getSortTypes().at(currentSortId);
-
-	std::stable_sort(ret.begin(), ret.end(), sort.comparisonFunction);
-
-	if (!sort.ascending)
-		std::reverse(ret.begin(), ret.end());
-
-	return ret;
+	return getFilesRecursive(GAME, displayedOnly, system);
 }
 
 std::vector<FileData*> FolderData::getFilesRecursive(unsigned int typeMask, bool displayedOnly, SystemData* system) const
@@ -537,30 +552,6 @@ void FolderData::removeChild(FileData* file)
 	// File somehow wasn't in our children.
 	assert(false);
 
-}
-
-void FolderData::sort(ComparisonFunction& comparator, bool ascending)
-{
-	std::stable_sort(mChildren.begin(), mChildren.end(), comparator);
-
-	for (auto it = mChildren.cbegin(); it != mChildren.cend(); it++)
-	{
-		if ((*it)->getType() != FOLDER)
-			continue;
-
-		FolderData* folder = (FolderData*)(*it);
-
-		if (folder->getChildren().size() > 0)
-			folder->sort(comparator, ascending);
-	}
-
-	if (!ascending)
-		std::reverse(mChildren.begin(), mChildren.end());
-}
-
-void FolderData::sort(const SortType& type)
-{
-	sort(*type.comparisonFunction, type.ascending);
 }
 
 FileData* FolderData::FindByPath(const std::string& path)

--- a/es-app/src/FileData.h
+++ b/es-app/src/FileData.h
@@ -79,6 +79,8 @@ public:
 
 	MetaDataList metadata;
 
+	static void resetSettings();
+
 protected:	
 	FolderData* mParent;
 	std::string mPath;
@@ -123,21 +125,6 @@ public:
 		mChildren.clear();
 	}
 
-	typedef bool ComparisonFunction(const FileData* a, const FileData* b);
-	struct SortType
-	{
-		int id;
-		ComparisonFunction* comparisonFunction;
-		bool ascending;
-		std::string description;
-		std::string icon;
-
-		SortType(int sortId, ComparisonFunction* sortFunction, bool sortAscending, const std::string & sortDescription, const std::string & iconId = "")
-			: id(sortId), comparisonFunction(sortFunction), ascending(sortAscending), description(sortDescription), icon(iconId) {}
-	};
-
-	void sort(ComparisonFunction& comparator, bool ascending = true);
-	void sort(const SortType& type);
 
 	FileData* FindByPath(const std::string& path);
 

--- a/es-app/src/FileSorts.cpp
+++ b/es-app/src/FileSorts.cpp
@@ -23,12 +23,12 @@ namespace FileSorts
 		sInstance = nullptr;
 	}
 
-	const std::vector<FolderData::SortType>& getSortTypes()
+	const std::vector<SortType>& getSortTypes()
 	{
 		return getInstance()->mSortTypes;
 	}
 
-	FolderData::SortType getSortType(int sortId)
+	SortType getSortType(int sortId)
 	{
 		for (auto sort : getSortTypes())
 			if (sort.id == sortId)
@@ -39,35 +39,53 @@ namespace FileSorts
 
 	Singleton::Singleton()
 	{
-		mSortTypes.push_back(FolderData::SortType(FILENAME_ASCENDING, &compareName, true, _("FILENAME, ASCENDING"), _U("\uF15d ")));
-		mSortTypes.push_back(FolderData::SortType(FILENAME_DESCENDING, &compareName, false, _("FILENAME, DESCENDING"), _U("\uF15e ")));
-		mSortTypes.push_back(FolderData::SortType(RATING_ASCENDING, &compareRating, true, _("RATING, ASCENDING"), _U("\uF165 ")));
-		mSortTypes.push_back(FolderData::SortType(RATING_DESCENDING, &compareRating, false, _("RATING, DESCENDING"), _U("\uF164 ")));
-		mSortTypes.push_back(FolderData::SortType(TIMESPLAYED_ASCENDING, &compareTimesPlayed, true, _("TIMES PLAYED, ASCENDING"), _U("\uF160 ")));
-		mSortTypes.push_back(FolderData::SortType(TIMESPLAYED_DESCENDING, &compareTimesPlayed, false, _("TIMES PLAYED, DESCENDING"), _U("\uF161 ")));
-		mSortTypes.push_back(FolderData::SortType(LASTPLAYED_ASCENDING, &compareLastPlayed, true, _("LAST PLAYED, ASCENDING"), _U("\uF160 ")));
-		mSortTypes.push_back(FolderData::SortType(LASTPLAYED_DESCENDING, &compareLastPlayed, false, _("LAST PLAYED, DESCENDING"), _U("\uF161 ")));
-		mSortTypes.push_back(FolderData::SortType(NUMBERPLAYERS_ASCENDING, &compareNumPlayers, true, _("NUMBER PLAYERS, ASCENDING"), _U("\uF162 ")));
-		mSortTypes.push_back(FolderData::SortType(NUMBERPLAYERS_DESCENDING, &compareNumPlayers, false, _("NUMBER PLAYERS, DESCENDING"), _U("\uF163 ")));
-		mSortTypes.push_back(FolderData::SortType(RELEASEDATE_ASCENDING, &compareReleaseDate, true, _("RELEASE DATE, ASCENDING"), _U("\uF160 ")));
-		mSortTypes.push_back(FolderData::SortType(RELEASEDATE_DESCENDING, &compareReleaseDate, false, _("RELEASE DATE, DESCENDING"), _U("\uF161 ")));
-		mSortTypes.push_back(FolderData::SortType(GENRE_ASCENDING, &compareGenre, true, _("GENRE, ASCENDING"), _U("\uF15d ")));		
-		mSortTypes.push_back(FolderData::SortType(GENRE_DESCENDING, &compareGenre, false, _("GENRE, DESCENDING"), _U("\uF15e ")));
-		mSortTypes.push_back(FolderData::SortType(DEVELOPER_ASCENDING, &compareDeveloper, true, _("DEVELOPER, ASCENDING"), _U("\uF15d ")));
-		mSortTypes.push_back(FolderData::SortType(DEVELOPER_DESCENDING, &compareDeveloper, false, _("DEVELOPER, DESCENDING"), _U("\uF15e ")));
-		mSortTypes.push_back(FolderData::SortType(PUBLISHER_ASCENDING, &comparePublisher, true, _("PUBLISHER, ASCENDING"), _U("\uF15d ")));
-		mSortTypes.push_back(FolderData::SortType(PUBLISHER_DESCENDING, &comparePublisher, false, _("PUBLISHER, DESCENDING"), _U("\uF15e ")));
-		mSortTypes.push_back(FolderData::SortType(SYSTEM_ASCENDING, &compareSystem, true, _("SYSTEM, ASCENDING"), _U("\uF15d ")));
-		mSortTypes.push_back(FolderData::SortType(SYSTEM_DESCENDING, &compareSystem, false, _("SYSTEM, DESCENDING"), _U("\uF15e ")));
+		mSortTypes.push_back(SortType(FILENAME_ASCENDING, &compareName, true, _("FILENAME, ASCENDING"), _U("\uF15d ")));
+		mSortTypes.push_back(SortType(FILENAME_DESCENDING, &compareName, false, _("FILENAME, DESCENDING"), _U("\uF15e ")));
+		mSortTypes.push_back(SortType(RATING_ASCENDING, &compareRating, true, _("RATING, ASCENDING"), _U("\uF165 ")));
+		mSortTypes.push_back(SortType(RATING_DESCENDING, &compareRating, false, _("RATING, DESCENDING"), _U("\uF164 ")));
+		mSortTypes.push_back(SortType(TIMESPLAYED_ASCENDING, &compareTimesPlayed, true, _("TIMES PLAYED, ASCENDING"), _U("\uF160 ")));
+		mSortTypes.push_back(SortType(TIMESPLAYED_DESCENDING, &compareTimesPlayed, false, _("TIMES PLAYED, DESCENDING"), _U("\uF161 ")));
+		mSortTypes.push_back(SortType(LASTPLAYED_ASCENDING, &compareLastPlayed, true, _("LAST PLAYED, ASCENDING"), _U("\uF160 ")));
+		mSortTypes.push_back(SortType(LASTPLAYED_DESCENDING, &compareLastPlayed, false, _("LAST PLAYED, DESCENDING"), _U("\uF161 ")));
+		mSortTypes.push_back(SortType(NUMBERPLAYERS_ASCENDING, &compareNumPlayers, true, _("NUMBER PLAYERS, ASCENDING"), _U("\uF162 ")));
+		mSortTypes.push_back(SortType(NUMBERPLAYERS_DESCENDING, &compareNumPlayers, false, _("NUMBER PLAYERS, DESCENDING"), _U("\uF163 ")));
+		mSortTypes.push_back(SortType(RELEASEDATE_ASCENDING, &compareReleaseDate, true, _("RELEASE DATE, ASCENDING"), _U("\uF160 ")));
+		mSortTypes.push_back(SortType(RELEASEDATE_DESCENDING, &compareReleaseDate, false, _("RELEASE DATE, DESCENDING"), _U("\uF161 ")));
+		mSortTypes.push_back(SortType(GENRE_ASCENDING, &compareGenre, true, _("GENRE, ASCENDING"), _U("\uF15d ")));		
+		mSortTypes.push_back(SortType(GENRE_DESCENDING, &compareGenre, false, _("GENRE, DESCENDING"), _U("\uF15e ")));
+		mSortTypes.push_back(SortType(DEVELOPER_ASCENDING, &compareDeveloper, true, _("DEVELOPER, ASCENDING"), _U("\uF15d ")));
+		mSortTypes.push_back(SortType(DEVELOPER_DESCENDING, &compareDeveloper, false, _("DEVELOPER, DESCENDING"), _U("\uF15e ")));
+		mSortTypes.push_back(SortType(PUBLISHER_ASCENDING, &comparePublisher, true, _("PUBLISHER, ASCENDING"), _U("\uF15d ")));
+		mSortTypes.push_back(SortType(PUBLISHER_DESCENDING, &comparePublisher, false, _("PUBLISHER, DESCENDING"), _U("\uF15e ")));
+		mSortTypes.push_back(SortType(SYSTEM_ASCENDING, &compareSystem, true, _("SYSTEM, ASCENDING"), _U("\uF15d ")));
+		mSortTypes.push_back(SortType(SYSTEM_DESCENDING, &compareSystem, false, _("SYSTEM, DESCENDING"), _U("\uF15e ")));
 	}
 
 	//returns if file1 should come before file2
 	bool compareName(const FileData* file1, const FileData* file2)
 	{
-		// we compare the actual metadata name, as collection files have the system appended which messes up the order
-		std::string name1 = Utils::String::toUpper(file1->metadata.getName());
-		std::string name2 = Utils::String::toUpper(file2->metadata.getName());
-		return name1.compare(name2) < 0;
+		if (file1->getType() != file2->getType())
+			return file1->getType() == FOLDER;
+
+		// we compare the actual metadata name, as collection files have the system appended which messes up the order		
+		std::string name1 = ((FileData*)file1)->getName();
+		std::string name2 = ((FileData*)file2)->getName();
+
+		for (auto ap = name1.c_str(), bp = name2.c_str(); ; ap++, bp++)
+		{			
+			if (*ap == 0 & *bp != 0)
+				return true;
+
+			if (*ap == 0 || *bp == 0)
+				return false;
+
+			auto c1 = toupper(*ap);
+			auto c2 = toupper(*bp);
+			if (c1 != c2)
+				return c1 < c2;			
+		}
+
+		return false;
 	}
 
 	bool compareRating(const FileData* file1, const FileData* file2)

--- a/es-app/src/FileSorts.h
+++ b/es-app/src/FileSorts.h
@@ -31,17 +31,31 @@ namespace FileSorts
 		SYSTEM_DESCENDING = 19
 	};
 
+	typedef bool ComparisonFunction(const FileData* a, const FileData* b);
+
+	struct SortType
+	{
+		int id;
+		ComparisonFunction* comparisonFunction;
+		bool ascending;
+		std::string description;
+		std::string icon;
+
+		SortType(int sortId, ComparisonFunction* sortFunction, bool sortAscending, const std::string & sortDescription, const std::string & iconId = "")
+			: id(sortId), comparisonFunction(sortFunction), ascending(sortAscending), description(sortDescription), icon(iconId) {}
+	};
+
 	class Singleton
 	{
 	public:
 		Singleton();
 	
-		std::vector<FolderData::SortType> mSortTypes;
+		std::vector<SortType> mSortTypes;
 	};
 
 	void reset();
-	FolderData::SortType getSortType(int sortId);
-	const std::vector<FolderData::SortType>& getSortTypes();
+	SortType getSortType(int sortId);
+	const std::vector<SortType>& getSortTypes();
 
 	bool compareName(const FileData* file1, const FileData* file2);
 	bool compareRating(const FileData* file1, const FileData* file2);

--- a/es-app/src/SystemData.cpp
+++ b/es-app/src/SystemData.cpp
@@ -49,11 +49,11 @@ SystemData::SystemData(const std::string& name, const std::string& fullName, Sys
 
 		if(!Settings::getInstance()->getBool("IgnoreGamelist") && mName != "imageviewer")
 			parseGamelist(this, fileMap);
-		
+		/*
 		if (mSortId >= 0 && mSortId < FileSorts::getSortTypes().size())
 			mRootFolder->sort(FileSorts::getSortTypes().at(mSortId));
 		else
-			mRootFolder->sort(FileSorts::getSortTypes().at(0));
+			mRootFolder->sort(FileSorts::getSortTypes().at(0));*/
 	}
 	else
 	{

--- a/es-app/src/guis/GuiFastSelect.cpp
+++ b/es-app/src/guis/GuiFastSelect.cpp
@@ -131,12 +131,7 @@ void GuiFastSelect::updateSortText()
 
 void GuiFastSelect::updateGameListSort()
 {
-	const FolderData::SortType& sort = FileSorts::getSortTypes().at(mSortId);
-
 	FolderData* root = mGameList->getCursor()->getSystem()->getRootFolder();
-	root->sort(sort); // will also recursively sort children
-
-	// notify that the root folder was sorted
 	mGameList->onFileChanged(root, FILE_SORTED);
 }
 
@@ -145,7 +140,7 @@ void GuiFastSelect::updateGameListCursor()
 	const std::vector<FileData*>& list = mGameList->getCursor()->getParent()->getChildren();
 
 	// only skip by letter when the sort mode is alphabetical
-	const FolderData::SortType& sort = FileSorts::getSortTypes().at(mSortId);
+	const FileSorts::SortType& sort = FileSorts::getSortTypes().at(mSortId);
 	if(sort.comparisonFunction != &FileSorts::compareName)
 		return;
 

--- a/es-app/src/guis/GuiGamelistOptions.cpp
+++ b/es-app/src/guis/GuiGamelistOptions.cpp
@@ -134,7 +134,7 @@ GuiGamelistOptions::GuiGamelistOptions(Window* window, SystemData* system, bool 
 	mListSort = std::make_shared<SortList>(mWindow, _("SORT GAMES BY"), false);
 	for(unsigned int i = 0; i < FileSorts::getSortTypes().size(); i++)
 	{
-		const FolderData::SortType& sort = FileSorts::getSortTypes().at(i);
+		const FileSorts::SortType& sort = FileSorts::getSortTypes().at(i);
 		mListSort->add(sort.icon + sort.description, sort.id, sort.id == currentSortId); // TODO - actually make the sort type persistent
 	}
 
@@ -373,12 +373,12 @@ GuiGamelistOptions::~GuiGamelistOptions()
 	if (!fromPlaceholder && mListSort->getSelected() != mSystem->getSortId())
 	{
 		mSystem->setSortId(mListSort->getSelected());
-
+		
 		FolderData* root = mSystem->getRootFolder();
-
+		/*
 		const FolderData::SortType& sort = FileSorts::getSortTypes().at(mListSort->getSelected());
 		root->sort(sort);
-
+		*/
 		// notify that the root folder was sorted
 		getGamelist()->onFileChanged(root, FILE_SORTED);
 	}
@@ -496,11 +496,12 @@ void GuiGamelistOptions::jumpToLetter()
 	{
 		mListSort->selectFirstItem();
 		mSystem->setSortId(0);
-
+		
 		FolderData* root = mSystem->getRootFolder();
+		/*
 		const FolderData::SortType& sort = FileSorts::getSortTypes().at(0);
 		root->sort(sort);
-
+		*/
 		getGamelist()->onFileChanged(root, FILE_SORTED);
 	}
 

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -1784,11 +1784,19 @@ void GuiMenu::openUISettings()
 	s->addWithLabel(_("SEARCH FOR LOCAL ART"), local_art);
 	s->addSaveFunc([local_art] { Settings::getInstance()->setBool("LocalArt", local_art->getState()); });
 
-	// hidden files
+	// filenames
 	auto hidden_files = std::make_shared<SwitchComponent>(mWindow);
-	hidden_files->setState(Settings::getInstance()->getBool("ShowHiddenFiles"));
-	s->addWithLabel(_("SHOW HIDDEN FILES"), hidden_files);
-	s->addSaveFunc([hidden_files] { Settings::getInstance()->setBool("ShowHiddenFiles", hidden_files->getState()); });
+	hidden_files->setState(Settings::getInstance()->getBool("ShowFilenames"));
+	s->addWithLabel(_("SHOW FILENAMES IN LISTS"), hidden_files);
+	s->addSaveFunc([hidden_files, s] 
+	{ 
+		if (Settings::getInstance()->setBool("ShowFilenames", hidden_files->getState()))
+		{
+			FileData::resetSettings();
+			s->setVariable("reloadCollections", true);
+			s->setVariable("reloadAll", true);
+		}
+	});
 	
 
 

--- a/es-app/src/views/gamelist/BasicGameListView.cpp
+++ b/es-app/src/views/gamelist/BasicGameListView.cpp
@@ -49,6 +49,12 @@ void BasicGameListView::populateList(const std::vector<FileData*>& files)
 
 	if (files.size() > 0)
 	{
+		if (mCursorStack.size())
+		{
+			FileData* placeholder = new FileData(PLACEHOLDER, "..", this->mRoot->getSystem());
+			mList.add(". .", placeholder, (placeholder->getType() == PLACEHOLDER));
+		}
+
 		bool favoritesFirst = Settings::getInstance()->getBool("FavoritesFirst");
 		bool showFavoriteIcon = (systemName != "favorites");
 		if (!showFavoriteIcon)
@@ -60,9 +66,11 @@ void BasicGameListView::populateList(const std::vector<FileData*>& files)
 			{
 				if (!(*it)->getFavorite())
 					continue;
-
+				
 				if (showFavoriteIcon)
 					mList.add(_U("\uF006 ") + (*it)->getName(), *it, ((*it)->getType() == FOLDER));
+				else if (((*it)->getType() == FOLDER))
+					mList.add(_U("\uF114 ") + (*it)->getName(), *it, ((*it)->getType() == FOLDER));
 				else
 					mList.add((*it)->getName(), *it, ((*it)->getType() == FOLDER));
 			}
@@ -82,7 +90,10 @@ void BasicGameListView::populateList(const std::vector<FileData*>& files)
 				}
 			}
 
-			mList.add((*it)->getName(), *it, ((*it)->getType() == FOLDER));
+			if (((*it)->getType() == FOLDER))
+				mList.add(_U("\uF114 ") + (*it)->getName(), *it, ((*it)->getType() == FOLDER));
+			else
+				mList.add((*it)->getName(), *it, ((*it)->getType() == FOLDER));
 		}
 	}
 	else

--- a/es-app/src/views/gamelist/GridGameListView.cpp
+++ b/es-app/src/views/gamelist/GridGameListView.cpp
@@ -211,6 +211,12 @@ void GridGameListView::populateList(const std::vector<FileData*>& files)
 	mHeaderText.setText(mRoot->getSystem()->getFullName());
 	if (files.size() > 0)
 	{
+		if (mCursorStack.size())
+		{
+			FileData* placeholder = new FileData(PLACEHOLDER, "..", this->mRoot->getSystem());
+			mGrid.add(". .", "", "", "", placeholder);
+		}
+
 		std::string systemName = mRoot->getSystem()->getFullName();
 
 		bool favoritesFirst = Settings::getInstance()->getBool("FavoritesFirst");

--- a/es-app/src/views/gamelist/ISimpleGameListView.cpp
+++ b/es-app/src/views/gamelist/ISimpleGameListView.cpp
@@ -86,32 +86,46 @@ bool ISimpleGameListView::input(InputConfig* config, Input input)
 			FileData* cursor = getCursor();
 			FolderData* folder = NULL;
 
-			if (cursor->getType() == FOLDER)
-				folder = (FolderData*)cursor;
-
-			if(cursor->getType() == GAME)
+			if (mCursorStack.size() && cursor->getType() == PLACEHOLDER && cursor->getPath() == "..")
 			{
-				Sound::getFromTheme(getTheme(), getName(), "launch")->play();
-				launch(cursor);
-			}else{
-				// it's a folder
-				if (folder != nullptr && folder->getChildren().size() > 0)
+				auto top = mCursorStack.top();
+				mCursorStack.pop();
+
+				populateList(top->getParent()->getChildrenListToDisplay());
+				setCursor(top);
+				Sound::getFromTheme(getTheme(), getName(), "back")->play();
+			}
+			else
+			{
+				if (cursor->getType() == FOLDER)
+					folder = (FolderData*)cursor;
+
+				if (cursor->getType() == GAME)
 				{
-					mCursorStack.push(cursor);
-					populateList(folder->getChildrenListToDisplay());
-					FileData* cursor = getCursor();
-					setCursor(cursor);
+					Sound::getFromTheme(getTheme(), getName(), "launch")->play();
+					launch(cursor);
+				}
+				else {
+					// it's a folder
+					if (folder != nullptr && folder->getChildren().size() > 0)
+					{
+						mCursorStack.push(cursor);
+						populateList(folder->getChildrenListToDisplay());
+						FileData* cursor = getCursor();
+						setCursor(cursor);
+					}
 				}
 			}
-
 			return true;
 		}else if(config->isMappedTo(BUTTON_BACK, input))
 		{
 			if(mCursorStack.size())
 			{
-				populateList(mCursorStack.top()->getParent()->getChildren());
-				setCursor(mCursorStack.top());
+				auto top = mCursorStack.top();
 				mCursorStack.pop();
+
+				populateList(top->getParent()->getChildrenListToDisplay());
+				setCursor(top);				
 				Sound::getFromTheme(getTheme(), getName(), "back")->play();
 			}else{
 				onFocusLost();

--- a/es-core/src/Settings.cpp
+++ b/es-core/src/Settings.cpp
@@ -195,6 +195,8 @@ void Settings::setDefaults()
 	mBoolMap["PreloadUI"] = false;
 	mBoolMap["OptimizeVRAM"] = true;
 	mBoolMap["OptimizeVideo"] = true;
+
+	mBoolMap["ShowFilenames"] = false;
 	
 	mIntMap["WindowWidth"]   = 0;
 	mIntMap["WindowHeight"]  = 0;

--- a/es-core/src/components/GridTileComponent.cpp
+++ b/es-core/src/components/GridTileComponent.cpp
@@ -25,6 +25,7 @@ GridTileComponent::GridTileComponent(Window* window) : GuiComponent(window), mBa
 	mAnimPosition = Vector3f(0, 0);
 	mVideo = nullptr;
 	mMarquee = nullptr;
+	mIsDefaultImage = false;
 
 	mLabelVisible = false;
 	mLabelMerged = false;
@@ -119,6 +120,7 @@ void GridTileComponent::resize()
 	float height = (int) (size.y() * currentProperties.mLabelSize.y());
 	float labelHeight = height;
 
+	mLabel.setVisible(mLabelVisible || mIsDefaultImage);
 
 	if (mLabelVisible)
 	{
@@ -144,7 +146,7 @@ void GridTileComponent::resize()
 			}
 		}
 	}
-
+		
 	if (!mLabelVisible || mLabelMerged || currentProperties.mLabelSize.x() == 0)
 		height = 0;
 
@@ -260,6 +262,17 @@ void GridTileComponent::resize()
 		bkposition = Vector3f(x - mPosition.x(), y - mPosition.y(), 0);
 	}
 
+	if (!mLabelVisible && mIsDefaultImage)
+	{
+		mLabel.setColor(0xFFFFFFFF);
+		mLabel.setGlowColor(0x00000010);
+		mLabel.setGlowSize(2);
+		mLabel.setOpacity(255);
+		mLabel.setPosition(mSize.x() * 0.1, mSize.y() * 0.2);
+		mLabel.setSize(mSize.x() - mSize.x() * 0.2, mSize.y() - mSize.y() * 0.3);
+	}
+
+
 	mBackground.setPosition(bkposition);
 	mBackground.setSize(bkSize);
 	mBackground.setCornerSize(currentProperties.mBackgroundCornerSize);
@@ -328,6 +341,8 @@ void GridTileComponent::renderContent(const Transform4x4f& parentTrans)
 	if (mMarquee != nullptr && mMarquee->hasImage())
 		mMarquee->render(trans);
 	else if (mLabelVisible && currentProperties.mLabelSize.y()>0)
+		mLabel.render(trans);
+	else if (!mLabelVisible && mIsDefaultImage)
 		mLabel.render(trans);
 
 	if (mLabelMerged && currentProperties.mImageSizeMode == "minSize")
@@ -621,8 +636,9 @@ bool GridTileComponent::isSelected() const
 	return mSelected;
 }
 
-void GridTileComponent::setImage(const std::string& path)
+void GridTileComponent::setImage(const std::string& path, bool isDefaultImage)
 {
+	mIsDefaultImage = isDefaultImage;
 	if (mCurrentPath == path)
 		return;
 	

--- a/es-core/src/components/GridTileComponent.h
+++ b/es-core/src/components/GridTileComponent.h
@@ -61,7 +61,7 @@ public:
 	void setLabel(std::string name);
 	void setVideo(const std::string& path, float defaultDelay = -1.0);
 
-	void setImage(const std::string& path);
+	void setImage(const std::string& path, bool isDefaultImage = false);
 	void setMarquee(const std::string& path);
 
 	void setSelected(bool selected, bool allowAnimation = true, Vector3f* pPosition = NULL, bool force=false);
@@ -114,6 +114,8 @@ private:
 	float mSelectedZoomPercent;
 	bool mSelected;
 	bool mVisible;
+
+	bool mIsDefaultImage;
 
 	Vector3f mAnimPosition;
 

--- a/es-core/src/components/ImageGridComponent.h
+++ b/es-core/src/components/ImageGridComponent.h
@@ -819,10 +819,10 @@ void ImageGridComponent<T>::updateTileAtPos(int tilePos, int imgPos, bool allowA
 
 		if (ResourceManager::getInstance()->fileExists(imagePath))
 			tile->setImage(imagePath);
-		else if (mEntries.at(imgPos).object->getType() == 2)		
-			tile->setImage(mDefaultFolderTexture);
+		else if (mEntries.at(imgPos).object->getType() == 2 || (mEntries.at(imgPos).object->getType() == PLACEHOLDER && mEntries.at(imgPos).object->getPath() == ".."))
+			tile->setImage(mDefaultFolderTexture, true);
 		else
-			tile->setImage(mDefaultGameTexture);		
+			tile->setImage(mDefaultGameTexture, true);
 		
 		// Marquee
 		std::string marqueePath = mEntries.at(imgPos).data.marqueePath;


### PR DESCRIPTION
- Added ".." item when navigating in a subfolder.
- Faster case insentisive sorting + refactored sort calls.
- Show labels on grid items using default folder/game image, when labels are not defined by the theme.
- Added option "SHOW FILENAMES IN LISTS" to display filenames instead of scrapped names ( except arcade systems using mamenames )