### PR TITLE
 Fix TextureResource & Replace "N GAMES AVAILABLE"

### DIFF
--- a/es-app/src/Win32ApiSystem.cpp
+++ b/es-app/src/Win32ApiSystem.cpp
@@ -613,7 +613,8 @@ std::pair<std::string, int> Win32ApiSystem::installBatoceraBezel(std::string bez
 
 		if (parts[1] == bezelsystem)
 		{
-			std::string themeUrl = parts.size() < 3 ? "" : (parts[2] == "-" ? parts[3] : parts[2]);
+			std::string themeUrl = parts.size() > 1 ? parts[2] : "";
+			std::string subFolder = parts.size() > 2 ? parts[3] : "";
 
 			std::string themeFileName = Utils::FileSystem::getFileName(themeUrl);
 			std::string zipFile = getEmulatorLauncherPath("decorations") + "/" + themeFileName + ".zip";
@@ -640,7 +641,9 @@ std::pair<std::string, int> Win32ApiSystem::installBatoceraBezel(std::string bez
 					if (ext != ".cfg" && ext != ".png")
 						continue;
 
-					if (file.find("/overlay/GameBezels/") == std::string::npos)
+					if (!subFolder.empty() && Utils::FileSystem::getGenericPath(file).find(subFolder.c_str()) == std::string::npos)
+						continue;
+					else if (subFolder.empty() && file.find("/overlay/GameBezels/") == std::string::npos)
 						continue;
 					
 					std::string dest;

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -3485,19 +3485,22 @@ void GuiMenu::popSpecificConfigurationGui(Window* mWindow, std::string title, st
 	// psp internal resolution
 	if (systemData->isFeatureSupported(currentEmulator, currentCore, EmulatorFeatures::internal_resolution))
 	{
+		std::string curResol = SystemConf::getInstance()->get(configName + ".internalresolution");
+
 		auto internalresolution = std::make_shared<OptionListComponent<std::string>>(mWindow, _("INTERNAL RESOLUTION"));
-		internalresolution->add(_("AUTO"), "auto",
-			SystemConf::getInstance()->get(configName + ".internalresolution") != "1" &&
-			SystemConf::getInstance()->get(configName + ".internalresolution") != "2" &&
-			SystemConf::getInstance()->get(configName + ".internalresolution") != "4" &&
-			SystemConf::getInstance()->get(configName + ".internalresolution") != "8" &&
-			SystemConf::getInstance()->get(configName + ".internalresolution") != "10");
-		internalresolution->add("1", "1", SystemConf::getInstance()->get(configName + ".internalresolution") == "1");
-		internalresolution->add("2", "2", SystemConf::getInstance()->get(configName + ".internalresolution") == "2");
-		internalresolution->add("4", "4", SystemConf::getInstance()->get(configName + ".internalresolution") == "4");
-		internalresolution->add("8", "8", SystemConf::getInstance()->get(configName + ".internalresolution") == "8");
-		internalresolution->add("10", "10", SystemConf::getInstance()->get(configName + ".internalresolution") == "10");
-			
+		internalresolution->add(_("AUTO"), "auto", curResol.empty() || curResol == "auto");
+		internalresolution->add("1:1", "0", curResol == "0");
+		internalresolution->add("x1", "1", curResol == "1");
+		internalresolution->add("x2", "2", curResol == "2");
+		internalresolution->add("x3", "3", curResol == "3");
+		internalresolution->add("x4", "4", curResol == "4");
+		internalresolution->add("x5", "5", curResol == "5");
+		internalresolution->add("x8", "8", curResol == "8");
+		internalresolution->add("x10", "10", curResol == "10");
+
+		if (!internalresolution->hasSelection())
+			internalresolution->selectFirstItem();
+
 		if (SystemData::es_features_loaded || (!SystemData::es_features_loaded && (systemData->getName() == "psp" || systemData->getName() == "wii" || systemData->getName() == "gamecube"))) // only for psp, wii, gamecube
 		{
 			systemConfiguration->addWithLabel(_("INTERNAL RESOLUTION"), internalresolution);

--- a/es-app/src/views/SystemView.cpp
+++ b/es-app/src/views/SystemView.cpp
@@ -489,8 +489,12 @@ void SystemView::onCursorChanged(const CursorState& /*state*/)
 			ss << "CONFIGURATION";
 		else 
 		{
-		  snprintf(strbuf, 256, ngettext("%i GAME AVAILABLE", "%i GAMES AVAILABLE", gameCount), gameCount);
-		  ss << strbuf;
+			if (getSelected()->hasPlatformId(PlatformIds::PLATFORM_IGNORE))
+				snprintf(strbuf, 256, ngettext("%i ITEM", "%i ITEMS", gameCount), gameCount);
+			else
+				snprintf(strbuf, 256, ngettext("%i GAME", "%i GAMES", gameCount), gameCount);
+
+			ss << strbuf;
 		}
 
 		mSystemInfo.setText(ss.str());

--- a/es-core/src/resources/TextureDataManager.cpp
+++ b/es-core/src/resources/TextureDataManager.cpp
@@ -98,6 +98,9 @@ std::shared_ptr<TextureData> TextureDataManager::get(const TextureResource* key,
 	{
 		tex = *(*it).second;
 
+		if (!enableLoading)
+			return tex;
+
 		if (mTextures.cbegin() != (*it).second)
 		{
 			// Remove the list entry

--- a/es-core/src/resources/TextureResource.cpp
+++ b/es-core/src/resources/TextureResource.cpp
@@ -198,8 +198,13 @@ std::shared_ptr<TextureResource> TextureResource::get(const std::string& path, b
 			std::shared_ptr<TextureResource> rc = foundTexture->second.lock();
 
 			if (maxSize != nullptr && !maxSize->empty() && Settings::getInstance()->getBool("OptimizeVRAM"))
-			{
-				auto dt = sTextureDataManager.get(rc.get());
+			{				
+				std::shared_ptr<TextureData> dt;
+				if (rc->mTextureData != nullptr)
+					dt = rc->mTextureData;
+				else
+					dt = sTextureDataManager.get(rc.get(), false);
+
 				if (dt != nullptr)
 				{
 					dt->setMaxSize(*maxSize);

--- a/es-core/src/utils/FileSystemUtil.cpp
+++ b/es-core/src/utils/FileSystemUtil.cpp
@@ -1111,15 +1111,20 @@ namespace Utils
 
 		void deleteDirectoryFiles(const std::string path)
 		{
+			std::vector<std::string> directories;
+
 			auto files = Utils::FileSystem::getDirContent(path, true, true);
 			std::reverse(std::begin(files), std::end(files));
 			for (auto file : files)
 			{
 				if (Utils::FileSystem::isDirectory(file))
-					rmdir(Utils::FileSystem::getPreferredPath(file).c_str());
+					directories.push_back(file);
 				else
 					Utils::FileSystem::removeFile(file);
 			}
+
+			for (auto file : directories)
+				rmdir(Utils::FileSystem::getPreferredPath(file).c_str());
 		}
 	} // FileSystem::
 

--- a/locale/lang/es/LC_MESSAGES/emulationstation2.po
+++ b/locale/lang/es/LC_MESSAGES/emulationstation2.po
@@ -1342,10 +1342,16 @@ msgid "DO YOU WANT TO START KODI MEDIA CENTER ?"
 msgstr "¿QUIERES INICIAR EL CENTRO MULTIMEDIA KODI?"
 
 #, c-format
-msgid "%i GAME AVAILABLE"
-msgid_plural "%i GAMES AVAILABLE"
-msgstr[0] "%i JUEGO DISPONIBLE"
-msgstr[1] "%i JUEGOS DISPONIBLES"
+msgid "%i GAME"
+msgid_plural "%i GAMES"
+msgstr[0] "%i JUEGO"
+msgstr[1] "%i JUEGOS"
+
+#, c-format
+msgid "%i ITEM"
+msgid_plural "%i ITEMS"
+msgstr[0] "%i ELEMENTO"
+msgstr[1] "%i ELEMENTOS"
 
 msgid "KODI"
 msgstr "KODI"

--- a/locale/lang/es_MX/LC_MESSAGES/emulationstation2.po
+++ b/locale/lang/es_MX/LC_MESSAGES/emulationstation2.po
@@ -1342,10 +1342,16 @@ msgid "DO YOU WANT TO START KODI MEDIA CENTER ?"
 msgstr "¿QUIERES INICIAR EL CENTRO MULTIMEDIA KODI?"
 
 #, c-format
-msgid "%i GAME AVAILABLE"
-msgid_plural "%i GAMES AVAILABLE"
-msgstr[0] "%i JUEGO DISPONIBLE"
-msgstr[1] "%i JUEGOS DISPONIBLES"
+msgid "%i GAME"
+msgid_plural "%i GAMES"
+msgstr[0] "%i JUEGO"
+msgstr[1] "%i JUEGOS"
+
+#, c-format
+msgid "%i ITEM"
+msgid_plural "%i ITEMS"
+msgstr[0] "%i ELEMENTO"
+msgstr[1] "%i ELEMENTOS"
 
 msgid "KODI"
 msgstr "KODI"

--- a/locale/lang/fr/LC_MESSAGES/emulationstation2.po
+++ b/locale/lang/fr/LC_MESSAGES/emulationstation2.po
@@ -1336,10 +1336,16 @@ msgid "DO YOU WANT TO START KODI MEDIA CENTER ?"
 msgstr "VOULEZ-VOUS LANCER KODI MEDIA CENTER ?"
 
 #, c-format
-msgid "%i GAME AVAILABLE"
-msgid_plural "%i GAMES AVAILABLE"
-msgstr[0] "%i JEU DISPONIBLE"
-msgstr[1] "%i JEUX DISPONIBLES"
+msgid "%i GAME"
+msgid_plural "%i GAMES"
+msgstr[0] "%i JEU"
+msgstr[1] "%i JEUX"
+
+#, c-format
+msgid "%i ITEM"
+msgid_plural "%i ITEMS"
+msgstr[0] "%i ELEMENT"
+msgstr[1] "%i ELEMENTS"
 
 msgid "KODI"
 msgstr "KODI"

--- a/locale/lang/it/LC_MESSAGES/emulationstation2.po
+++ b/locale/lang/it/LC_MESSAGES/emulationstation2.po
@@ -1340,10 +1340,16 @@ msgid "DO YOU WANT TO START KODI MEDIA CENTER ?"
 msgstr "VUOI ESEGUIRE KODI MEDIA CENTER?"
 
 #, c-format
-msgid "%i GAME AVAILABLE"
-msgid_plural "%i GAMES AVAILABLE"
-msgstr[0] "%i GIOCO DISPONIBILE"
-msgstr[1] "%i GIOCHI DISPONIBILI"
+msgid "%i GAME"
+msgid_plural "%i GAMES"
+msgstr[0] "%i GIOCO"
+msgstr[1] "%i GIOCHI"
+
+#, c-format
+msgid "%i ITEM"
+msgid_plural "%i ITEMS"
+msgstr[0] "%i ELEMENTO"
+msgstr[1] "%i ELEMENTI"
 
 msgid "KODI"
 msgstr "KODI"

--- a/locale/lang/pt_BR/LC_MESSAGES/emulationstation2.po
+++ b/locale/lang/pt_BR/LC_MESSAGES/emulationstation2.po
@@ -1341,10 +1341,16 @@ msgid "DO YOU WANT TO START KODI MEDIA CENTER ?"
 msgstr "DESEJA INICIAR O KODI MEDIA CENTER?"
 
 #, c-format
-msgid "%i GAME AVAILABLE"
-msgid_plural "%i GAMES AVAILABLE"
-msgstr[0] "%i JOGO DISPONÍVEL"
-msgstr[1] "%i JOGOS DISPONÍVEIS"
+msgid "%i GAME"
+msgid_plural "%i GAMES"
+msgstr[0] "%i JOGO"
+msgstr[1] "%i JOGOS"
+
+#, c-format
+msgid "%i ITEM"
+msgid_plural "%i ITEMS"
+msgstr[0] "%i ELEMENTO"
+msgstr[1] "%i ELEMENTOS"
 
 msgid "KODI"
 msgstr "KODI"

--- a/locale/lang/pt_PT/LC_MESSAGES/emulationstation2.po
+++ b/locale/lang/pt_PT/LC_MESSAGES/emulationstation2.po
@@ -1338,10 +1338,16 @@ msgid "DO YOU WANT TO START KODI MEDIA CENTER ?"
 msgstr "DESEJA INICIAR O KODI MEDIA CENTER?"
 
 #, c-format
-msgid "%i GAME AVAILABLE"
-msgid_plural "%i GAMES AVAILABLE"
-msgstr[0] "%i JOGO DISPONÍVEL"
-msgstr[1] "%i JOGOS DISPONÍVEIS"
+msgid "%i GAME"
+msgid_plural "%i GAMES"
+msgstr[0] "%i JOGO"
+msgstr[1] "%i JOGOS"
+
+#, c-format
+msgid "%i ITEM"
+msgid_plural "%i ITEMS"
+msgstr[0] "%i ELEMENTO"
+msgstr[1] "%i ELEMENTOS"
 
 msgid "KODI"
 msgstr "KODI"


### PR DESCRIPTION
- Replace "N GAMES AVAILABLE" with "N ITEMS" for systems with platform.ignore ( screenshots ) & removed the word "AVAILABLE"
- Fix TextureResource maxsize management 
 - Windows : Fix bezel installer 