### PR TITLE
Allow gamelist subsets storage/customisations per system 

### DIFF
--- a/es-app/src/guis/GuiMenu.h
+++ b/es-app/src/guis/GuiMenu.h
@@ -47,6 +47,8 @@ public:
 	static void popSystemConfigurationGui(Window* mWindow, SystemData *systemData, std::string previouslySelectedEmulator);
 	static void popGameConfigurationGui(Window* mWindow, std::string title, std::string romFilename, SystemData *systemData, std::string previouslySelectedEmulator);
 
+	static void openThemeConfiguration(Window* mWindow, GuiComponent* s, std::shared_ptr<OptionListComponent<std::string>> theme_set, const std::string systemTheme = "");
+
 private:
 	void addEntry(std::string name, bool add_arrow, const std::function<void()>& func, const std::string iconName = "");
 	void addVersionInfo();
@@ -72,7 +74,6 @@ private:
 	void openSystemInformations_batocera();
 	void openDeveloperSettings();
 	void openNetplaySettings();
-	void openThemeConfiguration(GuiSettings* s, std::shared_ptr<OptionListComponent<std::string>> theme_set);
 
 	void createInputTextRow(GuiSettings * gui, std::string title, const char* settingsID, bool password, bool storeInSettings=false);
 	MenuComponent mMenu;

--- a/es-core/src/ThemeData.h
+++ b/es-core/src/ThemeData.h
@@ -89,17 +89,22 @@ struct ThemeSet
 
 struct Subset
 {
-	Subset(const std::string set, const std::string nm, const std::string dn)
+	Subset(const std::string set, const std::string nm, const std::string dn, const std::string ssdn)
 	{
 		subset = set;
 		name = nm;
 		displayName = dn;
+		subSetDisplayName = ssdn;
 	}
 
 	std::string subset;
 	std::string name;	
 
 	std::string displayName;
+
+	std::vector<std::string> appliesTo;
+
+	std::string subSetDisplayName;
 };
 
 struct MenuElement 
@@ -214,6 +219,13 @@ private:
 		std::vector<std::string> orderedKeys;
 		std::string baseType;
 
+		std::vector<std::string> baseTypes;
+
+		bool isOfType(const std::string type) 
+		{
+			return baseType == type || std::find(baseTypes.cbegin(), baseTypes.cend(), type) != baseTypes.cend();
+		};
+
 		std::string displayName;
 
 		bool isCustomView;
@@ -256,7 +268,9 @@ public:
 	static const std::shared_ptr<ThemeData::ThemeMenu>& getMenuTheme();
 
 	std::vector<Subset>		    getSubSets() { return mSubsets; }
-	std::vector<std::string>	getSubSetNames();
+	std::vector<std::string>	getSubSetNames(const std::string ofView = "");
+
+	std::string					getDefaultSubSetValue(const std::string subsetname);
 
 	static std::vector<Subset> getSubSet(const std::vector<Subset>& subsets, const std::string& subset);
 
@@ -275,6 +289,8 @@ public:
 
 		return "";
 	}	
+
+	std::string getViewDisplayName(const std::string& view);
 
 private:
 	static std::map< std::string, std::map<std::string, ElementPropertyType> > sElementMap;
@@ -301,6 +317,7 @@ private:
 	bool isFirstSubset(const pugi::xml_node& node);
 	bool parseLanguage(const pugi::xml_node& node);
 	bool parseFilterAttributes(const pugi::xml_node& node);
+	void parseSubsetElement(const pugi::xml_node& root);
 
 	void parseCustomViewBaseClass(const pugi::xml_node& root, ThemeView& view, std::string baseClass);
 


### PR DESCRIPTION
- Created "subset" element to group includes & avoid repetitions of subset attributes in includes.
- Gamelist customisation per system is done using attribute appliesTo="viewname". 

```
<subset name="option" appliesTo="grid">
  <include name="yes">./samplefile0.xml</include>
  <include name="no">./samplefile1.xml</include>
</subset>
```