### PR TITLE
SmallScreens ( goa, gpi ) Fixes

### DIFF
--- a/es-app/src/main.cpp
+++ b/es-app/src/main.cpp
@@ -489,8 +489,8 @@ int main(int argc, char* argv[])
 	while(running)
 	{
 		SDL_Event event;
-		bool ps_standby = PowerSaver::getState() && (int) SDL_GetTicks() - ps_time > PowerSaver::getMode();
 
+		bool ps_standby = PowerSaver::getState() && (int) SDL_GetTicks() - ps_time > PowerSaver::getMode();
 		if(ps_standby ? SDL_WaitEventTimeout(&event, PowerSaver::getTimeout()) : SDL_PollEvent(&event))
 		{
 			// PowerSaver can push events to exit SDL_WaitEventTimeout immediatly
@@ -538,7 +538,7 @@ int main(int argc, char* argv[])
 		{
 			// If exitting SDL_WaitEventTimeout due to timeout. Trail considering
 			// timeout as an event
-			ps_time = SDL_GetTicks();
+		//	ps_time = SDL_GetTicks();
 		}
 
 		if(window.isSleeping())

--- a/es-core/src/PowerSaver.cpp
+++ b/es-core/src/PowerSaver.cpp
@@ -3,6 +3,7 @@
 #include "AudioManager.h"
 #include "Settings.h"
 #include <SDL.h>
+#include "math/Misc.h"
 
 bool PowerSaver::mState = false;
 bool PowerSaver::mRunningScreenSaver = false;
@@ -41,11 +42,10 @@ void PowerSaver::init()
 
 int PowerSaver::getTimeout()
 {
-//	if (SDL_GetAudioStatus() == SDL_AUDIO_PAUSED)
-//		AudioManager::getInstance()->deinit();
+	 if (mMode == INSTANT || mMode == ENHANCED)
+		 return mRunningScreenSaver ? mWakeupTimeout : mScreenSaverTimeout;
 
-	// Used only for SDL_WaitEventTimeout. Use `getMode()` for modes.
-	return mRunningScreenSaver ? mWakeupTimeout : mScreenSaverTimeout;
+	return 1000;	
 }
 
 void PowerSaver::loadWakeupTime()

--- a/es-core/src/VolumeControl.cpp
+++ b/es-core/src/VolumeControl.cpp
@@ -260,6 +260,9 @@ int VolumeControl::getVolume() const
 #elif defined(__linux__)
 	if (mixerElem != nullptr)
 	{
+		if (mixerHandle != nullptr)
+			snd_mixer_handle_events(mixerHandle);
+
 		int mute_state;
 		if (snd_mixer_selem_has_playback_switch(mixerElem)) 
 		{

--- a/es-core/src/components/ButtonComponent.cpp
+++ b/es-core/src/components/ButtonComponent.cpp
@@ -16,6 +16,7 @@ ButtonComponent::ButtonComponent(Window* window, const std::string& text, const 
 	mTextColorFocused = menuTheme->Text.selectedColor;
 	mColor = menuTheme->Text.color;
 	mColorFocused = menuTheme->Text.selectorColor;
+	mRenderNonFocusedBackground = true;
 
 	setPressedFunc(func);
 	setText(text, helpText, upperCase);
@@ -103,7 +104,8 @@ void ButtonComponent::render(const Transform4x4f& parentTrans)
 {
 	Transform4x4f trans = parentTrans * getTransform();
 
-	mBox.render(trans);
+	if (mRenderNonFocusedBackground || mFocused)
+		mBox.render(trans);
 
 	if(mTextCache)
 	{

--- a/es-core/src/components/ButtonComponent.h
+++ b/es-core/src/components/ButtonComponent.h
@@ -34,6 +34,8 @@ public:
 
 	virtual std::vector<HelpPrompt> getHelpPrompts() override;
 
+	void setRenderNonFocusedBackground(bool value) { mRenderNonFocusedBackground = value; }
+
 private:
 	std::shared_ptr<Font> mFont;
 	std::function<void()> mPressedFunc;
@@ -57,6 +59,8 @@ private:
 
 	unsigned int mColor;
 	unsigned int mColorFocused;
+
+	bool mRenderNonFocusedBackground;
 };
 
 #endif // ES_CORE_COMPONENTS_BUTTON_COMPONENT_H

--- a/es-core/src/components/ImageComponent.cpp
+++ b/es-core/src/components/ImageComponent.cpp
@@ -576,7 +576,21 @@ void ImageComponent::applyTheme(const std::shared_ptr<ThemeData>& theme, const s
 	if (properties & ThemeFlags::SIZE)
 	{
 		if (elem->has("size"))
-			setResize(elem->get<Vector2f>("size") * scale);
+		{
+			auto sz = elem->get<Vector2f>("size");
+			if (sz.x() == 0 && sz.y() != 0 && Settings::getInstance()->getInt("ScreenRotate") != 0)
+			{
+				sz.x() = sz.y();
+				setMinSize(sz * scale);
+			} 
+			else if (sz.y() == 0 && sz.x() != 0 && Settings::getInstance()->getInt("ScreenRotate") != 0)
+			{
+				sz.y() = sz.x();
+				setMinSize(sz * scale);
+			}
+			else
+				setResize(sz * scale);
+		}
 		else if (elem->has("maxSize"))
 			setMaxSize(elem->get<Vector2f>("maxSize") * scale);
 		else if (elem->has("minSize"))

--- a/es-core/src/guis/GuiTextEditPopupKeyboard.cpp
+++ b/es-core/src/guis/GuiTextEditPopupKeyboard.cpp
@@ -135,12 +135,13 @@ GuiTextEditPopupKeyboard::GuiTextEditPopupKeyboard(Window* window, const std::st
 					mShiftButton = std::make_shared<ButtonComponent>(mWindow, _U("\uF176"), _("SHIFTS FOR UPPER,LOWER, AND SPECIAL"), [this] {
 						shiftKeys();
 					}, false);
-
+					
 					button = mShiftButton;
 				}
 				else
 					button = makeButton(lower, upper);					
 
+				button->setRenderNonFocusedBackground(false);
 				buttons.push_back(button);
 
 				button->setSize(getButtonSize());

--- a/es-core/src/resources/Font.cpp
+++ b/es-core/src/resources/Font.cpp
@@ -4,6 +4,7 @@
 #include "utils/FileSystemUtil.h"
 #include "utils/StringUtil.h"
 #include "Log.h"
+#include "math/Misc.h"
 
 #ifdef WIN32
 #include <Windows.h>
@@ -78,7 +79,13 @@ Font::Font(int size, const std::string& path) : mSize(size), mPath(path)
 
 	// GPI
 	if (Renderer::isSmallScreen())
-		mSize = size * 1.5;
+	{
+		float sz = Math::min(Renderer::getScreenWidth(), Renderer::getScreenHeight());
+		if (sz >= 320) // ODROID 480x320;
+			mSize = size * 1.31;
+		else // GPI 320x240
+			mSize = size * 1.5;
+	}
 
 	assert(mSize > 0);
 	


### PR DESCRIPTION
- Volume control should work now when Volume changed by external code.
- Better font sizing for small screen ( depend on resolution )
- Removed button borders on virtual keyboard for more readability
- Powersaver : Run main loop at least once per second ( required if a component like volume control or video has to suspend the powersaver )
- ImageComponent : small fix for old theme using 0 width images ( old minSize mode  - ie : Simple theme )