### PR TITLE
GridView.centerSelection : add "partial" value & changed false value behaviour

### DIFF
--- a/es-core/src/ThemeData.cpp
+++ b/es-core/src/ThemeData.cpp
@@ -54,7 +54,7 @@ std::map<std::string, std::map<std::string, ThemeData::ElementPropertyType>> The
 		{ "showVideoAtDelay", FLOAT },
 		{ "scrollDirection", STRING },
 		{ "scrollSound", PATH },
-		{ "centerSelection", BOOLEAN },
+		{ "centerSelection", STRING },
 		{ "scrollLoop", BOOLEAN } } },
 	{ "gridtile", {
 		{ "size", NORMALIZED_PAIR },

--- a/es-core/src/components/GridTileComponent.cpp
+++ b/es-core/src/components/GridTileComponent.cpp
@@ -555,6 +555,9 @@ bool GridTextProperties::applyTheme(const ThemeData::ThemeElement* elem)
 	if (elem && elem->has("fontPath"))
 		fontPath = elem->get<std::string>("fontPath");
 
+	if (elem->has("singleLineScroll"))
+		autoScroll = elem->get<bool>("singleLineScroll");
+
 	return true;
 }
 

--- a/es-core/src/components/GridTileComponent.h
+++ b/es-core/src/components/GridTileComponent.h
@@ -97,6 +97,7 @@ public:
 		text->setBackgroundColor(backColor);
 		text->setGlowColor(glowColor);
 		text->setGlowSize(glowSize);
+		text->setAutoScroll(autoScroll);
 		text->setFont(fontPath, fontSize * (float)Renderer::getScreenHeight());
 	}
 
@@ -116,6 +117,7 @@ public:
 
 	std::string  fontPath;
 	float fontSize;
+	bool autoScroll;
 };
 
 struct GridNinePatchProperties

--- a/es-core/src/components/TextComponent.cpp
+++ b/es-core/src/components/TextComponent.cpp
@@ -173,7 +173,10 @@ void TextComponent::render(const Transform4x4f& parentTrans)
 		Renderer::drawRect(0.0f, 0.0f, mSize.x(), mSize.y(), bgColor, bgColor);
 	}
 
-	if(mTextCache && mFont)
+	if (mAutoScroll)
+		Renderer::pushClipRect(Vector2i(trans.translation().x(), trans.translation().y()), Vector2i(mSize.x(), mSize.y()));
+
+	if (mTextCache && mFont)
 	{
 		const Vector2f& textSize = mTextCache->metrics.size;
 		float yOff = 0;
@@ -277,6 +280,9 @@ void TextComponent::render(const Transform4x4f& parentTrans)
 
 			mFont->renderGradientTextCache(mTextCache.get(), colorB, colorT);
 		}
+
+		if (mAutoScroll)
+			Renderer::popClipRect();
 	}
 }
 

--- a/es-core/src/components/TextComponent.cpp
+++ b/es-core/src/components/TextComponent.cpp
@@ -309,7 +309,7 @@ void TextComponent::onTextChanged()
 	std::string text = mUppercase ? Utils::String::toUpper(mText) : mText;
 
 	std::shared_ptr<Font> f = mFont;
-	const bool isMultiline = !mAutoScroll && (mSize.y() == 0 || sy > f->getHeight()*1.2f);
+	const bool isMultiline = !mAutoScroll && (mSize.y() == 0 || sy > f->getHeight()*1.95f);
 
 	bool addAbbrev = false;
 	if(!isMultiline)
@@ -351,7 +351,7 @@ void TextComponent::update(int deltaTime)
 	GuiComponent::update(deltaTime);
 
 	int sy = mSize.y() - mPadding.y() - mPadding.w();
-	const bool isMultiline = !mAutoScroll && (mSize.y() == 0 || sy > mFont->getHeight()*1.2f);
+	const bool isMultiline = !mAutoScroll && (mSize.y() == 0 || sy > mFont->getHeight()*1.95f);
 
 	if (mAutoScroll && !isMultiline && mSize.x() > 0)
 	{
@@ -370,7 +370,7 @@ void TextComponent::update(int deltaTime)
 			// loop
 			// pixels per second ( based on nes-mini font at 1920x1080 to produce a speed of 200 )
 			const float speed = mFont->sizeText("ABCDEFGHIJKLMNOPQRSTUVWXYZ").x() * 0.247f;
-			const float delay = 3000;
+			const float delay = 1000;
 			const float scrollLength = textLength;
 			const float returnLength = speed * 1.5f;
 			const float scrollTime = (scrollLength * 1000) / speed;
@@ -531,4 +531,13 @@ void TextComponent::applyTheme(const std::shared_ptr<ThemeData>& theme, const st
 	}
 
 	setFont(Font::getFromTheme(elem, properties, mFont));
+}
+
+void TextComponent::setAutoScroll(bool value)
+{
+	if (mAutoScroll == value)
+		return;
+
+	mAutoScroll = value;
+	onTextChanged();
 }

--- a/es-core/src/components/TextComponent.h
+++ b/es-core/src/components/TextComponent.h
@@ -50,6 +50,9 @@ public:
 
 	virtual void update(int deltaTime);
 
+	bool getAutoScroll() { return mAutoScroll; }
+	void setAutoScroll(bool value);
+
 protected:
 	virtual void onTextChanged();
 


### PR DESCRIPTION
true -> always center the selection
partial -> center the selection except if at begin or end of gamelist ( was the previous default for false )
false -> never center selection

Default becomes "false" in vertical layout. ( instead of partial )
Default is "partial" in horizontal layout.

+ TextComponent : fix multiline calculation