### PR TITLE
Fix : Avoid accidental game launches

### DIFF
--- a/es-app/src/views/gamelist/ISimpleGameListView.cpp
+++ b/es-app/src/views/gamelist/ISimpleGameListView.cpp
@@ -87,6 +87,10 @@ bool ISimpleGameListView::input(InputConfig* config, Input input)
 	{
 		if(config->isMappedTo(BUTTON_OK, input))
 		{
+			// Don't launch game if transition is still running
+			if (ViewController::get()->isAnimationPlaying(0))
+				return true;
+			
 			FileData* cursor = getCursor();
 			FolderData* folder = NULL;
 


### PR DESCRIPTION
Avoid accidental game launches if transition is still running if the user accidentally "double clicked" on the system view.