### PR TITLE
Add run-ahead options

### DIFF
--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -876,7 +876,23 @@ void GuiMenu::openGamesSettings_batocera()
 			SystemConf::getInstance()->saveSystemConf();
 		}
 	});
-	
+	// run-ahead
+	auto runahead_enabled = std::make_shared<OptionListComponent<std::string>>(mWindow, _("RUN-AHEAD FRAMES"));
+	runahead_enabled->add(_("NO"), "0", SystemConf::getInstance()->get("global.runahead") < "1");
+	runahead_enabled->add("1", "1", SystemConf::getInstance()->get("global.runahead") == "1");
+	runahead_enabled->add("2", "2", SystemConf::getInstance()->get("global.runahead") == "2");
+	runahead_enabled->add("3", "3", SystemConf::getInstance()->get("global.runahead") == "3");
+	runahead_enabled->add("4", "4", SystemConf::getInstance()->get("global.runahead") == "4");
+	runahead_enabled->add("5", "5", SystemConf::getInstance()->get("global.runahead") == "5");
+	runahead_enabled->add("6", "6", SystemConf::getInstance()->get("global.runahead") == "6");
+	s->addWithLabel(_("RUN-AHEAD FRAMES"), runahead_enabled);
+
+	// second instance
+	auto secondinstance_enabled = std::make_shared<OptionListComponent<std::string>>(mWindow, _("SECOND INSTANCE"));
+	secondinstance_enabled->add(_("OFF"), "0", SystemConf::getInstance()->get("global.secondinstance") != "1");
+	secondinstance_enabled->add(_("ON"), "1", SystemConf::getInstance()->get("global.secondinstance") == "1");
+	s->addWithLabel(_("SECOND INSTANCE"), secondinstance_enabled);
+
 	// decorations
 	{		
 		auto sets = GuiMenu::getDecorationsSets(ViewController::get()->getState().getSystem());
@@ -1128,8 +1144,7 @@ void GuiMenu::openGamesSettings_batocera()
 			}, _("NO"), nullptr));
 		});
 	}
-
-	s->addSaveFunc([smoothing_enabled, rewind_enabled, shaders_choices, autosave_enabled] 
+	s->addSaveFunc([smoothing_enabled, rewind_enabled, shaders_choices, autosave_enabled, runahead_enabled, secondinstance_enabled] 
 	{
 		if (smoothing_enabled->changed())
 			SystemConf::getInstance()->set("global.smooth", smoothing_enabled->getSelected());
@@ -1139,7 +1154,10 @@ void GuiMenu::openGamesSettings_batocera()
 			SystemConf::getInstance()->set("global.shaderset", shaders_choices->getSelected());
 		if (autosave_enabled->changed())
 			SystemConf::getInstance()->set("global.autosave", autosave_enabled->getSelected());
-
+		if (runahead_enabled->changed())
+			SystemConf::getInstance()->set("global.runahead", runahead_enabled->getSelected());
+		if (secondinstance_enabled->changed())
+			SystemConf::getInstance()->set("global.secondinstance", secondinstance_enabled->getSelected());
 		SystemConf::getInstance()->saveSystemConf();
 	});
 
@@ -2426,6 +2444,22 @@ void GuiMenu::popSpecificConfigurationGui(Window* mWindow, std::string title, st
 	SystemConf::getInstance()->saveSystemConf();
       }
     });
+	// run-ahead
+	auto runahead_enabled = std::make_shared<OptionListComponent<std::string>>(mWindow, _("RUN-AHEAD FRAMES"));
+	runahead_enabled->add(_("NO"), "0", SystemConf::getInstance()->get(configName + ".runahead") < "0");
+	runahead_enabled->add("1", "1", SystemConf::getInstance()->get(configName + ".runahead") == "1");
+	runahead_enabled->add("2", "2", SystemConf::getInstance()->get(configName + ".runahead") == "2");
+	runahead_enabled->add("3", "3", SystemConf::getInstance()->get(configName + ".runahead") == "3");
+	runahead_enabled->add("4", "4", SystemConf::getInstance()->get(configName + ".runahead") == "4");
+	runahead_enabled->add("5", "5", SystemConf::getInstance()->get(configName + ".runahead") == "5");
+	runahead_enabled->add("6", "6", SystemConf::getInstance()->get(configName + ".runahead") == "6");
+	systemConfiguration->addWithLabel(_("RUN-AHEAD FRAMES"), runahead_enabled);
+
+	// second instance
+	auto secondinstance_enabled = std::make_shared<OptionListComponent<std::string>>(mWindow, _("SECOND INSTANCE"));
+	secondinstance_enabled->add(_("OFF"), "0", SystemConf::getInstance()->get(configName + ".secondinstance") != "1");
+	secondinstance_enabled->add(_("ON"), "1", SystemConf::getInstance()->get(configName + ".secondinstance") == "1");
+	systemConfiguration->addWithLabel(_("SECOND INSTANCE"), secondinstance_enabled);
 
   // decorations
   {
@@ -2562,7 +2596,7 @@ void GuiMenu::popSpecificConfigurationGui(Window* mWindow, std::string title, st
     systemConfiguration->addWithLabel(_("INTERNAL RESOLUTION"), internalresolution);
 
   systemConfiguration->addSaveFunc(
-				   [configName, systemData, smoothing_enabled, rewind_enabled, ratio_choice, videoResolutionMode_choice, emu_choice, core_choice, autosave_enabled, shaders_choices, colorizations_choices, fullboot_enabled, emulatedwiimotes_enabled, internalresolution] {
+				   [configName, systemData, smoothing_enabled, rewind_enabled, ratio_choice, videoResolutionMode_choice, emu_choice, core_choice, autosave_enabled, shaders_choices, colorizations_choices, fullboot_enabled, emulatedwiimotes_enabled, internalresolution, runahead_enabled, secondinstance_enabled] {
 				     if(ratio_choice->changed()){
 				       SystemConf::getInstance()->set(configName + ".ratio", ratio_choice->getSelected());
 				     }
@@ -2594,6 +2628,12 @@ void GuiMenu::popSpecificConfigurationGui(Window* mWindow, std::string title, st
 				     if(internalresolution->changed()){
 				       SystemConf::getInstance()->set(configName + ".internalresolution", internalresolution->getSelected());
 				     }
+					 if(runahead_enabled->changed()){
+				       SystemConf::getInstance()->set(configName + ".runahead", runahead_enabled->getSelected());
+				     }
+					 if(secondinstance_enabled->changed()){
+				       SystemConf::getInstance()->set(configName + ".secondinstance", secondinstance_enabled->getSelected());
+				     }				     
 
 				     // the menu GuiMenu::popSystemConfigurationGui is a hack
 				     // if you change any option except emulator and change the emulator, the value is lost

--- a/locale/emulationstation2.pot
+++ b/locale/emulationstation2.pot
@@ -348,6 +348,12 @@ msgstr ""
 msgid "SMOOTH GAMES"
 msgstr ""
 
+msgid "RUN-AHEAD FRAMES"
+msgstr ""
+
+msgid "SECOND INSTANCE"
+msgstr ""
+
 msgid "AUTO"
 msgstr ""
 

--- a/locale/lang/es/LC_MESSAGES/emulationstation2.po
+++ b/locale/lang/es/LC_MESSAGES/emulationstation2.po
@@ -340,6 +340,12 @@ msgstr "RELACIÓN DE ASPECTO"
 msgid "SMOOTH GAMES"
 msgstr "SUAVIZAR LOS JUEGOS"
 
+msgid "RUN-AHEAD FRAMES"
+msgstr "FRAMES POR ADELANTADO"
+
+msgid "SECOND INSTANCE"
+msgstr "SEGUNDA INSTANCIA"
+
 msgid "AUTO"
 msgstr "AUTO"
 


### PR DESCRIPTION
This will let you add up to 6 frames of run-ahead globally, per system, or per game, batocera.conf needs to be updated to handle 
* global.runahead
* global.secondinstance
* [system].runahead
* [system].secondinstance
* [game].runahead
* [game].secondinstance