### PR TITLE
gamelist.xml: added <gametime> (playing time)

### DIFF
--- a/es-app/src/MetaData.cpp
+++ b/es-app/src/MetaData.cpp
@@ -11,10 +11,10 @@
 static std::vector<MetaDataDecl> gameMDD;
 static std::vector<MetaDataDecl> folderMDD;
 
-static std::string mDefaultGameMap[20];
+static std::string mDefaultGameMap[21];
 static std::string mDefaultFolderMap[14];
 
-static MetaDataType mGameTypeMap[20];
+static MetaDataType mGameTypeMap[21];
 static MetaDataType mFolderTypeMap[14];
 
 static std::map<std::string, unsigned char> mGameIdMap;
@@ -41,10 +41,9 @@ void MetaDataList::initMetadata()
 	gameMDD.push_back(MetaDataDecl(15, "kidgame", MD_BOOL, "false", false, _("Kidgame"), _("set kidgame")));
 	gameMDD.push_back(MetaDataDecl(16, "playcount", MD_INT, "0", true, _("Play count"), _("enter number of times played")));
 	gameMDD.push_back(MetaDataDecl(17, "lastplayed", MD_TIME, "0", true, _("Last played"), _("enter last played date")));
-
 	gameMDD.push_back(MetaDataDecl(18, "crc32", MD_STRING, "", false, "Crc32", _("Crc32 checksum")));
 	gameMDD.push_back(MetaDataDecl(19, "md5", MD_STRING, "", false, "Md5", _("Md5 checksum")));
-
+	gameMDD.push_back(MetaDataDecl(20, "gametime", MD_INT, "0", true, _("Game time"), _("how long the game has been played in total (seconds)")));
 
 	folderMDD.push_back(MetaDataDecl(0, "name", MD_STRING, "", false, _("name"), _("enter game name")));
 	//  folderMDD.push_back(MetaDataDecl(1, "sortname",	MD_STRING,		"", 		false, _("sortname"),    _("enter game sort name")));

--- a/es-app/src/views/gamelist/DetailedGameListView.cpp
+++ b/es-app/src/views/gamelist/DetailedGameListView.cpp
@@ -394,7 +394,7 @@ void DetailedGameListView::updateInfoPanel()
 		{
 			mLastPlayed.setValue(file->getMetadata("lastplayed"));
 			mPlayCount.setValue(file->getMetadata("playcount"));
-			mGameTime.setValue(Utils::Time::secondsToString(std::stol(file->getMetadata("gametime"))));
+			mGameTime.setValue(Utils::Time::secondsToString(atol(file->getMetadata("gametime").c_str())));
 		}
 		
 		fadingOut = false;

--- a/es-app/src/views/gamelist/DetailedGameListView.cpp
+++ b/es-app/src/views/gamelist/DetailedGameListView.cpp
@@ -259,6 +259,9 @@ void DetailedGameListView::onThemeChanged(const std::shared_ptr<ThemeData>& them
 		values[i]->applyTheme(theme, getName(), valElements[i], ALL ^ ThemeFlags::TEXT);
 	}
 
+	mLblGameTime.setVisible(theme->getElement(getName(), "md_lbl_gametime", "text") != nullptr);
+	mGameTime.setVisible(theme->getElement(getName(), "md_gametime", "text") != nullptr);
+
 	mDescContainer.applyTheme(theme, getName(), "md_description", POSITION | ThemeFlags::SIZE | Z_INDEX | VISIBLE);
 	mDescription.setSize(mDescContainer.getSize().x(), 0);
 	mDescription.applyTheme(theme, getName(), "md_description", ALL ^ (POSITION | ThemeFlags::SIZE | ThemeFlags::ORIGIN | TEXT | ROTATION));
@@ -391,7 +394,7 @@ void DetailedGameListView::updateInfoPanel()
 		{
 			mLastPlayed.setValue(file->getMetadata("lastplayed"));
 			mPlayCount.setValue(file->getMetadata("playcount"));
-			mGameTime.setValue(file->getMetadata("gametime"));
+			mGameTime.setValue(Utils::Time::secondsToString(std::stol(file->getMetadata("gametime"))));
 		}
 		
 		fadingOut = false;

--- a/es-app/src/views/gamelist/DetailedGameListView.cpp
+++ b/es-app/src/views/gamelist/DetailedGameListView.cpp
@@ -16,11 +16,11 @@ DetailedGameListView::DetailedGameListView(Window* window, FolderData* root) :
 	mImage(nullptr), mMarquee(nullptr), mVideo(nullptr), mThumbnail(nullptr),
 
 	mLblRating(window), mLblReleaseDate(window), mLblDeveloper(window), mLblPublisher(window), 
-	mLblGenre(window), mLblPlayers(window), mLblLastPlayed(window), mLblPlayCount(window),
+	mLblGenre(window), mLblPlayers(window), mLblLastPlayed(window), mLblPlayCount(window), mLblGameTime(window),
 
 	mRating(window), mReleaseDate(window), mDeveloper(window), mPublisher(window), 
 	mGenre(window), mPlayers(window), mLastPlayed(window), mPlayCount(window),
-	mName(window)
+	mName(window), mGameTime(window)
 {
 	const float padding = 0.01f;
 
@@ -58,6 +58,9 @@ DetailedGameListView::DetailedGameListView(Window* window, FolderData* root) :
 	mLblPlayCount.setText(_("Times played") + ": "); // batocera
 	addChild(&mLblPlayCount);
 	addChild(&mPlayCount);
+	mLblGameTime.setText(_("Game time") + ": "); // batocera
+	addChild(&mLblGameTime);
+	addChild(&mGameTime);
 
 	mName.setPosition(mSize.x(), mSize.y());
 	mName.setDefaultZIndex(40);
@@ -231,10 +234,10 @@ void DetailedGameListView::onThemeChanged(const std::shared_ptr<ThemeData>& them
 
 	initMDLabels();
 	std::vector<TextComponent*> labels = getMDLabels();
-	assert(labels.size() == 8);
-	const char* lblElements[8] = {
+	assert(labels.size() == 9);
+	const char* lblElements[9] = {
 		"md_lbl_rating", "md_lbl_releasedate", "md_lbl_developer", "md_lbl_publisher", 
-		"md_lbl_genre", "md_lbl_players", "md_lbl_lastplayed", "md_lbl_playcount"
+		"md_lbl_genre", "md_lbl_players", "md_lbl_lastplayed", "md_lbl_playcount", "md_lbl_gametime"
 	};
 
 	for(unsigned int i = 0; i < labels.size(); i++)
@@ -245,10 +248,10 @@ void DetailedGameListView::onThemeChanged(const std::shared_ptr<ThemeData>& them
 
 	initMDValues();
 	std::vector<GuiComponent*> values = getMDValues();
-	assert(values.size() == 8);
-	const char* valElements[8] = {
+	assert(values.size() == 9);
+	const char* valElements[9] = {
 		"md_rating", "md_releasedate", "md_developer", "md_publisher", 
-		"md_genre", "md_players", "md_lastplayed", "md_playcount"
+		"md_genre", "md_players", "md_lastplayed", "md_playcount", "md_gametime"
 	};
 
 	for(unsigned int i = 0; i < values.size(); i++)
@@ -309,6 +312,7 @@ void DetailedGameListView::initMDValues()
 	mPlayers.setFont(defaultFont);
 	mLastPlayed.setFont(defaultFont);
 	mPlayCount.setFont(defaultFont);
+	mGameTime.setFont(defaultFont);
 
 	float bottom = 0.0f;
 
@@ -387,6 +391,7 @@ void DetailedGameListView::updateInfoPanel()
 		{
 			mLastPlayed.setValue(file->getMetadata("lastplayed"));
 			mPlayCount.setValue(file->getMetadata("playcount"));
+			mGameTime.setValue(file->getMetadata("gametime"));
 		}
 		
 		fadingOut = false;
@@ -470,6 +475,7 @@ std::vector<TextComponent*> DetailedGameListView::getMDLabels()
 	ret.push_back(&mLblPlayers);
 	ret.push_back(&mLblLastPlayed);
 	ret.push_back(&mLblPlayCount);
+	ret.push_back(&mLblGameTime);
 	return ret;
 }
 
@@ -484,6 +490,7 @@ std::vector<GuiComponent*> DetailedGameListView::getMDValues()
 	ret.push_back(&mPlayers);
 	ret.push_back(&mLastPlayed);
 	ret.push_back(&mPlayCount);
+	ret.push_back(&mGameTime);
 	return ret;
 }
 

--- a/es-app/src/views/gamelist/DetailedGameListView.h
+++ b/es-app/src/views/gamelist/DetailedGameListView.h
@@ -44,7 +44,7 @@ private:
 	ImageComponent* mMarquee;
 	VideoComponent* mVideo;
 
-	TextComponent mLblRating, mLblReleaseDate, mLblDeveloper, mLblPublisher, mLblGenre, mLblPlayers, mLblLastPlayed, mLblPlayCount;
+	TextComponent mLblRating, mLblReleaseDate, mLblDeveloper, mLblPublisher, mLblGenre, mLblPlayers, mLblLastPlayed, mLblPlayCount, mLblGameTime;
 
 	RatingComponent mRating;
 	DateTimeComponent mReleaseDate;
@@ -55,6 +55,7 @@ private:
 	DateTimeComponent mLastPlayed;
 	TextComponent mPlayCount;
 	TextComponent mName;
+	TextComponent mGameTime;
 
 	std::vector<TextComponent*> getMDLabels();
 	std::vector<GuiComponent*> getMDValues();

--- a/es-app/src/views/gamelist/GridGameListView.cpp
+++ b/es-app/src/views/gamelist/GridGameListView.cpp
@@ -22,11 +22,11 @@ GridGameListView::GridGameListView(Window* window, FolderData* root, const std::
 	mDescContainer(window), mDescription(window),
 	mImage(nullptr), mVideo(nullptr), mMarquee(nullptr), mThumbnail(nullptr),
 	mLblRating(window), mLblReleaseDate(window), mLblDeveloper(window), mLblPublisher(window),
-	mLblGenre(window), mLblPlayers(window), mLblLastPlayed(window), mLblPlayCount(window),
+	mLblGenre(window), mLblPlayers(window), mLblLastPlayed(window), mLblPlayCount(window), mLblGameTime(window),
 
 	mRating(window), mReleaseDate(window), mDeveloper(window), mPublisher(window),
 	mGenre(window), mPlayers(window), mLastPlayed(window), mPlayCount(window),
-	mName(window)
+	mName(window), mGameTime(window)
 {
 	setTag("grid");
 
@@ -64,6 +64,9 @@ GridGameListView::GridGameListView(Window* window, FolderData* root, const std::
 	mLblPlayCount.setText(_("Times played") + ": ");
 	addChild(&mLblPlayCount);
 	addChild(&mPlayCount);
+	mLblGameTime.setText(_("Game time") + ": ");
+	addChild(&mLblGameTime);
+	addChild(&mGameTime);
 
 	mName.setPosition(mSize.x(), mSize.y());
 	mName.setDefaultZIndex(40);
@@ -370,10 +373,10 @@ void GridGameListView::onThemeChanged(const std::shared_ptr<ThemeData>& theme)
 
 	initMDLabels();
 	std::vector<TextComponent*> labels = getMDLabels();
-	assert(labels.size() == 8);
-	const char* lblElements[8] = {
+	assert(labels.size() == 9);
+	const char* lblElements[9] = {
 			"md_lbl_rating", "md_lbl_releasedate", "md_lbl_developer", "md_lbl_publisher",
-			"md_lbl_genre", "md_lbl_players", "md_lbl_lastplayed", "md_lbl_playcount"
+			"md_lbl_genre", "md_lbl_players", "md_lbl_lastplayed", "md_lbl_playcount", "md_lbl_gametime"
 	};
 
 	for(unsigned int i = 0; i < labels.size(); i++)
@@ -384,10 +387,10 @@ void GridGameListView::onThemeChanged(const std::shared_ptr<ThemeData>& theme)
 
 	initMDValues();
 	std::vector<GuiComponent*> values = getMDValues();
-	assert(values.size() == 8);
-	const char* valElements[8] = {
+	assert(values.size() == 9);
+	const char* valElements[9] = {
 			"md_rating", "md_releasedate", "md_developer", "md_publisher",
-			"md_genre", "md_players", "md_lastplayed", "md_playcount"
+			"md_genre", "md_players", "md_lastplayed", "md_playcount", "md_gametime"
 	};
 
 	for(unsigned int i = 0; i < values.size(); i++)
@@ -504,6 +507,7 @@ void GridGameListView::initMDValues()
 	mPlayers.setFont(defaultFont);
 	mLastPlayed.setFont(defaultFont);
 	mPlayCount.setFont(defaultFont);
+	mGameTime.setFont(defaultFont);
 
 	float bottom = 0.0f;
 
@@ -588,6 +592,7 @@ void GridGameListView::updateInfoPanel()
 		{
 			mLastPlayed.setValue(file->getMetadata().get("lastplayed"));
 			mPlayCount.setValue(file->getMetadata().get("playcount"));
+			mGameTime.setValue(file->getMetadata().get("gametime"));
 		}
 
 		fadingOut = false;
@@ -699,6 +704,7 @@ std::vector<TextComponent*> GridGameListView::getMDLabels()
 	ret.push_back(&mLblPlayers);
 	ret.push_back(&mLblLastPlayed);
 	ret.push_back(&mLblPlayCount);
+	ret.push_back(&mLblGameTime);
 	return ret;
 }
 
@@ -713,6 +719,7 @@ std::vector<GuiComponent*> GridGameListView::getMDValues()
 	ret.push_back(&mPlayers);
 	ret.push_back(&mLastPlayed);
 	ret.push_back(&mPlayCount);
+	ret.push_back(&mGameTime);
 	return ret;
 }
 

--- a/es-app/src/views/gamelist/GridGameListView.cpp
+++ b/es-app/src/views/gamelist/GridGameListView.cpp
@@ -595,7 +595,7 @@ void GridGameListView::updateInfoPanel()
 		{
 			mLastPlayed.setValue(file->getMetadata().get("lastplayed"));
 			mPlayCount.setValue(file->getMetadata().get("playcount"));
-			mGameTime.setValue(Utils::Time::secondsToString(std::stol(file->getMetadata("gametime"))));
+			mGameTime.setValue(Utils::Time::secondsToString(atol(file->getMetadata("gametime").c_str())));
 		}
 
 		fadingOut = false;

--- a/es-app/src/views/gamelist/GridGameListView.cpp
+++ b/es-app/src/views/gamelist/GridGameListView.cpp
@@ -398,6 +398,9 @@ void GridGameListView::onThemeChanged(const std::shared_ptr<ThemeData>& theme)
 		values[i]->applyTheme(theme, getName(), valElements[i], ALL ^ ThemeFlags::TEXT);
 	}
 
+	mLblGameTime.setVisible(theme->getElement(getName(), "md_lbl_gametime", "text") != nullptr);
+	mGameTime.setVisible(theme->getElement(getName(), "md_gametime", "text") != nullptr);
+
 	if (theme->getElement(getName(), "md_description", "text"))
 	{
 		mDescContainer.applyTheme(theme, getName(), "md_description", POSITION | ThemeFlags::SIZE | Z_INDEX);
@@ -592,7 +595,7 @@ void GridGameListView::updateInfoPanel()
 		{
 			mLastPlayed.setValue(file->getMetadata().get("lastplayed"));
 			mPlayCount.setValue(file->getMetadata().get("playcount"));
-			mGameTime.setValue(file->getMetadata().get("gametime"));
+			mGameTime.setValue(Utils::Time::secondsToString(std::stol(file->getMetadata("gametime"))));
 		}
 
 		fadingOut = false;

--- a/es-app/src/views/gamelist/GridGameListView.h
+++ b/es-app/src/views/gamelist/GridGameListView.h
@@ -64,7 +64,7 @@ private:
 	void initMDLabels();
 	void initMDValues();
 
-	TextComponent mLblRating, mLblReleaseDate, mLblDeveloper, mLblPublisher, mLblGenre, mLblPlayers, mLblLastPlayed, mLblPlayCount;
+	TextComponent mLblRating, mLblReleaseDate, mLblDeveloper, mLblPublisher, mLblGenre, mLblPlayers, mLblLastPlayed, mLblPlayCount, mLblGameTime;
 
 	RatingComponent mRating;
 	DateTimeComponent mReleaseDate;
@@ -75,6 +75,7 @@ private:
 	DateTimeComponent mLastPlayed;
 	TextComponent mPlayCount;
 	TextComponent mName;
+	TextComponent mGameTime;
 
 	ImageComponent* mImage;
 	ImageComponent* mThumbnail;

--- a/es-app/src/views/gamelist/VideoGameListView.cpp
+++ b/es-app/src/views/gamelist/VideoGameListView.cpp
@@ -21,11 +21,11 @@ VideoGameListView::VideoGameListView(Window* window, FolderData* root) :
 	mThumbnail(nullptr),
 
 	mLblRating(window), mLblReleaseDate(window), mLblDeveloper(window), mLblPublisher(window),
-	mLblGenre(window), mLblPlayers(window), mLblLastPlayed(window), mLblPlayCount(window),
+	mLblGenre(window), mLblPlayers(window), mLblLastPlayed(window), mLblPlayCount(window), mLblGameTime(window),
 
 	mRating(window), mReleaseDate(window), mDeveloper(window), mPublisher(window),
 	mGenre(window), mPlayers(window), mLastPlayed(window), mPlayCount(window),
-	mName(window)
+	mName(window), mGameTime(window)
 {
 	const float padding = 0.01f;
 
@@ -96,6 +96,9 @@ VideoGameListView::VideoGameListView(Window* window, FolderData* root) :
 	mLblPlayCount.setText("Times played: ");
 	addChild(&mLblPlayCount);
 	addChild(&mPlayCount);
+	mLblGameTime.setText("Game time: ");
+	addChild(&mLblGameTime);
+	addChild(&mGameTime);
 
 	mName.setPosition(mSize.x(), mSize.y());
 	mName.setDefaultZIndex(40);
@@ -168,10 +171,10 @@ void VideoGameListView::onThemeChanged(const std::shared_ptr<ThemeData>& theme)
 
 	initMDLabels();
 	std::vector<TextComponent*> labels = getMDLabels();
-	assert(labels.size() == 8);
-	const char* lblElements[8] = {
+	assert(labels.size() == 9);
+	const char* lblElements[9] = {
 		"md_lbl_rating", "md_lbl_releasedate", "md_lbl_developer", "md_lbl_publisher",
-		"md_lbl_genre", "md_lbl_players", "md_lbl_lastplayed", "md_lbl_playcount"
+		"md_lbl_genre", "md_lbl_players", "md_lbl_lastplayed", "md_lbl_playcount", "md_lbl_gametime"
 	};
 
 	for(unsigned int i = 0; i < labels.size(); i++)
@@ -182,10 +185,10 @@ void VideoGameListView::onThemeChanged(const std::shared_ptr<ThemeData>& theme)
 
 	initMDValues();
 	std::vector<GuiComponent*> values = getMDValues();
-	assert(values.size() == 8);
-	const char* valElements[8] = {
+	assert(values.size() == 9);
+	const char* valElements[9] = {
 		"md_rating", "md_releasedate", "md_developer", "md_publisher",
-		"md_genre", "md_players", "md_lastplayed", "md_playcount"
+		"md_genre", "md_players", "md_lastplayed", "md_playcount", "md_gametime"
 	};
 
 	for(unsigned int i = 0; i < values.size(); i++)
@@ -245,6 +248,7 @@ void VideoGameListView::initMDValues()
 	mPlayers.setFont(defaultFont);
 	mLastPlayed.setFont(defaultFont);
 	mPlayCount.setFont(defaultFont);
+	mGameTime.setFont(defaultFont);
 
 	float bottom = 0.0f;
 
@@ -325,6 +329,7 @@ void VideoGameListView::updateInfoPanel()
 		{
 			mLastPlayed.setValue(file->getMetadata().get("lastplayed"));
 			mPlayCount.setValue(file->getMetadata().get("playcount"));
+			mGameTime.setValue(file->getMetadata().get("gametime"));
 		}
 
 		fadingOut = false;
@@ -428,6 +433,7 @@ std::vector<TextComponent*> VideoGameListView::getMDLabels()
 	ret.push_back(&mLblPlayers);
 	ret.push_back(&mLblLastPlayed);
 	ret.push_back(&mLblPlayCount);
+	ret.push_back(&mLblGameTime);
 	return ret;
 }
 
@@ -442,6 +448,7 @@ std::vector<GuiComponent*> VideoGameListView::getMDValues()
 	ret.push_back(&mPlayers);
 	ret.push_back(&mLastPlayed);
 	ret.push_back(&mPlayCount);
+	ret.push_back(&mGameTime);
 	return ret;
 }
 

--- a/es-app/src/views/gamelist/VideoGameListView.cpp
+++ b/es-app/src/views/gamelist/VideoGameListView.cpp
@@ -332,7 +332,7 @@ void VideoGameListView::updateInfoPanel()
 		{
 			mLastPlayed.setValue(file->getMetadata().get("lastplayed"));
 			mPlayCount.setValue(file->getMetadata().get("playcount"));
-			mGameTime.setValue(Utils::Time::secondsToString(std::stol(file->getMetadata("gametime"))));
+			mGameTime.setValue(Utils::Time::secondsToString(atol(file->getMetadata("gametime").c_str())));
 		}
 
 		fadingOut = false;

--- a/es-app/src/views/gamelist/VideoGameListView.cpp
+++ b/es-app/src/views/gamelist/VideoGameListView.cpp
@@ -196,6 +196,9 @@ void VideoGameListView::onThemeChanged(const std::shared_ptr<ThemeData>& theme)
 		values[i]->applyTheme(theme, getName(), valElements[i], ALL ^ ThemeFlags::TEXT);
 	}
 
+	mLblGameTime.setVisible(theme->getElement(getName(), "md_lbl_gametime", "text") != nullptr);
+	mGameTime.setVisible(theme->getElement(getName(), "md_gametime", "text") != nullptr);
+
 	mDescContainer.applyTheme(theme, getName(), "md_description", POSITION | ThemeFlags::SIZE | Z_INDEX | VISIBLE);
 	mDescription.setSize(mDescContainer.getSize().x(), 0);
 	mDescription.applyTheme(theme, getName(), "md_description", ALL ^ (POSITION | ThemeFlags::SIZE | ThemeFlags::ORIGIN | TEXT | ROTATION));
@@ -329,7 +332,7 @@ void VideoGameListView::updateInfoPanel()
 		{
 			mLastPlayed.setValue(file->getMetadata().get("lastplayed"));
 			mPlayCount.setValue(file->getMetadata().get("playcount"));
-			mGameTime.setValue(file->getMetadata().get("gametime"));
+			mGameTime.setValue(Utils::Time::secondsToString(std::stol(file->getMetadata("gametime"))));
 		}
 
 		fadingOut = false;

--- a/es-app/src/views/gamelist/VideoGameListView.h
+++ b/es-app/src/views/gamelist/VideoGameListView.h
@@ -44,7 +44,7 @@ private:
 	ImageComponent mImage;
 	ImageComponent* mThumbnail;
 
-	TextComponent mLblRating, mLblReleaseDate, mLblDeveloper, mLblPublisher, mLblGenre, mLblPlayers, mLblLastPlayed, mLblPlayCount;
+	TextComponent mLblRating, mLblReleaseDate, mLblDeveloper, mLblPublisher, mLblGenre, mLblPlayers, mLblLastPlayed, mLblPlayCount, mLblGameTime;
 
 	RatingComponent mRating;
 	DateTimeComponent mReleaseDate;
@@ -55,6 +55,7 @@ private:
 	DateTimeComponent mLastPlayed;
 	TextComponent mPlayCount;
 	TextComponent mName;
+	TextComponent mGameTime;
 
 	std::vector<TextComponent*> getMDLabels();
 	std::vector<GuiComponent*> getMDValues();

--- a/es-core/src/utils/TimeUtil.cpp
+++ b/es-core/src/utils/TimeUtil.cpp
@@ -270,6 +270,17 @@ namespace Utils
 
 		} // timeToString
 
+		std::string secondsToString(const long seconds)
+		{
+		// transforms a number of seconds into HH:MM:SS
+			int h=0, m=0, s=0;
+			h = (seconds/3600) % 24;
+			m = (seconds/60) % 60;
+			s = seconds % 60;
+			return std::to_string(h) + ":" + std::to_string(m) + ":" + std::to_string(s);
+
+		} //secondsToString
+
 		int daysInMonth(const int _year, const int _month)
 		{
 			tm timeStruct = { 0, 0, 0, 0, _month, _year - 1900, 0, 0, -1 };

--- a/es-core/src/utils/TimeUtil.h
+++ b/es-core/src/utils/TimeUtil.h
@@ -70,6 +70,7 @@ namespace Utils
 		std::string timeToString(const time_t& _time, const std::string& _format = "%Y%m%dT%H%M%S");
 		int         daysInMonth (const int _year, const int _month);
 		int         daysInYear  (const int _year);
+		std::string secondsToString(const long seconds);
 
 	} // Time::
 


### PR DESCRIPTION
Added a new `<gametime>` XML attribute in `gamelist.xml` that keeps track of how long you've played a game. It displays the total number of seconds the game has been launched from ES. This new attribute needs to be displayed by the themes (I'd recommend to add it to Batocera default theme).
 
To avoid false positives, it's logged only if the calculated game time for a session is >10 seconds.
Structure of the new attribute in gamelist.xml:
```
<gameList>
        <game>
             ....
             <gametime>1245</gametime>
</game>
</gameList>
```