### PR TITLE
CrashFix : prevent user from going in collections menu while scrapping

### DIFF
--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -314,7 +314,14 @@ void GuiMenu::openVideoScreensaverOptions() {
 }
 
 
-void GuiMenu::openCollectionSystemSettings() {
+void GuiMenu::openCollectionSystemSettings() 
+{
+	if (ThreadedScraper::isRunning() || ThreadedHasher::isRunning())
+	{
+		mWindow->pushGui(new GuiMsgBox(mWindow, _("THIS FUNCTION IS DISABLED WHEN SCRAPING IS RUNNING")));
+		return;
+	}
+
 	mWindow->pushGui(new GuiCollectionSystemsOptions(mWindow));
 }
 


### PR DESCRIPTION
and indexing hashes -> It can lead to a crash because some options need to delete all systems / rebuild all gamelist.