### PR TITLE
Fix : Gamelist recovery not cleaned up if recovery file are obsolete

### DIFF
--- a/es-app/src/Gamelist.cpp
+++ b/es-app/src/Gamelist.cpp
@@ -326,7 +326,10 @@ void updateGamelist(SystemData* system)
 			dirtyFiles.push_back(file);
 
 	if (dirtyFiles.size() == 0)
+	{
+		clearTemporaryGamelistRecovery(system);
 		return;
+	}
 
 	int numUpdated = 0;
 
@@ -400,4 +403,6 @@ void updateGamelist(SystemData* system)
 		else
 			clearTemporaryGamelistRecovery(system);
 	}
+	else
+		clearTemporaryGamelistRecovery(system);
 }


### PR DESCRIPTION
When the gamelist had external changes, recovery files are never deleted.