### PR TITLE
Fix : Many videos can be loaded/played together when returning from a…

### DIFF
--- a/es-app/src/MetaData.cpp
+++ b/es-app/src/MetaData.cpp
@@ -246,14 +246,14 @@ void MetaDataList::importScrappedMetadata(const MetaDataList& source)
 		if (Settings::getInstance()->getString("ScrapperImageSrc").empty())
 			type &= ~MetaDataImportType::Types::IMAGE;
 
-		if (!Settings::getInstance()->getString("ScrapperThumbSrc").empty())
+		if (Settings::getInstance()->getString("ScrapperThumbSrc").empty())
 			type &= ~MetaDataImportType::Types::THUMB;
+
+		if (Settings::getInstance()->getString("ScrapperLogoSrc").empty())
+			type &= ~MetaDataImportType::Types::MARQUEE;
 
 		if (!Settings::getInstance()->getBool("ScrapeVideos"))
 			type &= ~MetaDataImportType::Types::VIDEO;
-
-		if (!Settings::getInstance()->getBool("ScrapeMarquee"))
-			type &= ~MetaDataImportType::Types::MARQUEE;
 	}
 
 	for (auto mdd : getMDD())

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -140,50 +140,51 @@ void GuiMenu::openScraperSettings()
 
 	if (scraper == "ScreenScraper")
 	{
-		// image source
+		// Image source : <image> tag
 		std::string imageSourceName = Settings::getInstance()->getString("ScrapperImageSrc");
-		auto imageSource = std::make_shared< OptionListComponent<std::string> >(mWindow, _("PREFERED IMAGE SOURCE"), false);
+		auto imageSource = std::make_shared< OptionListComponent<std::string> >(mWindow, _("IMAGE SOURCE"), false);
 		imageSource->add(_("NONE"), "", imageSourceName.empty());
 		imageSource->add(_("SCREENSHOT"), "ss", imageSourceName == "ss");
 		imageSource->add(_("TITLE SCREENSHOT"), "sstitle", imageSourceName == "sstitle");
-		imageSource->add(_("BOX 2D"), "box-2D", imageSourceName == "box-2D");
-		imageSource->add(_("BOX 3D"), "box-3D", imageSourceName == "box-3D");
 		imageSource->add(_("MIX"), "mixrbv1", imageSourceName == "mixrbv1");
-		imageSource->add(_("WHEEL"), "wheel", imageSourceName == "wheel");
-		s->addWithLabel(_("PREFERED IMAGE SOURCE"), imageSource);
 
-		s->addSaveFunc([imageSource] {
-			if (Settings::getInstance()->getString("ScrapperImageSrc") != imageSource->getSelected())
-				Settings::getInstance()->setString("ScrapperImageSrc", imageSource->getSelected());
-		});
-		
+		if (!imageSource->hasSelection())
+			imageSource->selectFirstItem();
+
+		s->addWithLabel(_("IMAGE SOURCE"), imageSource);
+		s->addSaveFunc([imageSource] { Settings::getInstance()->setString("ScrapperImageSrc", imageSource->getSelected()); });
+
+		// Box source : <thumbnail> tag
 		std::string thumbSourceName = Settings::getInstance()->getString("ScrapperThumbSrc");
-		auto thumbSource = std::make_shared< OptionListComponent<std::string> >(mWindow, _("PREFERED THUMBNAIL SOURCE"), false);
+		auto thumbSource = std::make_shared< OptionListComponent<std::string> >(mWindow, _("BOX SOURCE"), false);
 		thumbSource->add(_("NONE"), "", thumbSourceName.empty());
-		thumbSource->add(_("SCREENSHOT"), "ss", thumbSourceName == "ss");
-		thumbSource->add(_("TITLE SCREENSHOT"), "sstitle", thumbSourceName == "sstitle");
 		thumbSource->add(_("BOX 2D"), "box-2D", thumbSourceName == "box-2D");
 		thumbSource->add(_("BOX 3D"), "box-3D", thumbSourceName == "box-3D");
-		thumbSource->add(_("MIX"), "mixrbv1", thumbSourceName == "mixrbv1");
-		thumbSource->add(_("WHEEL"), "wheel", thumbSourceName == "wheel");
-		s->addWithLabel(_("PREFERED THUMBNAIL SOURCE"), thumbSource);
 
-		s->addSaveFunc([thumbSource] {
-			if (Settings::getInstance()->getString("ScrapperThumbSrc") != thumbSource->getSelected())
-				Settings::getInstance()->setString("ScrapperThumbSrc", thumbSource->getSelected());
-		});
+		if (!thumbSource->hasSelection())
+			thumbSource->selectFirstItem();
+
+		s->addWithLabel(_("BOX SOURCE"), thumbSource);
+		s->addSaveFunc([thumbSource] { Settings::getInstance()->setString("ScrapperThumbSrc", thumbSource->getSelected()); });
+
+		// Logo source : <marquee> tag
+		std::string logoSourceName = Settings::getInstance()->getString("ScrapperLogoSrc");
+		auto logoSource = std::make_shared< OptionListComponent<std::string> >(mWindow, _("LOGO SOURCE"), false);
+		logoSource->add(_("NONE"), "", logoSourceName.empty());
+		logoSource->add(_("WHEEL"), "wheel", logoSourceName == "wheel");
+		logoSource->add(_("MARQUEE"), "marquee", logoSourceName == "marquee");
+
+		if (!logoSource->hasSelection())
+			logoSource->selectFirstItem();
+
+		s->addWithLabel(_("LOGO SOURCE"), logoSource);
+		s->addSaveFunc([logoSource] { Settings::getInstance()->setString("ScrapperLogoSrc", logoSource->getSelected()); });
 
 		// scrape ratings
 		auto scrape_ratings = std::make_shared<SwitchComponent>(mWindow);
 		scrape_ratings->setState(Settings::getInstance()->getBool("ScrapeRatings"));
 		s->addWithLabel(_("SCRAPE RATINGS"), scrape_ratings); // batocera
 		s->addSaveFunc([scrape_ratings] { Settings::getInstance()->setBool("ScrapeRatings", scrape_ratings->getState()); });
-
-		// scrape marquee
-		auto scrape_marquee = std::make_shared<SwitchComponent>(mWindow);
-		scrape_marquee->setState(Settings::getInstance()->getBool("ScrapeMarquee"));
-		s->addWithLabel(_("SCRAPE MARQUEE"), scrape_marquee);
-		s->addSaveFunc([scrape_marquee] { Settings::getInstance()->setBool("ScrapeMarquee", scrape_marquee->getState()); });
 
 		// scrape video
 		auto scrape_video = std::make_shared<SwitchComponent>(mWindow);

--- a/es-app/src/guis/GuiScraperStart.cpp
+++ b/es-app/src/guis/GuiScraperStart.cpp
@@ -31,13 +31,13 @@ GuiScraperStart::GuiScraperStart(Window* window) : GuiComponent(window),
 			if (!Settings::getInstance()->getString("ScrapperImageSrc").empty() && !Utils::FileSystem::exists(g->metadata.get("image")))
 				return true;
 
-			if (Settings::getInstance()->getString("ScrapperThumbSrc").empty() && !Utils::FileSystem::exists(g->metadata.get("thumbnail")))
+			if (!Settings::getInstance()->getString("ScrapperThumbSrc").empty() && !Utils::FileSystem::exists(g->metadata.get("thumbnail")))
+				return true;
+
+			if (!Settings::getInstance()->getString("ScrapperLogoSrc").empty() && !Utils::FileSystem::exists(g->metadata.get("marquee")))
 				return true;
 
 			if (Settings::getInstance()->getBool("ScrapeVideos") && !Utils::FileSystem::exists(g->metadata.get("video")))
-				return true;
-
-			if (Settings::getInstance()->getBool("ScrapeMarquee") && !Utils::FileSystem::exists(g->metadata.get("marquee")))
 				return true;
 
 			return false;

--- a/es-app/src/scrapers/Scraper.cpp
+++ b/es-app/src/scrapers/Scraper.cpp
@@ -253,7 +253,7 @@ MDResolveHandle::MDResolveHandle(const ScraperSearchResult& result, const Scrape
 		}, "thumbnail", result.mdl.getName()));
 	}
 
-	if (!search.overWriteMedias && Settings::getInstance()->getBool("ScrapeMarquee") && Utils::FileSystem::exists(search.game->metadata.get("marquee")))
+	if (!search.overWriteMedias && ss && !Settings::getInstance()->getString("ScrapperLogoSrc").empty() && Utils::FileSystem::exists(search.game->metadata.get("marquee")))
 		mResult.mdl.set("marquee", search.game->metadata.get("marquee"));
 	else if (!result.marqueeUrl.empty())
 	{

--- a/es-app/src/scrapers/ScreenScraper.cpp
+++ b/es-app/src/scrapers/ScreenScraper.cpp
@@ -333,8 +333,10 @@ std::vector<std::string> ScreenScraperRequest::getRipList(std::string imageSourc
 		ripList = { "box-2D", "box-3D" };
 	else if (imageSource == "box-3D")
 		ripList = { "box-3D", "box-2D" };
-	else if (imageSource == "wheel" || imageSource == "marquee")
+	else if (imageSource == "wheel")
 		ripList = { "wheel", "wheel-hd", "wheel-steel", "wheel-carbon", "screenmarqueesmall", "screenmarquee" };
+	else if (imageSource == "marquee")
+		ripList = { "screenmarqueesmall", "screenmarquee", "wheel", "wheel-hd", "wheel-steel", "wheel-carbon" };
 
 	return ripList;
 }
@@ -461,9 +463,9 @@ void ScreenScraperRequest::processGame(const pugi::xml_document& xmldoc, std::ve
 				}
 			}
 
-			if (Settings::getInstance()->getBool("ScrapeMarquee"))
+			if (!Settings::getInstance()->getString("ScrapperLogoSrc").empty())
 			{
-				ripList = getRipList("marquee");
+				ripList = getRipList(Settings::getInstance()->getString("ScrapperLogoSrc"));
 				if (!ripList.empty())
 				{
 					pugi::xml_node art = findMedia(media_list, ripList, region);

--- a/es-app/src/views/ViewController.cpp
+++ b/es-app/src/views/ViewController.cpp
@@ -732,3 +732,11 @@ void ViewController::onThemeChanged(const std::shared_ptr<ThemeData>& theme)
 	ThemeData::setDefaultTheme(theme.get());
 	mWindow->onThemeChanged(theme);
 }
+
+
+void ViewController::onShow()
+{
+	if (mCurrentView)
+		mCurrentView->onShow();
+}
+

--- a/es-app/src/views/ViewController.h
+++ b/es-app/src/views/ViewController.h
@@ -89,6 +89,8 @@ public:
 
 	void onThemeChanged(const std::shared_ptr<ThemeData>& theme);
 
+	virtual void onShow() override;	
+
 private:
 	ViewController(Window* window);
 	static ViewController* sInstance;

--- a/es-app/src/views/gamelist/VideoGameListView.cpp
+++ b/es-app/src/views/gamelist/VideoGameListView.cpp
@@ -38,9 +38,8 @@ VideoGameListView::VideoGameListView(Window* window, FolderData* root) :
 #else
 	mVideo = new VideoVlcComponent(window, getTitlePath());
 #endif
-
-	// Default is thumbnail in Retropie themes & video view
-	mVideo->setSnapshotSource(THUMBNAIL);
+	
+	mVideo->setSnapshotSource(IMAGE);
 
 	mList.setPosition(mSize.x() * (0.50f + padding), mList.getPosition().y());
 	mList.setSize(mSize.x() * (0.50f - padding), mList.getSize().y());

--- a/es-app/src/views/gamelist/VideoGameListView.cpp
+++ b/es-app/src/views/gamelist/VideoGameListView.cpp
@@ -302,10 +302,14 @@ void VideoGameListView::updateInfoPanel()
 		mVideo->setImage(snapShot);
 
 		mMarquee.setImage(file->getMarqueePath()/*, false, mMarquee.getMaxSizeInfo()*/); // Too slow on pi
-		mImage.setImage(file->getImagePath(), false, mImage.getMaxSizeInfo());
 
 		if (mThumbnail != nullptr)
+		{
+			mImage.setImage(file->getImagePath(), false, mImage.getMaxSizeInfo());
 			mThumbnail->setImage(file->getThumbnailPath(), false, mThumbnail->getMaxSizeInfo());
+		}
+		else
+			mImage.setImage(file->getThumbnailPath(), false, mImage.getMaxSizeInfo());
 
 		mDescription.setText(file->metadata.get("desc"));
 		mDescContainer.reset();

--- a/es-core/src/Settings.cpp
+++ b/es-core/src/Settings.cpp
@@ -122,7 +122,7 @@ void Settings::setDefaults()
 	mStringMap["Scraper"] = "ScreenScraper";
 	mStringMap["ScrapperImageSrc"] = "ss";
 	mStringMap["ScrapperThumbSrc"] = "box-2D";
-	mBoolMap["ScrapeMarquee"] = false;
+	mStringMap["ScrapperLogoSrc"] = "wheel";
 	mBoolMap["ScrapeVideos"] = false;
 	
 	mBoolMap["ScreenSaverMarquee"] = true;

--- a/es-core/src/components/OptionListComponent.h
+++ b/es-core/src/components/OptionListComponent.h
@@ -356,6 +356,15 @@ public:
 	  return firstSelected != getSelected();
 	}
 
+	bool hasSelection()
+	{
+		for (unsigned int i = 0; i < mEntries.size(); i++)
+			if (mEntries.at(i).selected)
+				return true;
+
+		return false;
+	}
+
 	void selectFirstItem()
 	{
 		for (unsigned int i = 0; i < mEntries.size(); i++)


### PR DESCRIPTION
- Fix : Many videos can be loaded/played together when returning from a game, when video delay is 0
+ Scraper : Simplified image/box/logo sources to avoid confusion 
+ Video View : Image in should now prefer thumbnail
+ Video View : Image snapshot defaut source set to Image to display screenshot as default scrapped image source is screenshot


