### PR TITLE
Fix : The gamelist logo is always the same as the systemview 

### DIFF
--- a/es-app/src/SystemScreenSaver.cpp
+++ b/es-app/src/SystemScreenSaver.cpp
@@ -20,6 +20,7 @@
 #include "AudioManager.h"
 #include "math/Vector2i.h"
 #include "SystemConf.h"
+#include "ImageIO.h"
 
 #define FADE_TIME 			500
 
@@ -621,15 +622,20 @@ void GameScreenSaverBase::setGame(FileData* game)
 							auto height = doc["height"].GetInt();
 							if (width > 0 && height > 0)
 							{
-								float px = Renderer::getScreenWidth() / (float)width;
-								float py = Renderer::getScreenHeight() / (float)height;
+								Vector2i sz = ImageIO::adjustPictureSize(Vector2i(width, height), Vector2i(Renderer::getScreenWidth(), Renderer::getScreenHeight()));
+
+								float px = (float) sz.x() / (float)width;
+								float py = (float) sz.y() / (float)height;
+
+								float dx = (Renderer::getScreenWidth() - sz.x()) / 2.0;
+								float dy = (Renderer::getScreenHeight() - sz.y()) / 2.0;
 
 								auto top = doc["top"].GetInt();
 								auto left = doc["left"].GetInt();
 								auto bottom = doc["bottom"].GetInt();
 								auto right = doc["right"].GetInt();
 
-								mViewport = Renderer::Rect(left * px, top * py, (width - right - left) * px, (height - bottom - top) * py);
+								mViewport = Renderer::Rect(dx + left * px, dy + top * py, (width - right - left) * px, (height - bottom - top) * py);
 							}
 						}
 					}
@@ -801,6 +807,7 @@ void VideoScreenSaver::setVideo(const std::string path)
 #endif
 		mVideo = new VideoVlcComponent(mWindow);
 
+		mVideo->setRoundCorners(0);
 		mVideo->topWindow(true);
 		mVideo->setOrigin(0.5f, 0.5f);
 		

--- a/es-app/src/guis/GuiInstallStart.h
+++ b/es-app/src/guis/GuiInstallStart.h
@@ -6,6 +6,8 @@
 template<typename T>
 class OptionListComponent;
 
+class SwitchComponent;
+
 class GuiInstallStart : public GuiComponent
 {
 public:
@@ -20,5 +22,5 @@ private:
 	MenuComponent mMenu;
 	std::shared_ptr< OptionListComponent<std::string> >moptionsStorage;
 	std::shared_ptr< OptionListComponent<std::string> >moptionsArchitecture;
-	std::shared_ptr< OptionListComponent<std::string> >moptionsValidation;
+	std::shared_ptr<SwitchComponent> moptionsValidation;
 };

--- a/es-app/src/views/gamelist/BasicGameListView.cpp
+++ b/es-app/src/views/gamelist/BasicGameListView.cpp
@@ -56,7 +56,7 @@ void BasicGameListView::populateList(const std::vector<FileData*>& files)
 	auto groupTheme = system->getTheme();
 	if (groupTheme)
 	{
-		const ThemeData::ThemeElement* logoElem = groupTheme->getElement("system", "logo", "image");
+		const ThemeData::ThemeElement* logoElem = groupTheme->getElement(getName(), "logo", "image");
 		if (logoElem && logoElem->has("path") && Utils::FileSystem::exists(logoElem->get<std::string>("path")))
 			mHeaderImage.setImage(logoElem->get<std::string>("path"));
 	}

--- a/es-app/src/views/gamelist/GridGameListView.cpp
+++ b/es-app/src/views/gamelist/GridGameListView.cpp
@@ -249,7 +249,7 @@ void GridGameListView::populateList(const std::vector<FileData*>& files)
 	auto groupTheme = system->getTheme();
 	if (groupTheme)
 	{
-		const ThemeData::ThemeElement* logoElem = groupTheme->getElement("system", "logo", "image");
+		const ThemeData::ThemeElement* logoElem = groupTheme->getElement(getName(), "logo", "image");
 		if (logoElem && logoElem->has("path") && Utils::FileSystem::exists(logoElem->get<std::string>("path")))
 			mHeaderImage.setImage(logoElem->get<std::string>("path"));
 	}


### PR DESCRIPTION
- even if defined different in the theme.
- Fix : INSTALL ON NEW DISK screen may crash if all options are not set
- Fix : Screensaver decoration viewport calculation when screen proportion is different than the bezel proportion (4:3 screens)

 
