### PR TITLE
Lot of fixes & things

### DIFF
--- a/es-app/src/ApiSystem.h
+++ b/es-app/src/ApiSystem.h
@@ -110,7 +110,7 @@ public:
     std::vector<std::string> getAvailableInstallArchitectures();
     std::vector<std::string> getAvailableOverclocking();
     std::vector<BiosSystem> getBiosInformations();
-    std::vector<std::string> getVideoModes();
+    virtual std::vector<std::string> getVideoModes();
 
 	virtual std::vector<std::string> getAvailableStorageDevices();
 	virtual std::vector<std::string> getSystemInformations();

--- a/es-app/src/CollectionSystemManager.cpp
+++ b/es-app/src/CollectionSystemManager.cpp
@@ -1255,7 +1255,10 @@ bool CollectionSystemManager::includeFileInAutoCollections(FileData* file)
 	// we exclude non-game files from collections (i.e. "kodi", entries from non-game systems)
 	// if/when there are more in the future, maybe this can be a more complex method, with a proper list
 	// but for now a simple string comparison is more performant
-	return file->getName() != "kodi" && file->getSystem()->isGameSystem();
+	if (file->getName() != "kodi" && file->getSystem()->isGameSystem() && !file->getSystem()->hasPlatformId(PlatformIds::PLATFORM_IGNORE))
+		return true;
+
+	return false;
 }
 
 std::string getCustomCollectionConfigPath(std::string collectionName)

--- a/es-app/src/FileData.cpp
+++ b/es-app/src/FileData.cpp
@@ -296,7 +296,39 @@ void FileData::launchGame(Window* window, LaunchGameOptions options)
 	std::string systemName = system->getName();
 	std::string emulator = getEmulator();
 	std::string core = getCore();
+
+	bool forceCore = false;
+
+	if (options.netPlayMode == CLIENT && !options.core.empty() && core != options.core)
+	{
+		for (auto& em : system->getEmulators())
+		{
+			for (auto& cr : em.cores)
+			{
+				if (cr.name == options.core)
+				{
+					emulator = em.name;
+					core = cr.name;
+					forceCore = true;
+					break;
+				}
+			}
+
+			if (forceCore)
+				break;
+		}
+	}
+
 	std::string command = system->getLaunchCommand(emulator, core);
+
+	if (forceCore)
+	{
+		if (command.find("%EMULATOR%") == std::string::npos && command.find("-emulator") == std::string::npos)
+			command = command + " -emulator %EMULATOR%";
+
+		if (command.find("%CORE%") == std::string::npos && command.find("-core") == std::string::npos)
+			command = command + " -core %CORE%";
+	}
 
 	const std::string rom = Utils::FileSystem::getEscapedPath(getPath());
 	const std::string basename = Utils::FileSystem::getStem(getPath());
@@ -311,7 +343,7 @@ void FileData::launchGame(Window* window, LaunchGameOptions options)
 	command = Utils::String::replace(command, "%CORE%", core);
 	command = Utils::String::replace(command, "%HOME%", Utils::FileSystem::getHomePath());
 
-	if (options.netPlayMode != DISABLED && mSystem->isNetplaySupported() && command.find("%NETPLAY%") == std::string::npos)
+	if (options.netPlayMode != DISABLED && (forceCore || gameToUpdate->isNetplaySupported()) && command.find("%NETPLAY%") == std::string::npos)
 		command = command + " %NETPLAY%"; // Add command line parameter if the netplay option is defined at <core netplay="true"> level
 
 	if (options.netPlayMode == CLIENT)
@@ -334,6 +366,10 @@ void FileData::launchGame(Window* window, LaunchGameOptions options)
 	}
 	else
 		command = Utils::String::replace(command, "%NETPLAY%", "");
+
+	int monitorId = Settings::getInstance()->getInt("MonitorID");
+	if (monitorId >= 0 && command.find(" -system ") != std::string::npos)
+		command = command + " -monitor " + std::to_string(monitorId);
 
 	Scripting::fireEvent("game-start", rom, basename);
 
@@ -757,4 +793,36 @@ void FileData::setEmulator(const std::string value)
 #else
 	SystemConf::getInstance()->set(getConfigurationName() + ".emulator", value);
 #endif
+}
+
+bool FileData::isNetplaySupported()
+{
+	if (!SystemConf::getInstance()->getBool("global.netplay"))
+		return false;
+
+	auto file = getSourceFileData();
+	if (file->getType() != GAME)
+		return false;
+
+	auto system = file->getSystem();
+	if (system == nullptr)
+		return false;
+	
+	std::string emulName = getEmulator();
+	std::string coreName = getCore();
+
+	if (!SystemData::es_features_loaded)
+	{
+		std::string command = system->getLaunchCommand(emulName, coreName);
+		if (command.find("%NETPLAY%") != std::string::npos)
+			return true;
+	}
+	
+	for (auto emul : system->getEmulators())
+		if (emulName == emul.name)
+			for (auto core : emul.cores)
+				if (coreName == core.name)
+					return core.netplay;
+					
+	return false;
 }

--- a/es-app/src/FileData.h
+++ b/es-app/src/FileData.h
@@ -39,6 +39,8 @@ struct LaunchGameOptions
 	int netPlayMode;
 	std::string ip;
 	int port;
+
+	std::string core;
 };
 
 class FolderData;
@@ -70,6 +72,8 @@ public:
 
 	virtual const std::string getCore(bool resolveDefault = true);
 	virtual const std::string getEmulator(bool resolveDefault = true);
+
+	virtual bool isNetplaySupported();
 
 	void setCore(const std::string value);
 	void setEmulator(const std::string value);
@@ -163,6 +167,8 @@ public:
 
 		mChildren.clear();
 	}
+
+	inline bool isVirtualStorage() { return !mOwnsChildrens; }
 
 	inline bool isVirtualFolderDisplay() { return mIsDisplayableAsVirtualFolder && !mOwnsChildrens; }
 	

--- a/es-app/src/Gamelist.cpp
+++ b/es-app/src/Gamelist.cpp
@@ -240,7 +240,11 @@ bool addFileDataNode(pugi::xml_node& parent, const FileData* file, const char* t
 
 	// there's something useful in there so we'll keep the node, add the path
 	// try and make the path relative if we can so things still work if we change the rom folder location in the future
-	newNode.prepend_child("path").text().set(Utils::FileSystem::createRelativePath(file->getPath(), system->getStartPath(), false).c_str());
+	std::string path = Utils::FileSystem::createRelativePath(file->getPath(), system->getStartPath(), false).c_str();
+	if (path.empty() && file->getType() == FOLDER)
+		path = ".";
+
+	newNode.prepend_child("path").text().set(path.c_str());
 	return true;	
 }
 

--- a/es-app/src/Win32ApiSystem.cpp
+++ b/es-app/src/Win32ApiSystem.cpp
@@ -936,4 +936,45 @@ bool Win32ApiSystem::isReadyFlagSet()
 {
 	return Utils::FileSystem::exists(Utils::FileSystem::getEsConfigPath() + "/tmp/emulationstation.ready");
 }
+
+std::vector<std::string> Win32ApiSystem::getVideoModes()
+{
+	std::vector<std::string> ret;
+
+	DEVMODE vDevMode;
+
+	int i = 0;
+	while (EnumDisplaySettings(nullptr, i, &vDevMode))
+	{
+		if (vDevMode.dmDisplayFixedOutput == 0)
+		{			
+			if (vDevMode.dmBitsPerPel == 32)
+				ret.push_back(
+					std::to_string(vDevMode.dmPelsWidth)+"x"+
+					std::to_string(vDevMode.dmPelsHeight)+"x"+
+					std::to_string(vDevMode.dmBitsPerPel)+"x"+
+					std::to_string(vDevMode.dmDisplayFrequency) + ":" +
+					std::to_string(vDevMode.dmPelsWidth) + "x" +
+					std::to_string(vDevMode.dmPelsHeight) + " " +
+					std::to_string(vDevMode.dmDisplayFrequency) + "Hz");
+			else
+			{
+				ret.push_back(
+					std::to_string(vDevMode.dmPelsWidth) + "x" +
+					std::to_string(vDevMode.dmPelsHeight) + "x" +
+					std::to_string(vDevMode.dmBitsPerPel) + "x" +
+					std::to_string(vDevMode.dmDisplayFrequency) + ":" +
+					std::to_string(vDevMode.dmPelsWidth) + "x" +
+					std::to_string(vDevMode.dmPelsHeight) + "x" +
+					std::to_string(vDevMode.dmBitsPerPel) + " " +
+					std::to_string(vDevMode.dmDisplayFrequency) + "Hz");
+			}				
+		}
+
+		i++;
+	}
+
+	return ret;
+}
+
 #endif

--- a/es-app/src/Win32ApiSystem.h
+++ b/es-app/src/Win32ApiSystem.h
@@ -16,6 +16,7 @@ public:
 	unsigned long getFreeSpaceGB(std::string mountpoint) override;
 	std::string getFreeSpaceInfo() override;
 	std::string getIpAdress() override;
+	std::vector<std::string> getVideoModes() override;
 
 	void setReadyFlag(bool ready = true) override;
 	bool isReadyFlagSet() override;

--- a/es-app/src/components/TextListComponent.h
+++ b/es-app/src/components/TextListComponent.h
@@ -285,7 +285,7 @@ bool TextListComponent<T>::input(InputConfig* config, Input input)
 			}
 		}else{
 			if(config->isMappedLike("down", input) || config->isMappedLike("up", input) || 
-				config->isMappedTo("pagedown", input) || config->isMappedTo("pageup", input))
+				config->isMappedLike("pagedown", input) || config->isMappedLike("pageup", input))
 			{
 				stopScrolling();
 			}

--- a/es-app/src/guis/GuiGamelistOptions.cpp
+++ b/es-app/src/guis/GuiGamelistOptions.cpp
@@ -207,18 +207,26 @@ GuiGamelistOptions::GuiGamelistOptions(Window* window, SystemData* system, bool 
 		if (UIModeController::getInstance()->isUIModeFull() && CollectionSystemManager::get()->isEditing())
 			mMenu.addEntry(_("FINISH EDITING COLLECTION") + " : " + Utils::String::toUpper(CollectionSystemManager::get()->getEditingCollection()), true, std::bind(&GuiGamelistOptions::exitEditMode, this));
 
-		if (!fromPlaceholder && !mSystem->isCollection())
+		if (file->getType() == FOLDER && ((FolderData*) file)->isVirtualStorage())
+			fromPlaceholder = true;
+		
+		if (!fromPlaceholder)
 		{
 			mMenu.addGroup(_("GAME OPTIONS"));
 
 			if (ApiSystem::getInstance()->isScriptingSupported(ApiSystem::GAMESETTINGS))
-			if (mSystem->hasFeatures() || mSystem->hasEmulatorSelection())
 			{
-				if (!mSystem->isCollection() && !mSystem->hasPlatformId(PlatformIds::PLATFORM_IGNORE) && !mSystem->isGroupSystem())
-					mMenu.addEntry(_("ADVANCED SYSTEM OPTIONS"), true, [this, system] { GuiMenu::popSystemConfigurationGui(mWindow, system); });
+				auto srcSystem = file->getSourceFileData()->getSystem();
+				auto sysOptions = mSystem->isGroupSystem() ? srcSystem : mSystem;
+
+				if (sysOptions->hasFeatures() || sysOptions->hasEmulatorSelection())
+					mMenu.addEntry(_("ADVANCED SYSTEM OPTIONS"), true, [this, sysOptions] { GuiMenu::popSystemConfigurationGui(mWindow, sysOptions); });
 
 				if (file->getType() != FOLDER)
-					mMenu.addEntry(_("ADVANCED GAME OPTIONS"), true, [this, file] { GuiMenu::popGameConfigurationGui(mWindow, file); });
+				{
+					if (srcSystem->hasFeatures() || srcSystem->hasEmulatorSelection())
+						mMenu.addEntry(_("ADVANCED GAME OPTIONS"), true, [this, file] { GuiMenu::popGameConfigurationGui(mWindow, file); });
+				}
 			}
 
 			if (file->getType() == FOLDER)

--- a/es-app/src/guis/GuiNetPlay.h
+++ b/es-app/src/guis/GuiNetPlay.h
@@ -34,6 +34,8 @@ struct LobbyAppEntry
 	bool		fixed;
 	std::string retroarch_version;
 	int         port;
+
+	bool		coreExists;
 };
 
 
@@ -54,6 +56,7 @@ private:
 	void launchGame(LobbyAppEntry entry);
 
 	FileData* getFileData(const std::string gameInfo, bool crc = true);
+	bool coreExists(FileData* file, std::string core_name);
 
 	NinePatchComponent				mBackground;
 	ComponentGrid					mGrid;

--- a/es-app/src/main.cpp
+++ b/es-app/src/main.cpp
@@ -458,6 +458,12 @@ int main(int argc, char* argv[])
 	if(!verifyHomeFolderExists())
 		return 1;
 
+	if (!gPlayVideo.empty())
+	{
+		playVideo();
+		return 0;
+	}
+
 	//start the logger
 	Log::setupReportingLevel();
 	Log::init();	

--- a/es-app/src/views/gamelist/BasicGameListView.cpp
+++ b/es-app/src/views/gamelist/BasicGameListView.cpp
@@ -233,27 +233,18 @@ std::vector<HelpPrompt> BasicGameListView::getHelpPrompts()
 	std::vector<HelpPrompt> prompts;
 
 	if(Settings::getInstance()->getBool("QuickSystemSelect"))
-	  prompts.push_back(HelpPrompt("left/right", _("SYSTEM"))); // batocera
+		prompts.push_back(HelpPrompt("left/right", _("SYSTEM"))); // batocera
+
 	prompts.push_back(HelpPrompt("up/down", _("CHOOSE"))); // batocera
 	prompts.push_back(HelpPrompt(BUTTON_OK, _("LAUNCH")));
 	prompts.push_back(HelpPrompt(BUTTON_BACK, _("BACK")));
 	if(!UIModeController::getInstance()->isUIModeKid())
 	  prompts.push_back(HelpPrompt("select", _("OPTIONS"))); // batocera
 
-	if (SystemConf::getInstance()->getBool("global.netplay"))
-	{
-		if (mRoot->getSystem()->isNetplaySupported())
-			prompts.push_back(HelpPrompt("x", _("NETPLAY"))); // batocera
-		else
-		{
-			FileData* cursor = getCursor();
-			if (cursor != nullptr && cursor->getType() == GAME && cursor->getSourceFileData()->getSystem() != nullptr && cursor->getSourceFileData()->getSystem()->isNetplaySupported())
-				prompts.push_back(HelpPrompt("x", _("NETPLAY"))); // batocera
-			else if (mRoot->getSystem()->isGameSystem())
-				prompts.push_back(HelpPrompt("x", _("RANDOM"))); // batocera
-		}
-	}
-	else if(mRoot->getSystem()->isGameSystem())
+	FileData* cursor = getCursor();
+	if (cursor != nullptr && cursor->isNetplaySupported())
+		prompts.push_back(HelpPrompt("x", _("NETPLAY"))); // batocera
+	else
 		prompts.push_back(HelpPrompt("x", _("RANDOM"))); // batocera
 
 	if(mRoot->getSystem()->isGameSystem() && !UIModeController::getInstance()->isUIModeKid())

--- a/es-app/src/views/gamelist/GridGameListView.cpp
+++ b/es-app/src/views/gamelist/GridGameListView.cpp
@@ -779,23 +779,14 @@ std::vector<HelpPrompt> GridGameListView::getHelpPrompts()
 	prompts.push_back(HelpPrompt("up/down/left/right", _("CHOOSE"))); // batocera
 	prompts.push_back(HelpPrompt(BUTTON_OK, _("LAUNCH")));
 	prompts.push_back(HelpPrompt(BUTTON_BACK, _("BACK")));
+
 	if(!UIModeController::getInstance()->isUIModeKid())
 		prompts.push_back(HelpPrompt("select", _("OPTIONS"))); // batocera
 
-	if (SystemConf::getInstance()->getBool("global.netplay"))
-	{
-		if (mRoot->getSystem()->isNetplaySupported())
-			prompts.push_back(HelpPrompt("x", _("NETPLAY"))); // batocera
-		else
-		{
-			FileData* cursor = getCursor();
-			if (cursor != nullptr && cursor->getType() == GAME && cursor->getSourceFileData()->getSystem() != nullptr && cursor->getSourceFileData()->getSystem()->isNetplaySupported())
-				prompts.push_back(HelpPrompt("x", _("NETPLAY"))); // batocera
-			else if (mRoot->getSystem()->isGameSystem())
-				prompts.push_back(HelpPrompt("x", _("RANDOM"))); // batocera
-		}
-	}
-	else if(mRoot->getSystem()->isGameSystem())
+	FileData* cursor = getCursor();
+	if (cursor != nullptr && cursor->isNetplaySupported())
+		prompts.push_back(HelpPrompt("x", _("NETPLAY"))); // batocera
+	else
 		prompts.push_back(HelpPrompt("x", _("RANDOM"))); // batocera
 
 	if(mRoot->getSystem()->isGameSystem() && !UIModeController::getInstance()->isUIModeKid())

--- a/es-app/src/views/gamelist/ISimpleGameListView.cpp
+++ b/es-app/src/views/gamelist/ISimpleGameListView.cpp
@@ -177,34 +177,28 @@ bool ISimpleGameListView::input(InputConfig* config, Input input)
 			}
 		}else if (config->isMappedTo("x", input))
 		{
-			if (SystemConf::getInstance()->getBool("global.netplay")) //  && mRoot->getSystem()->isNetplaySupported()
+			FileData* cursor = getCursor();
+			if(cursor != nullptr && cursor->isNetplaySupported())
 			{
-				FileData* cursor = getCursor();
-				if(cursor != nullptr && cursor->getType() == GAME && cursor->getSourceFileData()->getSystem() != nullptr && cursor->getSourceFileData()->getSystem()->isNetplaySupported())
+				Window* window = mWindow;
+
+				window->pushGui(new GuiMsgBox(mWindow, _("LAUNCH THE GAME AS NETPLAY HOST ?"), _("YES"), [this, window, cursor]
 				{
-					Window* window = mWindow;
+					LaunchGameOptions options;
+					options.netPlayMode = SERVER;
+					ViewController::get()->launch(cursor, options);
 
-					window->pushGui(new GuiMsgBox(mWindow, _("LAUNCH THE GAME AS NETPLAY HOST ?"), _("YES"), [this, window, cursor]
-					{
-						LaunchGameOptions options;
-						options.netPlayMode = SERVER;
-						ViewController::get()->launch(cursor, options);
-
-					}, _("NO"), nullptr));
-
-					return true;
-				}				
-			}
-			
-			if (mRoot->getSystem()->isGameSystem())
-			{		
-				// go to random system game
-				FileData* randomGame = getCursor()->getSystem()->getRandomGame();
-				if (randomGame)
-					setCursor(randomGame);
+				}, _("NO"), nullptr));
 
 				return true;
-			}
+			}				
+			
+			// go to random system game
+			FileData* randomGame = getRandomGame();
+			if (randomGame)
+				setCursor(randomGame);
+
+			return true;
 		}
 		else if (config->isMappedTo("y", input) && !UIModeController::getInstance()->isUIModeKid())
 		{
@@ -214,6 +208,21 @@ bool ISimpleGameListView::input(InputConfig* config, Input input)
 		}
 	}
 	return IGameListView::input(config, input);
+}
+
+FileData* ISimpleGameListView::getRandomGame()
+{
+	auto list = getFileDataEntries();
+
+	unsigned int total = (int)list.size();
+	if (total == 0)
+		return nullptr;
+
+	int target = (int)Math::round((std::rand() / (float)RAND_MAX) * (total - 1));
+	if (target >= 0 && target < total)
+		return list.at(target);
+
+	return nullptr;
 }
 
 std::vector<std::string> ISimpleGameListView::getEntriesLetters()

--- a/es-app/src/views/gamelist/ISimpleGameListView.h
+++ b/es-app/src/views/gamelist/ISimpleGameListView.h
@@ -33,6 +33,8 @@ public:
 	virtual std::vector<std::string> getEntriesLetters() override;
 
 protected:
+	FileData* getRandomGame();
+
 	virtual std::vector<FileData*> getFileDataEntries() = 0;
 	virtual std::string getQuickSystemSelectRightButton() = 0;
 	virtual std::string getQuickSystemSelectLeftButton() = 0;

--- a/es-core/src/Splash.cpp
+++ b/es-core/src/Splash.cpp
@@ -46,7 +46,11 @@ Splash::Splash(Window* window, const std::string image, bool fullScreenBackGroun
 	if (backGroundImageTheme && backGroundImageTheme->has("path") && Utils::FileSystem::exists(backGroundImageTheme->get<std::string>("path")))
 		imagePath = backGroundImageTheme->get<std::string>("path");
 
-	mTexture = TextureResource::get(imagePath, false, true, true, false, false);
+	bool linearSmooth = false;
+	if (backGroundImageTheme && backGroundImageTheme->has("linearSmooth"))
+		linearSmooth = backGroundImageTheme->get<bool>("linearSmooth");
+	
+	mTexture = TextureResource::get(imagePath, false, linearSmooth, true, false, false);
 	
 	if (!fullScreenBackGround)
 		ResourceManager::getInstance()->removeReloadable(mTexture);
@@ -246,7 +250,12 @@ void Splash::render(float opacity, bool swapBuffers)
 	if (!mText.getText().empty())
 	{
 		// Ensure font is loaded
-		Font::get(FONT_SIZE_MEDIUM)->reload();
+		auto font = mText.getFont();
+		if (font != nullptr)
+			font->reload();
+		else
+			Font::get(FONT_SIZE_MEDIUM)->reload();
+
 		mText.render(trans);
 	}
 

--- a/es-core/src/SystemConf.cpp
+++ b/es-core/src/SystemConf.cpp
@@ -28,6 +28,51 @@
 
 SystemConf *SystemConf::sInstance = NULL;
 
+static std::vector<std::string> dontRemoveAutoValue
+{
+	{ "audio.device" }
+};
+
+static std::map<std::string, std::string> defaults =
+{
+	{ "kodi.enabled", "1" },
+	{ "kodi.atstartup", "0" },
+	{ "kodi.xbutton", "1" },
+	{ "audio.bgmusic", "1" },
+	{ "wifi.enabled", "0" },
+	{ "system.hostname", "BATOCERA" },
+	{ "global.retroachievements", "0" },
+	{ "global.retroachievements.hardcore", "0" },
+	{ "global.retroachievements.leaderboards", "0" },
+	{ "global.retroachievements.verbose", "0" },
+	{ "global.retroachievements.screenshot", "0" },
+	{ "global.retroachievements.username", "" },
+	{ "global.retroachievements.password", "" },
+	{ "global.ai_service_enabled", "0" },
+};
+
+/*
+kodi.enabled=1
+kodi.atstartup=0
+kodi.xbutton=1
+audio.bgmusic=1
+system.language=en_US
+controllers.bluetooth.enabled=1
+controllers.ps3.enabled=1
+controllers.ps3.driver=bluez
+controllers.xboxdrv.enabled=0
+controllers.xboxdrv.nbcontrols=2
+controllers.gpio.enabled=0
+controllers.gpio.args=map=1,2
+controllers.db9.enabled=0
+controllers.db9.args=map=1
+controllers.gamecon.enabled=0
+controllers.gamecon.args=map=1
+controllers.xarcade.enabled=1
+wifi.enabled=0
+system.hostname=BATOCERA
+global.retroachievements.*
+*/
 std::string systemConfFile = "/userdata/system/batocera.conf";
 std::string systemConfFileTmp = "/userdata/system/batocera.conf.tmp";
 
@@ -111,6 +156,8 @@ bool SystemConf::saveSystemConf()
 		filein.close();
 	}
 
+	static std::string removeID = "$^é(p$^mpv$êrpver$^vper$vper$^vper$vper$vper$^vperv^pervncvizn";
+
 	int lastTime = SDL_GetTicks();
 
 	/* Save new value if exists */
@@ -137,10 +184,16 @@ bool SystemConf::saveSystemConf()
 			if (idx == 0 || (idx == 1 && (fc == ';' || fc == '#')))
 			{
 				std::string val = it.second;
-				if (!val.empty() && val != "auto")
-					currentLine = key + val;
-				else
-					currentLine = "#" + key + it.second;
+				if ((!val.empty() && val != "auto") || std::find(dontRemoveAutoValue.cbegin(), dontRemoveAutoValue.cend(), it.first) != dontRemoveAutoValue.cend())
+				{
+					auto defaultValue = defaults.find(key);
+					if (defaultValue != defaults.cend() && defaultValue->second == val)
+						currentLine = removeID;
+					else
+						currentLine = key + val;
+				}
+				else 
+					currentLine = removeID;
 
 				lineFound = true;
 			}
@@ -164,8 +217,10 @@ bool SystemConf::saveSystemConf()
 		LOG(LogError) << "Unable to open for saving :  " << systemConfFileTmp << "\n";
 		return false;
 	}
-	for (int i = 0; i < fileLines.size(); i++) {
-		fileout << fileLines[i] << "\n";
+	for (int i = 0; i < fileLines.size(); i++) 
+	{
+		if (fileLines[i] != removeID)
+			fileout << fileLines[i] << "\n";
 	}
 
 	fileout.close();

--- a/es-core/src/renderers/Renderer.cpp
+++ b/es-core/src/renderers/Renderer.cpp
@@ -165,8 +165,9 @@ namespace Renderer
 
 	void activateWindow()
 	{
+		SDL_RestoreWindow(sdlWindow);
 		SDL_RaiseWindow(sdlWindow);
-		SDL_SetWindowInputFocus(sdlWindow);
+		SDL_SetWindowInputFocus(sdlWindow);		
 	}
 
 	bool init()


### PR DESCRIPTION
- SystemConf : Don't serialise default values & auto or empty values to avoid file growing.
- es_features : System management
- Netplay : Force the appropriate core when running a game to join a server.
- Netplay : Better management using es_features
- Netplay : UI Fixes - don't allow netplay server if current core does not support it.
- Random game : Fixes.
- Advanced options : Fixes
- Splash : Enable linearSmooth flag in background image.
- Menu UI : Fix infinite scroll with pageup/pagedown.
- Windows : getVideoModes without external script
- Windows : Transmit monitorId to emulatorLauncher
- Windows : fix --video command line.
- Windows : fix window restore after game exit with --fullscreen active.