### PR TITLE
Add a <gametime> attribute in gamelist.xml to keep track of playing time

### DIFF
--- a/es-app/src/FileData.cpp
+++ b/es-app/src/FileData.cpp
@@ -387,7 +387,7 @@ void FileData::launchGame(Window* window, LaunchGameOptions options)
 	// Batocera 5.25: how long have you played that game? (more than 5 seconds, otherwise 
 	// your might have experienced a loading problem)
 	long gameTime = gameToUpdate->getMetadata().getInt("gametime") + elapsed_seconds;
-	if (gameTime >= 5)
+	if (elapsed_seconds >= 5)
 		gameToUpdate->getMetadata().set("gametime", std::to_string(static_cast<long>(gameTime)));
 
 	//update last played time

--- a/es-app/src/FileData.cpp
+++ b/es-app/src/FileData.cpp
@@ -21,6 +21,7 @@
 #include "scrapers/ThreadedScraper.h"
 #include "Gamelist.h" 
 #include "ApiSystem.h"
+#include <time.h>
 
 FileData::FileData(FileType type, const std::string& path, SystemData* system)
 	: mType(type), mSystem(system), mParent(NULL), mMetadata(type == GAME ? GAME_METADATA : FOLDER_METADATA) // metadata is REALLY set in the constructor!
@@ -353,6 +354,8 @@ void FileData::launchGame(Window* window, LaunchGameOptions options)
 
 	Scripting::fireEvent("game-start", rom, basename);
 
+	time_t tstart = time(NULL);
+
 	LOG(LogInfo) << "	" << command;
 	int exitCode = runSystemCommand(command);
 
@@ -366,6 +369,9 @@ void FileData::launchGame(Window* window, LaunchGameOptions options)
 	window->init();
 	VolumeControl::getInstance()->init();
 
+	time_t tend = time(NULL);
+	long elapsed_seconds = difftime(tend, tstart);
+
 	// mSystem can be NULL
 	//AudioManager::getInstance()->setName(mSystem->getName()); // batocera system-specific music
 	AudioManager::getInstance()->init(); // batocera
@@ -377,6 +383,12 @@ void FileData::launchGame(Window* window, LaunchGameOptions options)
 
 	int timesPlayed = gameToUpdate->getMetadata().getInt("playcount") + 1;
 	gameToUpdate->getMetadata().set("playcount", std::to_string(static_cast<long long>(timesPlayed)));
+
+	// Batocera 5.25: how long have you played that game? (more than 5 seconds, otherwise 
+	// your might have experienced a loading problem)
+	long gameTime = gameToUpdate->getMetadata().getInt("gametime") + elapsed_seconds;
+	if (gameTime >= 5)
+		gameToUpdate->getMetadata().set("gametime", std::to_string(static_cast<long>(gameTime)));
 
 	//update last played time
 	gameToUpdate->getMetadata().set("lastplayed", Utils::Time::DateTime(Utils::Time::now()));

--- a/es-app/src/MetaData.cpp
+++ b/es-app/src/MetaData.cpp
@@ -11,10 +11,10 @@
 static std::vector<MetaDataDecl> gameMDD;
 static std::vector<MetaDataDecl> folderMDD;
 
-static std::string mDefaultGameMap[20];
+static std::string mDefaultGameMap[21];
 static std::string mDefaultFolderMap[14];
 
-static MetaDataType mGameTypeMap[20];
+static MetaDataType mGameTypeMap[21];
 static MetaDataType mFolderTypeMap[14];
 
 static std::map<std::string, unsigned char> mGameIdMap;
@@ -41,10 +41,9 @@ void MetaDataList::initMetadata()
 	gameMDD.push_back(MetaDataDecl(15, "kidgame", MD_BOOL, "false", false, _("Kidgame"), _("set kidgame")));
 	gameMDD.push_back(MetaDataDecl(16, "playcount", MD_INT, "0", true, _("Play count"), _("enter number of times played")));
 	gameMDD.push_back(MetaDataDecl(17, "lastplayed", MD_TIME, "0", true, _("Last played"), _("enter last played date")));
-
 	gameMDD.push_back(MetaDataDecl(18, "crc32", MD_STRING, "", false, "Crc32", _("Crc32 checksum")));
 	gameMDD.push_back(MetaDataDecl(19, "md5", MD_STRING, "", false, "Md5", _("Md5 checksum")));
-
+	gameMDD.push_back(MetaDataDecl(20, "gametime", MD_INT, "0", true, _("Game time"), _("how long the game has been played in total")));
 
 	folderMDD.push_back(MetaDataDecl(0, "name", MD_STRING, "", false, _("name"), _("enter game name")));
 	//  folderMDD.push_back(MetaDataDecl(1, "sortname",	MD_STRING,		"", 		false, _("sortname"),    _("enter game sort name")));


### PR DESCRIPTION
Added a new `<gametime>` XML attribute in `gamelist.xml` that keeps track of how long you've played a game. It displays the total number of seconds the game has been launched from ES. This new attribute needs to be displayed by the themes (I'd recommend to add it to Batocera default theme).

To avoid false positives, it's logged only if the calculated game time for a session is >5.
Structure of the new attribute:

```
<gameList>
        <game>
             ....
             <gametime>164</gametime>
	</game>
</gameList>
```