### PR TITLE
Fixes

### DIFF
--- a/es-app/src/guis/GuiGamelistOptions.cpp
+++ b/es-app/src/guis/GuiGamelistOptions.cpp
@@ -413,7 +413,16 @@ GuiGamelistOptions::~GuiGamelistOptions()
 	else
 		gridSizeOverride = mSystem->getGridSizeOverride();
 
-	bool viewModeChanged = mSystem->setSystemViewMode(mViewMode->getSelected(), gridSizeOverride);
+	std::string viewMode = mViewMode->getSelected();
+
+	if (mSystem->getSystemViewMode() != (viewMode == "automatic" ? "" : viewMode))
+	{
+		for (auto sm : Settings::getInstance()->getStringMap())
+			if (Utils::String::startsWith(sm.first, "subset." + mSystem->getThemeFolder() + "."))
+				Settings::getInstance()->setString(sm.first, "");
+	}
+
+	bool viewModeChanged = mSystem->setSystemViewMode(viewMode, gridSizeOverride);
 
 	Settings::getInstance()->saveFile();
 
@@ -428,6 +437,8 @@ GuiGamelistOptions::~GuiGamelistOptions()
 		// only reload full view if we came from a placeholder
 		// as we need to re-display the remaining elements for whatever new
 		// game is selected
+		mSystem->loadTheme();
+		mSystem->resetFilters();
 		ViewController::get()->reloadGameListView(mSystem);
 	}
 }

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -1587,95 +1587,6 @@ void GuiMenu::openThemeConfiguration(Window* mWindow, GuiComponent* s, std::shar
 		showGridFeatures = (viewName == "grid" || baseType == "grid");
 	}
 
-	std::map<std::string, ThemeConfigOption> options;
-
-	for (std::string subset : theme->getSubSetNames(viewName))
-	{
-		std::string settingName = "subset." + subset;
-		std::string perSystemSettingName = systemTheme.empty() ? "" : "subset." + systemTheme + "." + subset;
-
-		if (subset == "colorset") settingName = "ThemeColorSet";
-		else if (subset == "iconset") settingName = "ThemeIconSet";
-		else if (subset == "menu") settingName = "ThemeMenu";
-		else if (subset == "systemview") settingName = "ThemeSystemView";
-		else if (subset == "gamelistview") settingName = "ThemeGamelistView";
-		else if (subset == "region") settingName = "ThemeRegionName";
-
-		auto themeColorSets = ThemeData::getSubSet(themeSubSets, subset);
-
-		if (themeColorSets.size() > 0)
-		{
-			auto selectedColorSet = themeColorSets.end();
-			auto selectedName = !perSystemSettingName.empty() ? Settings::getInstance()->getString(perSystemSettingName) : Settings::getInstance()->getString(settingName);
-
-			if (!perSystemSettingName.empty() && selectedName.empty())
-				selectedName = Settings::getInstance()->getString(settingName);
-
-			for (auto it = themeColorSets.begin(); it != themeColorSets.end() && selectedColorSet == themeColorSets.end(); it++)
-				if (it->name == selectedName)
-					selectedColorSet = it;
-
-			std::shared_ptr<OptionListComponent<std::string>> item = std::make_shared<OptionListComponent<std::string> >(mWindow, _(("THEME " + Utils::String::toUpper(subset)).c_str()), false);
-			item->setTag(!perSystemSettingName.empty() ? perSystemSettingName : settingName);
-
-			for (auto it = themeColorSets.begin(); it != themeColorSets.end(); it++)
-			{
-				std::string displayName = it->displayName;
-
-				if (!systemTheme.empty())
-				{
-					std::string defaultValue = Settings::getInstance()->getString(settingName);
-					if (defaultValue.empty())
-						defaultValue = system->getTheme()->getDefaultSubSetValue(subset);
-
-					if (it->name == defaultValue)
-						displayName = displayName + " (" + _("DEFAULT") + ")";
-				}
-
-				item->add(displayName, it->name, it == selectedColorSet);
-			}
-
-			if (selectedColorSet == themeColorSets.end())
-				item->selectFirstItem();
-
-			if (!themeColorSets.empty())
-			{
-				std::string displayName = themeColorSets.cbegin()->subSetDisplayName;
-				if (!displayName.empty())
-				{
-					std::string prefix;
-
-					if (systemTheme.empty())
-					{
-						auto itSubsetName = themeColorSets.cbegin()->appliesTo.cbegin();
-						if (itSubsetName != themeColorSets.cbegin()->appliesTo.cend())
-						{
-							prefix = theme->getViewDisplayName(*itSubsetName);
-							if (!prefix.empty())
-								prefix = prefix + " / ";
-						}
-					}
-
-					themeconfig->addWithLabel(prefix + displayName, item);
-				}
-				else
-					themeconfig->addWithLabel(_(("THEME " + Utils::String::toUpper(subset)).c_str()), item);
-			}
-
-			ThemeConfigOption opt;
-			opt.component = item;
-			opt.subset = subset;
-			opt.defaultSettingName = settingName;
-			options[!perSystemSettingName.empty() ? perSystemSettingName : settingName] = opt;
-		}
-		else
-		{
-			ThemeConfigOption opt;
-			opt.component = nullptr;
-			options[!perSystemSettingName.empty() ? perSystemSettingName : settingName] = opt;
-		}
-	}
-
 	// gamelist_style
 	std::shared_ptr<OptionListComponent<std::string>> gamelist_style = nullptr;
 
@@ -1744,6 +1655,102 @@ void GuiMenu::openThemeConfiguration(Window* mWindow, GuiComponent* s, std::shar
 		themeconfig->addWithLabel(_("DEFAULT GRID SIZE"), mGridSize);
 	}
 
+	std::map<std::string, ThemeConfigOption> options;
+
+	for (std::string subset : theme->getSubSetNames(viewName))
+	{
+		std::string settingName = "subset." + subset;
+		std::string perSystemSettingName = systemTheme.empty() ? "" : "subset." + systemTheme + "." + subset;
+
+		if (subset == "colorset") settingName = "ThemeColorSet";
+		else if (subset == "iconset") settingName = "ThemeIconSet";
+		else if (subset == "menu") settingName = "ThemeMenu";
+		else if (subset == "systemview") settingName = "ThemeSystemView";
+		else if (subset == "gamelistview") settingName = "ThemeGamelistView";
+		else if (subset == "region") settingName = "ThemeRegionName";
+
+		auto themeColorSets = ThemeData::getSubSet(themeSubSets, subset);
+
+		if (themeColorSets.size() > 0)
+		{
+			auto selectedColorSet = themeColorSets.end();
+			auto selectedName = !perSystemSettingName.empty() ? Settings::getInstance()->getString(perSystemSettingName) : Settings::getInstance()->getString(settingName);
+
+			if (!perSystemSettingName.empty() && selectedName.empty())
+				selectedName = Settings::getInstance()->getString(settingName);
+
+			for (auto it = themeColorSets.begin(); it != themeColorSets.end() && selectedColorSet == themeColorSets.end(); it++)
+				if (it->name == selectedName)
+					selectedColorSet = it;
+
+			std::shared_ptr<OptionListComponent<std::string>> item = std::make_shared<OptionListComponent<std::string> >(mWindow, _(("THEME " + Utils::String::toUpper(subset)).c_str()), false);
+			item->setTag(!perSystemSettingName.empty() ? perSystemSettingName : settingName);
+
+			for (auto it = themeColorSets.begin(); it != themeColorSets.end(); it++)
+			{
+				std::string displayName = it->displayName;
+
+				if (!systemTheme.empty())
+				{
+					std::string defaultValue = Settings::getInstance()->getString(settingName);
+					if (defaultValue.empty())
+						defaultValue = system->getTheme()->getDefaultSubSetValue(subset);
+
+					if (it->name == defaultValue)
+						displayName = displayName + " (" + _("DEFAULT") + ")";
+				}
+
+				item->add(displayName, it->name, it == selectedColorSet);
+			}
+
+			if (selectedColorSet == themeColorSets.end())
+				item->selectFirstItem();
+
+			if (!themeColorSets.empty())
+			{
+				std::string displayName = themeColorSets.cbegin()->subSetDisplayName;
+				if (!displayName.empty())
+				{
+					std::string prefix;
+					if (systemTheme.empty())
+					{
+						for (auto subsetName : themeColorSets.cbegin()->appliesTo)
+						{
+							std::string pfx = theme->getViewDisplayName(subsetName);
+							if (!pfx.empty())
+							{
+								if (prefix.empty())
+									prefix = pfx;
+								else
+									prefix = prefix + ", " + pfx;
+							}
+						}
+
+						if (!prefix.empty())
+							prefix = " (" + prefix + ")";
+
+					}
+
+					themeconfig->addWithLabel(displayName + prefix, item);
+				}
+				else
+					themeconfig->addWithLabel(_(("THEME " + Utils::String::toUpper(subset)).c_str()), item);
+			}
+
+			ThemeConfigOption opt;
+			opt.component = item;
+			opt.subset = subset;
+			opt.defaultSettingName = settingName;
+			options[!perSystemSettingName.empty() ? perSystemSettingName : settingName] = opt;
+		}
+		else
+		{
+			ThemeConfigOption opt;
+			opt.component = nullptr;
+			options[!perSystemSettingName.empty() ? perSystemSettingName : settingName] = opt;
+		}
+	}
+	
 	if (systemTheme.empty())
 	{
 		themeconfig->addEntry(_("RESET GAMELIST CUSTOMISATIONS"), false, [s, themeconfig, window]

--- a/es-core/src/ThemeData.cpp
+++ b/es-core/src/ThemeData.cpp
@@ -438,22 +438,12 @@ bool ThemeData::isFirstSubset(const pugi::xml_node& node)
 	const std::string subsetToFind = resolvePlaceholders(node.attribute("subset").as_string());
 	const std::string name = node.attribute("name").as_string();
 
-	pugi::xml_node root = node.parent();
-
-	for (pugi::xml_node node = root.child("include"); node; node = node.next_sibling("include"))
-	{
-		const std::string subsetAttr = resolvePlaceholders(node.attribute("subset").as_string());
-		if (subsetAttr.empty() || subsetAttr != subsetToFind)
-			continue;
-
-		const std::string nameAttr = resolvePlaceholders(node.attribute("name").as_string());
-		return (nameAttr == name);
-	}
+	for (const auto& it : mSubsets)
+		if (it.subset == subsetToFind)
+			return it.name == name;
 
 	return false;
 }
-
-
 
 bool ThemeData::parseSubset(const pugi::xml_node& node)
 {

--- a/es-core/src/ThemeData.cpp
+++ b/es-core/src/ThemeData.cpp
@@ -11,6 +11,7 @@
 #include "Settings.h"
 #include "SystemConf.h"
 #include <algorithm>
+#include "LocaleES.h"
 
 std::vector<std::string> ThemeData::sSupportedViews { { "system" }, { "basic" }, { "detailed" }, { "grid" }, { "video" }, { "menu" }, { "screen" } };
 std::vector<std::string> ThemeData::sSupportedFeatures { { "video" }, { "carousel" }, { "z-index" }, { "visible" } };
@@ -861,15 +862,36 @@ void ThemeData::parseCustomView(const pugi::xml_node& node, const pugi::xml_node
 		return;
 
 	std::string viewKey = node.attribute("name").as_string();
+	std::string inherits = node.attribute("inherits").as_string();
+
+	if (viewKey.find(",") != std::string::npos && inherits.empty())
+	{
+		for (auto name : Utils::String::split(viewKey, ','))
+		{
+			std::string trim = Utils::String::trim(name);
+			if (mViews.find(trim) != mViews.cend())
+			{
+				ThemeView& view = mViews.insert(std::pair<std::string, ThemeView>(trim, ThemeView())).first->second;
+
+				if (node.attribute("displayName"))
+					view.displayName = resolvePlaceholders(node.attribute("displayName").as_string());
+
+				parseView(node, view);
+			}
+		}
+
+		return;
+	}
 
 	ThemeView& view = mViews.insert(std::pair<std::string, ThemeView>(viewKey, ThemeView())).first->second;
-	view.displayName = node.attribute("displayName") ? resolvePlaceholders(node.attribute("displayName").as_string()) : viewKey;
-	if (view.displayName.empty())
+
+	if (node.attribute("displayName"))
+		view.displayName = resolvePlaceholders(node.attribute("displayName").as_string());
+	else if (view.displayName.empty())
 		view.displayName = viewKey;
 
 	view.isCustomView = true;
 
-	std::string inherits = node.attribute("inherits").as_string();
 	if (!inherits.empty())
 	{
 		view.baseType = inherits;
@@ -1162,9 +1184,14 @@ std::string ThemeData::getViewDisplayName(const std::string& view)
 {
 	auto viewIt = mViews.find(view);
 	if (viewIt != mViews.cend())
-		return viewIt->second.displayName;
+	{
+		if (viewIt->second.displayName.empty())
+			return _(view.c_str());
 
-	return "";
+		return viewIt->second.displayName;
+	}
+	
+	return view;
 }
 
 bool ThemeData::isCustomView(const std::string& view)
@@ -1496,7 +1523,7 @@ std::vector<std::string> ThemeData::getSubSetNames(const std::string ofView)
 			{
 				if (std::find(it.appliesTo.cbegin(), it.appliesTo.cend(), ofView) != it.appliesTo.cend())
 					ret.push_back(it.subset);
-				else
+			/*	else
 				{
 					auto viewIt = mViews.find(ofView);
 					if (viewIt != mViews.cend())
@@ -1510,7 +1537,7 @@ std::vector<std::string> ThemeData::getSubSetNames(const std::string ofView)
 							}
 						}
 					}
-				}
+				}*/
 			}
 		}
 	}

--- a/es-core/src/renderers/Renderer_GL21.cpp
+++ b/es-core/src/renderers/Renderer_GL21.cpp
@@ -110,8 +110,8 @@ namespace Renderer
 		glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, _repeat ? GL_REPEAT : GL_CLAMP_TO_EDGE);
 		glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, _repeat ? GL_REPEAT : GL_CLAMP_TO_EDGE);
 
-		glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, _linear ? GL_LINEAR : GL_NEAREST);
-		glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+		glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+		glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, _linear ? GL_LINEAR : GL_NEAREST);
 
 		glPixelStorei(GL_PACK_ALIGNMENT, 1);
 		glPixelStorei(GL_UNPACK_ALIGNMENT, 1);

--- a/es-core/src/renderers/Renderer_GLES10.cpp
+++ b/es-core/src/renderers/Renderer_GLES10.cpp
@@ -107,8 +107,8 @@ namespace Renderer
 		glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, _repeat ? GL_REPEAT : GL_CLAMP_TO_EDGE);
 		glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, _repeat ? GL_REPEAT : GL_CLAMP_TO_EDGE);
 
-		glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, _linear ? GL_LINEAR : GL_NEAREST);
-		glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+		glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+		glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, _linear ? GL_LINEAR : GL_NEAREST);
 
 		glPixelStorei(GL_PACK_ALIGNMENT, 1);
 		glPixelStorei(GL_UNPACK_ALIGNMENT, 1);

--- a/es-core/src/resources/TextureData.cpp
+++ b/es-core/src/resources/TextureData.cpp
@@ -254,7 +254,7 @@ bool TextureData::uploadAndBind()
 			return false;
 
 		// Upload texture
-		mTextureID = Renderer::createTexture(Renderer::Texture::RGBA, true, mTile, mWidth, mHeight, mDataRGBA);
+		mTextureID = Renderer::createTexture(Renderer::Texture::RGBA, mHeight >= 480, mTile, mWidth, mHeight, mDataRGBA);
 		if (mTextureID)
 		{
 			if (mDataRGBA != nullptr && !mIsExternalDataRGBA)

--- a/es-core/src/utils/FileSystemUtil.cpp
+++ b/es-core/src/utils/FileSystemUtil.cpp
@@ -690,11 +690,11 @@ namespace Utils
 				return _path;
 
 			// replace '.' with relativeTo
-			if((_path[0] == '.') && (_path[1] == '/'))
+			if((_path[0] == '.') && (_path[1] == '/' || _path[1] == '\\'))
 				return getGenericPath(_relativeTo + &(_path[1]));
 
 			// replace '~' with homePath
-			if(_allowHome && (_path[0] == '~') && (_path[1] == '/'))
+			if(_allowHome && (_path[0] == '~') && (_path[1] == '/' || _path[1] == '\\'))
 				return getCanonicalPath(getHomePath() + &(_path[1]));
 
 			// nothing to resolve


### PR DESCRIPTION
- use GL_LINEAR for upscaling filter when images are designed for fullscreen ( height >= 480p )
This make better upscaling look for background images stored in 480p / 720p for 1080p+ resolution.
Thus : "Pixel" themes must have background image height < 480 or they'll be smoothed. ( themes like  es_theme_pixel works fine ).
- Bad gamelist file resolution when relative path starts with .\ instead of ./ (With some gamelist created/edited on Windows)
- Theming : IsFirstSubset, better mecanism for finding first subset -> This allow splitting a subset item in multiple includes.
- Theming : Subset appliesTo & customViews : Fixes & Allow multiple view/customView customisation using commas in customView name.


