### PR TITLE
ImageComponent : Add boolean 'image.linearSmooth' + SystemView : Support extra="static" items

### DIFF
--- a/es-app/src/FileFilterIndex.cpp
+++ b/es-app/src/FileFilterIndex.cpp
@@ -5,6 +5,7 @@
 #include "FileData.h"
 #include "Log.h"
 #include "Settings.h"
+#include "LocaleES.h"
 
 #define UNKNOWN_LABEL "UNKNOWN"
 #define INCLUDE_UNKNOWN false;
@@ -15,12 +16,12 @@ FileFilterIndex::FileFilterIndex()
 	clearAllFilters();
 	FilterDataDecl filterDecls[] = {
 		//type 				//allKeys 				//filteredBy 		//filteredKeys 				//primaryKey 	//hasSecondaryKey 	//secondaryKey 	//menuLabel
-		{ FAVORITES_FILTER, &favoritesIndexAllKeys, &filterByFavorites,	&favoritesIndexFilteredKeys,"favorite",		false,				"",				"FAVORITES"	},
-		{ GENRE_FILTER, 	&genreIndexAllKeys, 	&filterByGenre,		&genreIndexFilteredKeys, 	"genre",		true,				"genre",		"GENRE"	},
-		{ PLAYER_FILTER, 	&playersIndexAllKeys, 	&filterByPlayers,	&playersIndexFilteredKeys, 	"players",		false,				"",				"PLAYERS"	},
-		{ PUBDEV_FILTER, 	&pubDevIndexAllKeys, 	&filterByPubDev,	&pubDevIndexFilteredKeys, 	"developer",	true,				"publisher",	"PUBLISHER / DEVELOPER"	},
-		{ RATINGS_FILTER, 	&ratingsIndexAllKeys, 	&filterByRatings,	&ratingsIndexFilteredKeys, 	"rating",		false,				"",				"RATING"	},
-		{ KIDGAME_FILTER, 	&kidGameIndexAllKeys, 	&filterByKidGame,	&kidGameIndexFilteredKeys, 	"kidgame",		false,				"",				"KIDGAME" }
+		{ FAVORITES_FILTER, &favoritesIndexAllKeys, &filterByFavorites,	&favoritesIndexFilteredKeys,"favorite",		false,				"",				_("FAVORITES")	},
+		{ GENRE_FILTER, 	&genreIndexAllKeys, 	&filterByGenre,		&genreIndexFilteredKeys, 	"genre",		true,				"genre",		_("GENRE")	},
+		{ PLAYER_FILTER, 	&playersIndexAllKeys, 	&filterByPlayers,	&playersIndexFilteredKeys, 	"players",		false,				"",				_("PLAYERS")	},
+		{ PUBDEV_FILTER, 	&pubDevIndexAllKeys, 	&filterByPubDev,	&pubDevIndexFilteredKeys, 	"developer",	true,				"publisher",	_("PUBLISHER / DEVELOPER")	},
+		{ RATINGS_FILTER, 	&ratingsIndexAllKeys, 	&filterByRatings,	&ratingsIndexFilteredKeys, 	"rating",		false,				"",				_("RATING")	},
+		{ KIDGAME_FILTER, 	&kidGameIndexAllKeys, 	&filterByKidGame,	&kidGameIndexFilteredKeys, 	"kidgame",		false,				"",				_("KIDGAME") }
 		//{ HIDDEN_FILTER, 	&hiddenIndexAllKeys, 	&filterByHidden,	&hiddenIndexFilteredKeys, 	"hidden",		false,				"",				"HIDDEN" }
 	};
 

--- a/es-app/src/guis/GuiGamelistFilter.cpp
+++ b/es-app/src/guis/GuiGamelistFilter.cpp
@@ -6,7 +6,7 @@
 #include "guis/GuiTextEditPopup.h"
 #include "guis/GuiTextEditPopupKeyboard.h"
 
-GuiGamelistFilter::GuiGamelistFilter(Window* window, SystemData* system) : GuiComponent(window), mMenu(window, "FILTER GAMELIST BY"), mSystem(system)
+GuiGamelistFilter::GuiGamelistFilter(Window* window, SystemData* system) : GuiComponent(window), mMenu(window, _("FILTER GAMELIST BY")), mSystem(system)
 {
 	initializeMenu();
 }
@@ -110,9 +110,8 @@ void GuiGamelistFilter::addFiltersToMenu()
 		// add genres
 		optionList = std::make_shared< OptionListComponent<std::string> >(mWindow, menuLabel, true);
 		for(auto it: *allKeys)
-		{
-			optionList->add(it.first, it.first, mFilterIndex->isKeyBeingFilteredBy(it.first, type));
-		}
+			optionList->add(_(it.first.c_str()), it.first, mFilterIndex->isKeyBeingFilteredBy(it.first, type));
+
 		if (allKeys->size() > 0)
 			mMenu.addWithLabel(menuLabel, optionList);
 

--- a/es-app/src/guis/GuiGamelistOptions.cpp
+++ b/es-app/src/guis/GuiGamelistOptions.cpp
@@ -232,14 +232,11 @@ GuiGamelistOptions::GuiGamelistOptions(Window* window, SystemData* system, bool 
 
 	// Folder View Mode
 	auto foldersBehavior = std::make_shared< OptionListComponent<std::string> >(mWindow, _("SHOW FOLDERS"), false);
-	std::vector<std::string> folders;
-	folders.push_back("always");
-	folders.push_back("never");
-	folders.push_back("having multiple games");
 
-	for (auto it = folders.cbegin(); it != folders.cend(); it++)
-		foldersBehavior->add(_(it->c_str()), *it, Settings::getInstance()->getString("FolderViewMode") == *it);
-	
+	foldersBehavior->add(_("always"), "always", Settings::getInstance()->getString("FolderViewMode") == "always");
+	foldersBehavior->add(_("never"), "never", Settings::getInstance()->getString("FolderViewMode") == "never");
+	foldersBehavior->add(_("having multiple games"), "having multiple games", Settings::getInstance()->getString("FolderViewMode") == "having multiple games");
+
 	mMenu.addWithLabel(_("SHOW FOLDERS"), foldersBehavior);
 	addSaveFunc([this, foldersBehavior] 
 	{

--- a/es-core/src/GuiComponent.cpp
+++ b/es-core/src/GuiComponent.cpp
@@ -11,7 +11,8 @@
 
 GuiComponent::GuiComponent(Window* window) : mWindow(window), mParent(NULL), mOpacity(255),
 	mPosition(Vector3f::Zero()), mOrigin(Vector2f::Zero()), mRotationOrigin(0.5, 0.5),
-	mSize(Vector2f::Zero()), mTransform(Transform4x4f::Identity()), mIsProcessing(false), mVisible(true)
+	mSize(Vector2f::Zero()), mTransform(Transform4x4f::Identity()), mIsProcessing(false), mVisible(true),
+	mStaticExtra(false)
 {
 	for(unsigned char i = 0; i < MAX_ANIMATIONS; i++)
 		mAnimationMap[i] = NULL;

--- a/es-core/src/GuiComponent.h
+++ b/es-core/src/GuiComponent.h
@@ -160,6 +160,9 @@ public:
 
 	std::string getTag() const { return mTag; };
 	void setTag(const std::string& value) { mTag = value; };
+	
+	bool isStaticExtra() const { return mStaticExtra; }
+	void setIsStaticExtra(bool value) { mStaticExtra = value; }
 
 protected:
 	void renderChildren(const Transform4x4f& transform) const;
@@ -185,6 +188,8 @@ protected:
 
 	bool mIsProcessing;
 	bool mVisible;
+
+	bool mStaticExtra;
 
 public:
 	const static unsigned char MAX_ANIMATIONS = 4;

--- a/es-core/src/ThemeData.cpp
+++ b/es-core/src/ThemeData.cpp
@@ -39,6 +39,7 @@ std::map<std::string, std::map<std::string, ThemeData::ElementPropertyType>> The
 		{ "roundCorners", FLOAT },
 		{ "flipX", BOOLEAN },
 		{ "flipY", BOOLEAN },
+		{ "linearSmooth", BOOLEAN },
 		{ "zIndex", FLOAT } } },
 	{ "imagegrid", {
 		{ "pos", NORMALIZED_PAIR },

--- a/es-core/src/ThemeData.cpp
+++ b/es-core/src/ThemeData.cpp
@@ -1005,8 +1005,17 @@ void ThemeData::parseElement(const pugi::xml_node& root, const std::map<std::str
 	// error.setFiles(mPaths);
 
 	element.type = root.name();
-	element.extra = root.attribute("extra").as_bool(false);
-	
+
+	if (root.attribute("extra"))
+	{
+		std::string extra = Utils::String::toLower(root.attribute("extra").as_string());
+		
+		if (extra == "true")
+			element.extra = 1;
+		else if (extra == "static")
+			element.extra = 2;
+	}	
+
 	for(pugi::xml_node node = root.first_child(); node; node = node.next_sibling())
 	{
 		if (!parseFilterAttributes(node))
@@ -1272,6 +1281,7 @@ std::vector<GuiComponent*> ThemeData::makeExtras(const std::shared_ptr<ThemeData
 			if (comp == nullptr)
 				continue;
 
+			comp->setIsStaticExtra(elem.extra == 2);
 			comp->setTag((*it).c_str());
 			comp->setDefaultZIndex(10);
 			comp->applyTheme(theme, view, *it, ThemeFlags::ALL);

--- a/es-core/src/ThemeData.h
+++ b/es-core/src/ThemeData.h
@@ -172,7 +172,10 @@ public:
 	class ThemeElement
 	{
 	public:
-		bool extra;
+		ThemeElement() { extra = 0; }
+
+		int extra;
+
 		std::string type;
 
 		struct Property

--- a/es-core/src/Window.cpp
+++ b/es-core/src/Window.cpp
@@ -541,7 +541,7 @@ void Window::endRenderLoadingScreen()
 void Window::renderLoadingScreen(std::string text, float percent, unsigned char opacity)
 {
 	if (mSplash == NULL)
-		mSplash = TextureResource::get(":/splash_batocera.svg", false, true, false, false);
+		mSplash = TextureResource::get(":/splash_batocera.svg", false, true, true, false, false);
 
 	Transform4x4f trans = Transform4x4f::Identity();
 	Renderer::setMatrix(trans);

--- a/es-core/src/components/ImageComponent.cpp
+++ b/es-core/src/components/ImageComponent.cpp
@@ -26,6 +26,7 @@ ImageComponent::ImageComponent(Window* window, bool forceLoad, bool dynamic) : G
 	mFadeOpacity(0), mFading(false), mRotateByTargetSize(false), mTopLeftCrop(0.0f, 0.0f), mBottomRightCrop(1.0f, 1.0f),
 	mReflection(0.0f, 0.0f), mPadding(Vector4f(0, 0, 0, 0))
 {
+	mLinear = false;
 	mHorizontalAlignment = ALIGN_CENTER;
 	mVerticalAlignment = ALIGN_CENTER;
 	mReflectOnBorders = false;
@@ -165,11 +166,11 @@ void ImageComponent::setImage(std::string path, bool tile, MaxSizeInfo maxSize)
 		if(mDefaultPath.empty() || !ResourceManager::getInstance()->fileExists(mDefaultPath))
 			mTexture.reset();
 		else
-			mTexture = TextureResource::get(mDefaultPath, tile, mForceLoad, mDynamic, true, maxSize.empty() ? nullptr : &maxSize);
+			mTexture = TextureResource::get(mDefaultPath, tile, mLinear, mForceLoad, mDynamic, true, maxSize.empty() ? nullptr : &maxSize);
 	} 
 	else
 	{
-		std::shared_ptr<TextureResource> texture = TextureResource::get(mPath, tile, mForceLoad, mDynamic, true, maxSize.empty() ? nullptr : &maxSize);
+		std::shared_ptr<TextureResource> texture = TextureResource::get(mPath, tile, mLinear, mForceLoad, mDynamic, true, maxSize.empty() ? nullptr : &maxSize);
 
 		if (!mForceLoad && mDynamic && !mAllowFading && texture != nullptr && !texture->isLoaded())
 			mLoadingTexture = texture;
@@ -560,6 +561,9 @@ void ImageComponent::applyTheme(const std::shared_ptr<ThemeData>& theme, const s
 	{
 		return;
 	}
+
+	if (elem->has("linearSmooth"))
+		mLinear = elem->get<bool>("linearSmooth");
 
 	Vector2f scale = getParent() ? getParent()->getSize() : Vector2f((float)Renderer::getScreenWidth(), (float)Renderer::getScreenHeight());
 

--- a/es-core/src/components/ImageComponent.h
+++ b/es-core/src/components/ImageComponent.h
@@ -118,6 +118,9 @@ public:
 	std::string getImagePath() { return mPath; }
 	bool isTiled();
 
+	bool isLinear() { return mLinear; }
+	void setIsLinear(bool value) { mLinear = value; }
+
 private:
 	Vector2f mTargetSize;
 
@@ -166,6 +169,8 @@ private:
 	bool			mShowing;
 	std::shared_ptr<IPlaylist> mPlaylist;
 	float mPlaylistTimer;
+
+	bool mLinear;
 };
 
 #endif // ES_CORE_COMPONENTS_IMAGE_COMPONENT_H

--- a/es-core/src/resources/TextureData.cpp
+++ b/es-core/src/resources/TextureData.cpp
@@ -15,7 +15,7 @@
 
 #define OPTIMIZEVRAM Settings::getInstance()->getBool("OptimizeVRAM")
 
-TextureData::TextureData(bool tile) : mTile(tile), mTextureID(0), mDataRGBA(nullptr), mScalable(false),
+TextureData::TextureData(bool tile, bool linear) : mTile(tile), mLinear(linear), mTextureID(0), mDataRGBA(nullptr), mScalable(false),
 									  mWidth(0), mHeight(0), mSourceWidth(0.0f), mSourceHeight(0.0f),
 									  mPackedSize(Vector2i(0, 0)), mBaseSize(Vector2i(0, 0))
 {
@@ -254,7 +254,7 @@ bool TextureData::uploadAndBind()
 			return false;
 
 		// Upload texture
-		mTextureID = Renderer::createTexture(Renderer::Texture::RGBA, mHeight >= 480, mTile, mWidth, mHeight, mDataRGBA);
+		mTextureID = Renderer::createTexture(Renderer::Texture::RGBA, mLinear, mTile, mWidth, mHeight, mDataRGBA);
 		if (mTextureID)
 		{
 			if (mDataRGBA != nullptr && !mIsExternalDataRGBA)

--- a/es-core/src/resources/TextureData.h
+++ b/es-core/src/resources/TextureData.h
@@ -11,7 +11,7 @@ class TextureResource;
 class TextureData
 {
 public:
-	TextureData(bool tile);
+	TextureData(bool tile, bool linear);
 	~TextureData();
 
 	// These functions populate mDataRGBA but do not upload the texture to VRAM
@@ -64,6 +64,7 @@ public:
 private:
 	std::mutex		mMutex;
 	bool			mTile;
+	bool			mLinear;
 	std::string		mPath;
 	unsigned int	mTextureID;
 	unsigned char*	mDataRGBA;

--- a/es-core/src/resources/TextureDataManager.cpp
+++ b/es-core/src/resources/TextureDataManager.cpp
@@ -9,7 +9,7 @@
 TextureDataManager::TextureDataManager()
 {
 	unsigned char data[5 * 5 * 4];
-	mBlank = std::make_shared<TextureData>(false);
+	mBlank = std::make_shared<TextureData>(false, false);
 	for (int i = 0; i < (5 * 5); ++i)
 	{
 		data[i * 4] = 0; // (i % 2) * 255;
@@ -41,7 +41,7 @@ void TextureDataManager::onTextureLoaded(std::shared_ptr<TextureData> tex)
 	}
 }
 
-std::shared_ptr<TextureData> TextureDataManager::add(const TextureResource* key, bool tiled)
+std::shared_ptr<TextureData> TextureDataManager::add(const TextureResource* key, bool tiled, bool linear)
 {	
 	std::unique_lock<std::mutex> lock(mMutex);
 
@@ -55,7 +55,7 @@ std::shared_ptr<TextureData> TextureDataManager::add(const TextureResource* key,
 		mTextureLookup.erase(it);
 	}
 
-	std::shared_ptr<TextureData> data = std::make_shared<TextureData>(tiled);
+	std::shared_ptr<TextureData> data = std::make_shared<TextureData>(tiled, linear);
 	mTextures.push_front(data);
 	mTextureLookup[key] = mTextures.cbegin();
 

--- a/es-core/src/resources/TextureDataManager.h
+++ b/es-core/src/resources/TextureDataManager.h
@@ -60,7 +60,7 @@ public:
 	TextureDataManager();
 	~TextureDataManager();
 
-	std::shared_ptr<TextureData> add(const TextureResource* key, bool tiled);
+	std::shared_ptr<TextureData> add(const TextureResource* key, bool tiled, bool linear);
 
 	// The texturedata being removed may be loading in a different thread. However it will
 	// be referenced by a smart point so we only need to remove it from our array and it

--- a/es-core/src/resources/TextureResource.h
+++ b/es-core/src/resources/TextureResource.h
@@ -9,17 +9,18 @@
 #include "resources/TextureData.h"
 #include <set>
 #include <string>
+#include <tuple>
 
 // An OpenGL texture.
 // Automatically recreates the texture with renderer deinit/reinit.
 class TextureResource : public IReloadable
 {
 public:
-	TextureResource(const std::string& path, bool tile, bool dynamic, bool allowAsync, MaxSizeInfo* maxSize = nullptr);
+	TextureResource(const std::string& path, bool tile, bool linear, bool dynamic, bool allowAsync, MaxSizeInfo* maxSize = nullptr);
 
 public:
 	static void cancelAsync(std::shared_ptr<TextureResource> texture);
-	static std::shared_ptr<TextureResource> get(const std::string& path, bool tile = false, bool forceLoad = false, bool dynamic = true, bool asReloadable = true, MaxSizeInfo* maxSize = nullptr);
+	static std::shared_ptr<TextureResource> get(const std::string& path, bool tile = false, bool linear = false, bool forceLoad = false, bool dynamic = true, bool asReloadable = true, MaxSizeInfo* maxSize = nullptr);
 	void initFromPixels(unsigned char* dataRGBA, size_t width, size_t height);
 	void initFromExternalPixels(unsigned char* dataRGBA, size_t width, size_t height);
 	virtual void initFromMemory(const char* file, size_t length);
@@ -58,7 +59,7 @@ private:
 	Vector2f					mSourceSize;
 	bool							mForceLoad;
 
-	typedef std::pair<std::string, bool> TextureKeyType;
+	typedef std::tuple<std::string, bool, bool> TextureKeyType;
 	static std::map< TextureKeyType, std::weak_ptr<TextureResource> > sTextureMap; // map of textures, used to prevent duplicate textures
 	static std::set<TextureResource*> 	sAllTextures;	// Set of all textures, used for memory management
 };


### PR DESCRIPTION
- Allow Themes to declare image smoothing for (background) images when they are upscaled.
+ Translation : Somes menu options are not ready for translation 
+ SystemView : Support extra="static" items -> static items don't scroll with systems & are in a fixed position.