### PR TITLE
Fix Battery indicator for GOA.

### DIFF
--- a/es-core/src/components/BatteryIndicatorComponent.cpp
+++ b/es-core/src/components/BatteryIndicatorComponent.cpp
@@ -236,7 +236,7 @@ void BatteryIndicatorComponent::updateBatteryInfo()
 	else 
 	{	
 		mHasBattery = true;
-		mIsCharging = (Utils::FileSystem::readAllText(batteryStatusPath) != "Discharging");
+		mIsCharging = (Utils::String::replace(Utils::FileSystem::readAllText(batteryStatusPath), "\n", "") != "Discharging");
 		mBatteryLevel = atoi(Utils::FileSystem::readAllText(batteryCapacityPath).c_str());
 	}
 }


### PR DESCRIPTION
/sys/class/power_supply/battery/status contains an extra \n char