### PR TITLE
Fix : Grouped systems subfolder management.

### DIFF
--- a/es-app/src/FileData.cpp
+++ b/es-app/src/FileData.cpp
@@ -538,23 +538,15 @@ const std::vector<FileData*> FolderData::getChildrenListToDisplay()
 
 FileData* FolderData::findUniqueGameForFolder()
 {
-	std::vector<FileData*> children = getChildren();
-
-	if (children.size() == 1 && children.at(0)->getType() == GAME)
-		return children.at(0);
-
-	for (std::vector<FileData*>::const_iterator it = children.cbegin(); it != children.cend(); ++it)
+	auto games = this->getFilesRecursive(GAME);
+	if (games.size() == 1)
 	{
+		auto it = games.cbegin();
 		if ((*it)->getType() == GAME)
-			return NULL;
-
-		FolderData* folder = (FolderData*)(*it);
-		FileData* ret = folder->findUniqueGameForFolder();
-		if (ret != NULL)
-			return ret;
+			return (*it);
 	}
 
-	return NULL;
+	return nullptr;
 }
 
 std::vector<FileData*> FolderData::getFlatGameList(bool displayedOnly, SystemData* system) const 

--- a/es-app/src/SystemData.cpp
+++ b/es-app/src/SystemData.cpp
@@ -243,7 +243,7 @@ void SystemData::createGroupedSystems()
 
 		for (auto childSystem : item.second)
 		{			
-			auto children = childSystem->getRootFolder()->getFilesRecursive(GAME | FOLDER);
+			auto children = childSystem->getRootFolder()->getChildren();
 			if (children.size() > 0)
 			{
 				auto folder = new FolderData(childSystem->getRootFolder()->getPath(), childSystem, false);

--- a/es-app/src/guis/GuiGamelistOptions.cpp
+++ b/es-app/src/guis/GuiGamelistOptions.cpp
@@ -437,8 +437,7 @@ GuiGamelistOptions::~GuiGamelistOptions()
 		// only reload full view if we came from a placeholder
 		// as we need to re-display the remaining elements for whatever new
 		// game is selected
-		mSystem->loadTheme();
-		mSystem->resetFilters();
+		mSystem->loadTheme();		
 		ViewController::get()->reloadGameListView(mSystem);
 	}
 }

--- a/es-app/src/views/gamelist/ISimpleGameListView.cpp
+++ b/es-app/src/views/gamelist/ISimpleGameListView.cpp
@@ -95,7 +95,11 @@ bool ISimpleGameListView::input(InputConfig* config, Input input)
 				auto top = mCursorStack.top();
 				mCursorStack.pop();
 
-				populateList(top->getParent()->getChildrenListToDisplay());
+				FolderData* folder = top->getParent();
+				if (folder == nullptr)
+					folder = getCursor()->getSystem()->getParentGroupSystem()->getRootFolder();
+
+				populateList(folder->getChildrenListToDisplay());
 				setCursor(top);
 				Sound::getFromTheme(getTheme(), getName(), "back")->play();
 			}


### PR DESCRIPTION
- Presence of game and also its folder when the game is in a subfolder.
- fix detection of single game in folder using option "show folders / having multiple games"
- fix crash when navigating to parent folder after "show folder" option change
- Fix gamelist filters not working anymore