### PR TITLE
Add <gametime> in gamelist.xml to keep track of playing time

### DIFF
--- a/es-app/src/FileData.cpp
+++ b/es-app/src/FileData.cpp
@@ -21,6 +21,7 @@
 #include "scrapers/ThreadedScraper.h"
 #include "Gamelist.h" 
 #include "ApiSystem.h"
+#include <time.h>
 
 FileData::FileData(FileType type, const std::string& path, SystemData* system)
 	: mType(type), mSystem(system), mParent(NULL), mMetadata(type == GAME ? GAME_METADATA : FOLDER_METADATA) // metadata is REALLY set in the constructor!
@@ -353,6 +354,8 @@ void FileData::launchGame(Window* window, LaunchGameOptions options)
 
 	Scripting::fireEvent("game-start", rom, basename);
 
+	time_t tstart = time(NULL);
+
 	LOG(LogInfo) << "	" << command;
 	int exitCode = runSystemCommand(command);
 
@@ -366,6 +369,9 @@ void FileData::launchGame(Window* window, LaunchGameOptions options)
 	window->init();
 	VolumeControl::getInstance()->init();
 
+	time_t tend = time(NULL);
+	long elapsedSeconds = difftime(tend, tstart);
+
 	// mSystem can be NULL
 	//AudioManager::getInstance()->setName(mSystem->getName()); // batocera system-specific music
 	AudioManager::getInstance()->init(); // batocera
@@ -377,6 +383,12 @@ void FileData::launchGame(Window* window, LaunchGameOptions options)
 
 	int timesPlayed = gameToUpdate->getMetadata().getInt("playcount") + 1;
 	gameToUpdate->getMetadata().set("playcount", std::to_string(static_cast<long long>(timesPlayed)));
+
+	// Batocera 5.25: how long have you played that game? (more than 10 seconds, otherwise 
+	// your might have experienced a loading problem)
+	long gameTime = gameToUpdate->getMetadata().getInt("gametime") + elapsedSeconds;
+	if (elapsedSeconds >= 10)
+		gameToUpdate->getMetadata().set("gametime", std::to_string(static_cast<long>(gameTime)));
 
 	//update last played time
 	gameToUpdate->getMetadata().set("lastplayed", Utils::Time::DateTime(Utils::Time::now()));

--- a/es-app/src/MetaData.cpp
+++ b/es-app/src/MetaData.cpp
@@ -11,10 +11,10 @@
 static std::vector<MetaDataDecl> gameMDD;
 static std::vector<MetaDataDecl> folderMDD;
 
-static std::string mDefaultGameMap[20];
+static std::string mDefaultGameMap[21];
 static std::string mDefaultFolderMap[14];
 
-static MetaDataType mGameTypeMap[20];
+static MetaDataType mGameTypeMap[21];
 static MetaDataType mFolderTypeMap[14];
 
 static std::map<std::string, unsigned char> mGameIdMap;
@@ -41,10 +41,9 @@ void MetaDataList::initMetadata()
 	gameMDD.push_back(MetaDataDecl(15, "kidgame", MD_BOOL, "false", false, _("Kidgame"), _("set kidgame")));
 	gameMDD.push_back(MetaDataDecl(16, "playcount", MD_INT, "0", true, _("Play count"), _("enter number of times played")));
 	gameMDD.push_back(MetaDataDecl(17, "lastplayed", MD_TIME, "0", true, _("Last played"), _("enter last played date")));
-
 	gameMDD.push_back(MetaDataDecl(18, "crc32", MD_STRING, "", false, "Crc32", _("Crc32 checksum")));
 	gameMDD.push_back(MetaDataDecl(19, "md5", MD_STRING, "", false, "Md5", _("Md5 checksum")));
-
+	gameMDD.push_back(MetaDataDecl(20, "gametime", MD_INT, "0", true, _("Game time"), _("how long the game has been played in total (seconds)")));
 
 	folderMDD.push_back(MetaDataDecl(0, "name", MD_STRING, "", false, _("name"), _("enter game name")));
 	//  folderMDD.push_back(MetaDataDecl(1, "sortname",	MD_STRING,		"", 		false, _("sortname"),    _("enter game sort name")));

--- a/es-app/src/views/gamelist/DetailedGameListView.cpp
+++ b/es-app/src/views/gamelist/DetailedGameListView.cpp
@@ -16,11 +16,11 @@ DetailedGameListView::DetailedGameListView(Window* window, FolderData* root) :
 	mImage(nullptr), mMarquee(nullptr), mVideo(nullptr), mThumbnail(nullptr),
 
 	mLblRating(window), mLblReleaseDate(window), mLblDeveloper(window), mLblPublisher(window), 
-	mLblGenre(window), mLblPlayers(window), mLblLastPlayed(window), mLblPlayCount(window),
+	mLblGenre(window), mLblPlayers(window), mLblLastPlayed(window), mLblPlayCount(window), mLblGameTime(window),
 
 	mRating(window), mReleaseDate(window), mDeveloper(window), mPublisher(window), 
 	mGenre(window), mPlayers(window), mLastPlayed(window), mPlayCount(window),
-	mName(window)
+	mName(window), mGameTime(window)
 {
 	const float padding = 0.01f;
 
@@ -58,6 +58,9 @@ DetailedGameListView::DetailedGameListView(Window* window, FolderData* root) :
 	mLblPlayCount.setText(_("Times played") + ": "); // batocera
 	addChild(&mLblPlayCount);
 	addChild(&mPlayCount);
+	mLblGameTime.setText(_("Game time") + ": "); // batocera
+	addChild(&mLblGameTime);
+	addChild(&mGameTime);
 
 	mName.setPosition(mSize.x(), mSize.y());
 	mName.setDefaultZIndex(40);
@@ -231,10 +234,10 @@ void DetailedGameListView::onThemeChanged(const std::shared_ptr<ThemeData>& them
 
 	initMDLabels();
 	std::vector<TextComponent*> labels = getMDLabels();
-	assert(labels.size() == 8);
-	const char* lblElements[8] = {
+	assert(labels.size() == 9);
+	const char* lblElements[9] = {
 		"md_lbl_rating", "md_lbl_releasedate", "md_lbl_developer", "md_lbl_publisher", 
-		"md_lbl_genre", "md_lbl_players", "md_lbl_lastplayed", "md_lbl_playcount"
+		"md_lbl_genre", "md_lbl_players", "md_lbl_lastplayed", "md_lbl_playcount", "md_lbl_gametime"
 	};
 
 	for(unsigned int i = 0; i < labels.size(); i++)
@@ -245,10 +248,10 @@ void DetailedGameListView::onThemeChanged(const std::shared_ptr<ThemeData>& them
 
 	initMDValues();
 	std::vector<GuiComponent*> values = getMDValues();
-	assert(values.size() == 8);
-	const char* valElements[8] = {
+	assert(values.size() == 9);
+	const char* valElements[9] = {
 		"md_rating", "md_releasedate", "md_developer", "md_publisher", 
-		"md_genre", "md_players", "md_lastplayed", "md_playcount"
+		"md_genre", "md_players", "md_lastplayed", "md_playcount", "md_gametime"
 	};
 
 	for(unsigned int i = 0; i < values.size(); i++)
@@ -309,6 +312,7 @@ void DetailedGameListView::initMDValues()
 	mPlayers.setFont(defaultFont);
 	mLastPlayed.setFont(defaultFont);
 	mPlayCount.setFont(defaultFont);
+	mGameTime.setFont(defaultFont);
 
 	float bottom = 0.0f;
 
@@ -387,6 +391,7 @@ void DetailedGameListView::updateInfoPanel()
 		{
 			mLastPlayed.setValue(file->getMetadata("lastplayed"));
 			mPlayCount.setValue(file->getMetadata("playcount"));
+			mGameTime.setValue(file->getMetadata("gametime"));
 		}
 		
 		fadingOut = false;
@@ -470,6 +475,7 @@ std::vector<TextComponent*> DetailedGameListView::getMDLabels()
 	ret.push_back(&mLblPlayers);
 	ret.push_back(&mLblLastPlayed);
 	ret.push_back(&mLblPlayCount);
+	ret.push_back(&mLblGameTime);
 	return ret;
 }
 
@@ -484,6 +490,7 @@ std::vector<GuiComponent*> DetailedGameListView::getMDValues()
 	ret.push_back(&mPlayers);
 	ret.push_back(&mLastPlayed);
 	ret.push_back(&mPlayCount);
+	ret.push_back(&mGameTime);
 	return ret;
 }
 

--- a/es-app/src/views/gamelist/DetailedGameListView.h
+++ b/es-app/src/views/gamelist/DetailedGameListView.h
@@ -44,7 +44,7 @@ private:
 	ImageComponent* mMarquee;
 	VideoComponent* mVideo;
 
-	TextComponent mLblRating, mLblReleaseDate, mLblDeveloper, mLblPublisher, mLblGenre, mLblPlayers, mLblLastPlayed, mLblPlayCount;
+	TextComponent mLblRating, mLblReleaseDate, mLblDeveloper, mLblPublisher, mLblGenre, mLblPlayers, mLblLastPlayed, mLblPlayCount, mLblGameTime;
 
 	RatingComponent mRating;
 	DateTimeComponent mReleaseDate;
@@ -55,6 +55,7 @@ private:
 	DateTimeComponent mLastPlayed;
 	TextComponent mPlayCount;
 	TextComponent mName;
+	TextComponent mGameTime;
 
 	std::vector<TextComponent*> getMDLabels();
 	std::vector<GuiComponent*> getMDValues();

--- a/es-app/src/views/gamelist/GridGameListView.cpp
+++ b/es-app/src/views/gamelist/GridGameListView.cpp
@@ -22,11 +22,11 @@ GridGameListView::GridGameListView(Window* window, FolderData* root, const std::
 	mDescContainer(window), mDescription(window),
 	mImage(nullptr), mVideo(nullptr), mMarquee(nullptr), mThumbnail(nullptr),
 	mLblRating(window), mLblReleaseDate(window), mLblDeveloper(window), mLblPublisher(window),
-	mLblGenre(window), mLblPlayers(window), mLblLastPlayed(window), mLblPlayCount(window),
+	mLblGenre(window), mLblPlayers(window), mLblLastPlayed(window), mLblPlayCount(window), mLblGameTime(window),
 
 	mRating(window), mReleaseDate(window), mDeveloper(window), mPublisher(window),
 	mGenre(window), mPlayers(window), mLastPlayed(window), mPlayCount(window),
-	mName(window)
+	mName(window), mGameTime(window)
 {
 	setTag("grid");
 
@@ -64,6 +64,9 @@ GridGameListView::GridGameListView(Window* window, FolderData* root, const std::
 	mLblPlayCount.setText(_("Times played") + ": ");
 	addChild(&mLblPlayCount);
 	addChild(&mPlayCount);
+	mLblGameTime.setText(_("Game time") + ": ");
+	addChild(&mLblGameTime);
+	addChild(&mGameTime);
 
 	mName.setPosition(mSize.x(), mSize.y());
 	mName.setDefaultZIndex(40);
@@ -345,10 +348,10 @@ void GridGameListView::onThemeChanged(const std::shared_ptr<ThemeData>& theme)
 
 	initMDLabels();
 	std::vector<TextComponent*> labels = getMDLabels();
-	assert(labels.size() == 8);
-	const char* lblElements[8] = {
+	assert(labels.size() == 9);
+	const char* lblElements[9] = {
 			"md_lbl_rating", "md_lbl_releasedate", "md_lbl_developer", "md_lbl_publisher",
-			"md_lbl_genre", "md_lbl_players", "md_lbl_lastplayed", "md_lbl_playcount"
+			"md_lbl_genre", "md_lbl_players", "md_lbl_lastplayed", "md_lbl_playcount", "md_lbl_gametime"
 	};
 
 	for(unsigned int i = 0; i < labels.size(); i++)
@@ -359,10 +362,10 @@ void GridGameListView::onThemeChanged(const std::shared_ptr<ThemeData>& theme)
 
 	initMDValues();
 	std::vector<GuiComponent*> values = getMDValues();
-	assert(values.size() == 8);
-	const char* valElements[8] = {
+	assert(values.size() == 9);
+	const char* valElements[9] = {
 			"md_rating", "md_releasedate", "md_developer", "md_publisher",
-			"md_genre", "md_players", "md_lastplayed", "md_playcount"
+			"md_genre", "md_players", "md_lastplayed", "md_playcount", "md_gametime"
 	};
 
 	for(unsigned int i = 0; i < values.size(); i++)
@@ -479,6 +482,7 @@ void GridGameListView::initMDValues()
 	mPlayers.setFont(defaultFont);
 	mLastPlayed.setFont(defaultFont);
 	mPlayCount.setFont(defaultFont);
+	mGameTime.setFont(defaultFont);
 
 	float bottom = 0.0f;
 
@@ -563,6 +567,7 @@ void GridGameListView::updateInfoPanel()
 		{
 			mLastPlayed.setValue(file->getMetadata().get("lastplayed"));
 			mPlayCount.setValue(file->getMetadata().get("playcount"));
+			mGameTime.setValue(file->getMetadata().get("gametime"));
 		}
 
 		fadingOut = false;
@@ -674,6 +679,7 @@ std::vector<TextComponent*> GridGameListView::getMDLabels()
 	ret.push_back(&mLblPlayers);
 	ret.push_back(&mLblLastPlayed);
 	ret.push_back(&mLblPlayCount);
+	ret.push_back(&mLblGameTime);
 	return ret;
 }
 
@@ -688,6 +694,7 @@ std::vector<GuiComponent*> GridGameListView::getMDValues()
 	ret.push_back(&mPlayers);
 	ret.push_back(&mLastPlayed);
 	ret.push_back(&mPlayCount);
+	ret.push_back(&mGameTime);
 	return ret;
 }
 

--- a/es-app/src/views/gamelist/GridGameListView.h
+++ b/es-app/src/views/gamelist/GridGameListView.h
@@ -63,7 +63,7 @@ private:
 	void initMDLabels();
 	void initMDValues();
 
-	TextComponent mLblRating, mLblReleaseDate, mLblDeveloper, mLblPublisher, mLblGenre, mLblPlayers, mLblLastPlayed, mLblPlayCount;
+	TextComponent mLblRating, mLblReleaseDate, mLblDeveloper, mLblPublisher, mLblGenre, mLblPlayers, mLblLastPlayed, mLblPlayCount, mLblGameTime;
 
 	RatingComponent mRating;
 	DateTimeComponent mReleaseDate;
@@ -74,6 +74,7 @@ private:
 	DateTimeComponent mLastPlayed;
 	TextComponent mPlayCount;
 	TextComponent mName;
+	TextComponent mGameTime;
 
 	ImageComponent* mImage;
 	ImageComponent* mThumbnail;

--- a/es-app/src/views/gamelist/VideoGameListView.cpp
+++ b/es-app/src/views/gamelist/VideoGameListView.cpp
@@ -21,11 +21,11 @@ VideoGameListView::VideoGameListView(Window* window, FolderData* root) :
 	mThumbnail(nullptr),
 
 	mLblRating(window), mLblReleaseDate(window), mLblDeveloper(window), mLblPublisher(window),
-	mLblGenre(window), mLblPlayers(window), mLblLastPlayed(window), mLblPlayCount(window),
+	mLblGenre(window), mLblPlayers(window), mLblLastPlayed(window), mLblPlayCount(window), mLblGameTime(window),
 
 	mRating(window), mReleaseDate(window), mDeveloper(window), mPublisher(window),
 	mGenre(window), mPlayers(window), mLastPlayed(window), mPlayCount(window),
-	mName(window)
+	mName(window), mGameTime(window)
 {
 	const float padding = 0.01f;
 
@@ -96,6 +96,9 @@ VideoGameListView::VideoGameListView(Window* window, FolderData* root) :
 	mLblPlayCount.setText("Times played: ");
 	addChild(&mLblPlayCount);
 	addChild(&mPlayCount);
+	mLblGameTime.setText("Game time: ");
+	addChild(&mLblGameTime);
+	addChild(&mGameTime);
 
 	mName.setPosition(mSize.x(), mSize.y());
 	mName.setDefaultZIndex(40);
@@ -168,10 +171,10 @@ void VideoGameListView::onThemeChanged(const std::shared_ptr<ThemeData>& theme)
 
 	initMDLabels();
 	std::vector<TextComponent*> labels = getMDLabels();
-	assert(labels.size() == 8);
-	const char* lblElements[8] = {
+	assert(labels.size() == 9);
+	const char* lblElements[9] = {
 		"md_lbl_rating", "md_lbl_releasedate", "md_lbl_developer", "md_lbl_publisher",
-		"md_lbl_genre", "md_lbl_players", "md_lbl_lastplayed", "md_lbl_playcount"
+		"md_lbl_genre", "md_lbl_players", "md_lbl_lastplayed", "md_lbl_playcount", "md_lbl_gametime"
 	};
 
 	for(unsigned int i = 0; i < labels.size(); i++)
@@ -182,10 +185,10 @@ void VideoGameListView::onThemeChanged(const std::shared_ptr<ThemeData>& theme)
 
 	initMDValues();
 	std::vector<GuiComponent*> values = getMDValues();
-	assert(values.size() == 8);
-	const char* valElements[8] = {
+	assert(values.size() == 9);
+	const char* valElements[9] = {
 		"md_rating", "md_releasedate", "md_developer", "md_publisher",
-		"md_genre", "md_players", "md_lastplayed", "md_playcount"
+		"md_genre", "md_players", "md_lastplayed", "md_playcount", "md_gametime"
 	};
 
 	for(unsigned int i = 0; i < values.size(); i++)
@@ -245,6 +248,7 @@ void VideoGameListView::initMDValues()
 	mPlayers.setFont(defaultFont);
 	mLastPlayed.setFont(defaultFont);
 	mPlayCount.setFont(defaultFont);
+	mGameTime.setFont(defaultFont);
 
 	float bottom = 0.0f;
 
@@ -325,6 +329,7 @@ void VideoGameListView::updateInfoPanel()
 		{
 			mLastPlayed.setValue(file->getMetadata().get("lastplayed"));
 			mPlayCount.setValue(file->getMetadata().get("playcount"));
+			mGameTime.setValue(file->getMetadata().get("gametime"));
 		}
 
 		fadingOut = false;
@@ -428,6 +433,7 @@ std::vector<TextComponent*> VideoGameListView::getMDLabels()
 	ret.push_back(&mLblPlayers);
 	ret.push_back(&mLblLastPlayed);
 	ret.push_back(&mLblPlayCount);
+	ret.push_back(&mLblGameTime);
 	return ret;
 }
 
@@ -442,6 +448,7 @@ std::vector<GuiComponent*> VideoGameListView::getMDValues()
 	ret.push_back(&mPlayers);
 	ret.push_back(&mLastPlayed);
 	ret.push_back(&mPlayCount);
+	ret.push_back(&mGameTime);
 	return ret;
 }
 

--- a/es-app/src/views/gamelist/VideoGameListView.h
+++ b/es-app/src/views/gamelist/VideoGameListView.h
@@ -44,7 +44,7 @@ private:
 	ImageComponent mImage;
 	ImageComponent* mThumbnail;
 
-	TextComponent mLblRating, mLblReleaseDate, mLblDeveloper, mLblPublisher, mLblGenre, mLblPlayers, mLblLastPlayed, mLblPlayCount;
+	TextComponent mLblRating, mLblReleaseDate, mLblDeveloper, mLblPublisher, mLblGenre, mLblPlayers, mLblLastPlayed, mLblPlayCount, mLblGameTime;
 
 	RatingComponent mRating;
 	DateTimeComponent mReleaseDate;
@@ -55,6 +55,7 @@ private:
 	DateTimeComponent mLastPlayed;
 	TextComponent mPlayCount;
 	TextComponent mName;
+	TextComponent mGameTime;
 
 	std::vector<TextComponent*> getMDLabels();
 	std::vector<GuiComponent*> getMDValues();


### PR DESCRIPTION
Added a new `<gametime>` XML attribute in `gamelist.xml` that keeps track of how long you've played a game. It displays the total number of seconds the game has been launched from ES. This new attribute needs to be displayed by the themes (I'd recommend to add it to Batocera default theme).
 
To avoid false positives, it's logged only if the calculated game time for a session is >5 seconds.
Structure of the new attribute in `gamelist.xml`:
```
<gameList>
        <game>
             ....
             <gametime>1245</gametime>
</game>
</gameList>
```