### PR TITLE
ImageCache : Reduce lags for image async loadings

### DIFF
--- a/es-app/src/main.cpp
+++ b/es-app/src/main.cpp
@@ -29,6 +29,7 @@
 #include "scrapers/ThreadedScraper.h"
 #include "ThreadedHasher.h"
 #include <FreeImage.h>
+#include "ImageIO.h"
 
 #ifdef WIN32
 #include <Windows.h>
@@ -226,6 +227,8 @@ bool verifyHomeFolderExists()
 bool loadSystemConfigFile(Window* window, const char** errorString)
 {
 	*errorString = NULL;
+
+	ImageIO::loadImageCache();
 
 	if(!SystemData::loadConfig(window))
 	{
@@ -602,6 +605,7 @@ int main(int argc, char* argv[])
 	if (SystemData::hasDirtySystems())
 		window.renderLoadingScreen(_("SAVING METADATAS. PLEASE WAIT..."));
 
+	ImageIO::saveImageCache();
 	MameNames::deinit();
 	CollectionSystemManager::deinit();
 	SystemData::deleteSystems();

--- a/es-core/src/ImageIO.h
+++ b/es-core/src/ImageIO.h
@@ -50,6 +50,10 @@ public:
 	static Vector2f getPictureMinSize(Vector2f imageSize, Vector2f maxSize);
 	static Vector2i adjustPictureSize(Vector2i imageSize, Vector2i maxSize, bool externSize = false);
 	static bool		loadImageSize(const char *fn, unsigned int *x, unsigned int *y);
+
+	static void		updateImageCache(const std::string fn, int sz, int x, int y);
+	static void		loadImageCache();
+	static void		saveImageCache();	
 };
 
 #endif // ES_CORE_IMAGE_IO

--- a/es-core/src/components/ImageGridComponent.h
+++ b/es-core/src/components/ImageGridComponent.h
@@ -750,6 +750,9 @@ void ImageGridComponent<T>::updateTiles(bool allowAnimation, bool updateSelected
 	if (!mTiles.size())
 		return;
 
+	if (!mEntries.size())
+		return;
+
 	// Stop updating the tiles at highest scroll speed
 	if (mScrollTier == 3)
 	{

--- a/es-core/src/resources/TextureData.cpp
+++ b/es-core/src/resources/TextureData.cpp
@@ -203,7 +203,7 @@ bool TextureData::initFromExternalRGBA(unsigned char* dataRGBA, size_t width, si
 	return true;
 }
 
-bool TextureData::load()
+bool TextureData::load(bool updateCache)
 {
 	bool retval = false;
 
@@ -222,7 +222,11 @@ bool TextureData::load()
 		}
 		else
 			retval = initImageFromMemory((const unsigned char*)data.ptr.get(), data.length);
+
+		if (updateCache && retval)
+			ImageIO::updateImageCache(mPath, data.length, mBaseSize.x(), mBaseSize.y());
 	}
+
 	return retval;
 }
 

--- a/es-core/src/resources/TextureData.h
+++ b/es-core/src/resources/TextureData.h
@@ -23,7 +23,7 @@ public:
 	bool initFromRGBA(unsigned char* dataRGBA, size_t width, size_t height, bool copyData = true);
 
 	// Read the data into memory if necessary
-	bool load();
+	bool load(bool updateCache = false);
 
 	bool isLoaded();
 

--- a/es-core/src/resources/TextureDataManager.cpp
+++ b/es-core/src/resources/TextureDataManager.cpp
@@ -286,16 +286,18 @@ void TextureLoader::threadProc()
 
 			if (textureData && !textureData->isLoaded())
 			{
-				LOG(LogDebug) << "TextureLoader::Thread\tLoading " << textureData->getPath().c_str();
+				//LOG(LogDebug) << "TextureLoader::Thread\tLoading " << textureData->getPath().c_str();
+				std::this_thread::yield();
 
-				textureData->load();
-				mManager->onTextureLoaded(textureData);				
+				textureData->load(true);
+				//mManager->onTextureLoaded(textureData);				
 
 				lock.lock();
-				mProcessingTextureDataQ.remove(textureData);
-
-				std::this_thread::yield();
+				mProcessingTextureDataQ.remove(textureData);			
+				lock.unlock();
 			}
+
+			std::this_thread::yield();
 		}		
 	}
 }

--- a/es-core/src/utils/FileSystemUtil.cpp
+++ b/es-core/src/utils/FileSystemUtil.cpp
@@ -548,7 +548,13 @@ namespace Utils
 			if(_path.size() >= 2 && _path[0] == ':' && _path[1] == '/')
 				return _path;
 
+#if WIN32
+			std::string path = _path[0] == '.' ? getAbsolutePath(_path) : getGenericPath(_path);
+			if (path.find("./") == std::string::npos)
+				return path;
+#else
 			std::string path = exists(_path) ? getAbsolutePath(_path) : getGenericPath(_path);
+#endif
 
 			// cleanup path
 			bool scan = true;
@@ -582,7 +588,7 @@ namespace Utils
 #else // _WIN32
 					// append folder to path
 					path += ("/" + (*it));
-#endif // _WIN32
+
 
 					// resolve symlink
 					if(isSymlink(path))
@@ -603,6 +609,7 @@ namespace Utils
 						scan = true;
 						break;
 					}
+#endif // _WIN32
 				}
 			}
 


### PR DESCRIPTION
Improves performance & reduce lags when async loading images (ie. in grid view) with slow access time drives (mecanical HDDs/NAS/Slow SD card) using file "/userdata/system/configs/emulationstation/imagecache.db".