### PR TITLE
Fix video path with random fallback

### DIFF
--- a/es-app/src/views/SystemView.cpp
+++ b/es-app/src/views/SystemView.cpp
@@ -267,8 +267,19 @@ void SystemView::populate()
 				if (extra->isKindOf<VideoComponent>())
 				{
 					auto elem = (*it)->getTheme()->getElement("system", extra->getTag(), "video");
-					if (elem != nullptr && elem->has("path") && Utils::String::startsWith(elem->get<std::string>("path"), "{random"))
-						((VideoComponent*)extra)->setPlaylist(std::make_shared<SystemRandomPlaylist>(*it, SystemRandomPlaylist::VIDEO));
+                    if (elem != nullptr && elem->has("path"))
+                    {
+                        std::string src = elem->get<std::string>("path");
+
+                        if (Utils::String::startsWith(src, "{random"))
+                        {
+                                ((VideoComponent*)extra)->setPlaylist(std::make_shared<SystemRandomPlaylist>(*it, SystemRandomPlaylist::VIDEO));
+                        }
+					    else
+                        {
+                                ((VideoComponent*)extra)->setVideo(src);
+                        }
+                    }
 				}
 				else if (extra->isKindOf<ImageComponent>())
 				{

--- a/es-core/src/ThemeData.cpp
+++ b/es-core/src/ThemeData.cpp
@@ -1091,9 +1091,26 @@ void ThemeData::parseElement(const pugi::xml_node& root, const std::map<std::str
 		case PATH:
 		{
 			std::string path = Utils::FileSystem::resolveRelativePath(str, Utils::FileSystem::getParent(mPaths.back()), true);
-			
-			if (Utils::String::startsWith(path, "{random"))
+
+            if (Utils::String::startsWith(path, "{random|"))
+            {
+                std::string stringToErase = "{random|";
+                std::string fallbackPath = path;
+
+                fallbackPath.erase(0, stringToErase.length());
+                fallbackPath.erase(fallbackPath.length()-1, 1);
+
+                std::string rootPath = Utils::FileSystem::resolveRelativePath(fallbackPath, Utils::FileSystem::getParent(mPaths.back()), true);
+                if (Utils::FileSystem::exists(rootPath))
+                    path = rootPath;
+                else
+                    path = "{random}";
+            }
+
+
+            if (Utils::String::startsWith(path, "{random"))
 			{
+
 				pugi::xml_node parent = root.parent();
 
 				if (!element.extra)


### PR DESCRIPTION
Possibility to put a fixed video in the themes.
In the video tags indicate the path of the video in the <path> tag.
It is possible to use the following syntax: {random|path of the video}. If the video is not found, the videos of the platform are displayed randomly. 