### PR TITLE
bcm option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ option(GLES "Set to ON if targeting Embedded OpenGL" ${GLES})
 option(GL "Set to ON if targeting Desktop OpenGL" ${GL})
 option(RPI "Set to ON to enable the Raspberry PI video player (omxplayer)" ${RPI})
 option(CEC "CEC" ON)
+option(BCM "BCM host" OFF)
 
 # batocera
 option(ENABLE_FILEMANAGER "Set to ON to enable f1 shortcut for filesystem")
@@ -37,6 +38,10 @@ if(CEC)
   MESSAGE("CEC enabled")
 else()
   MESSAGE("CEC disabled")
+endif()
+
+if(BCM)
+    set(BCMHOST found)
 endif()
 
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
Add an option to force BCM (=rpi)
the option RPI is not set by batocera and seems to be only for the omx player. but i understand that even without this option set, the omx is enabled.

without this option, we get linker errors (i don't know why it didnt occured before)

Signed-off-by: Nicolas Adenis-Lamarre <nicolas.adenis.lamarre@gmail.com>