### PR TITLE
Fix : Potential crash when reloading a view

### DIFF
--- a/es-app/src/views/ViewController.cpp
+++ b/es-app/src/views/ViewController.cpp
@@ -613,7 +613,12 @@ void ViewController::reloadGameListView(IGameListView* view, bool reloadTheme, b
 		{
 			bool isCurrent = (mCurrentView == it->second);
 			SystemData* system = it->first;
+			
+			std::string cursorPath;
 			FileData* cursor = view->getCursor();
+			if (cursor != nullptr && !cursor->isPlaceHolder())
+				cursorPath = cursor->getPath();
+
 			mGameListViews.erase(it);
 
 			if(reloadTheme)
@@ -628,10 +633,22 @@ void ViewController::reloadGameListView(IGameListView* view, bool reloadTheme, b
 
 			std::shared_ptr<IGameListView> newView = getGameListView(system);
 			
-			// to counter having come from a placeholder
-			if (system->getName() != "recent" && cursor != nullptr && !cursor->isPlaceHolder())
-				newView->setCursor(cursor);
-			
+			if (!cursorPath.empty())
+			{
+				ISimpleGameListView* view = dynamic_cast<ISimpleGameListView*>(newView.get());
+				if (view != nullptr)
+				{					
+					for (auto file : view->getFileDataEntries())
+					{
+						if (file->getPath() == cursorPath)
+						{
+							newView->setCursor(file);
+							break;
+						}
+					}
+				}
+			}
+
 			if(isCurrent)
 				mCurrentView = newView;
 

--- a/es-app/src/views/gamelist/BasicGameListView.h
+++ b/es-app/src/views/gamelist/BasicGameListView.h
@@ -30,10 +30,9 @@ public:
 
 	virtual std::vector<HelpPrompt> getHelpPrompts() override;
 	virtual void launch(FileData* game) override;
-
-protected:
 	virtual std::vector<FileData*> getFileDataEntries() override;
 
+protected:
 	virtual std::string getQuickSystemSelectRightButton() override;
 	virtual std::string getQuickSystemSelectLeftButton() override;
 	virtual void populateList(const std::vector<FileData*>& files) override;

--- a/es-app/src/views/gamelist/GridGameListView.h
+++ b/es-app/src/views/gamelist/GridGameListView.h
@@ -40,9 +40,9 @@ public:
 
 	virtual void setThemeName(std::string name);
 	virtual void onShow();
+	virtual std::vector<FileData*> getFileDataEntries() override;
 
 protected:
-	virtual std::vector<FileData*> getFileDataEntries() override;
 	virtual std::string getQuickSystemSelectRightButton() override;
 	virtual std::string getQuickSystemSelectLeftButton() override;
 	virtual void populateList(const std::vector<FileData*>& files) override;

--- a/es-app/src/views/gamelist/ISimpleGameListView.h
+++ b/es-app/src/views/gamelist/ISimpleGameListView.h
@@ -31,12 +31,12 @@ public:
 	virtual void launch(FileData* game) = 0;
 	
 	virtual std::vector<std::string> getEntriesLetters() override;
+	virtual std::vector<FileData*> getFileDataEntries() = 0;
 
 protected:
 	FileData* getRandomGame();
 	void	  updateFolderPath();
 
-	virtual std::vector<FileData*> getFileDataEntries() = 0;
 	virtual std::string getQuickSystemSelectRightButton() = 0;
 	virtual std::string getQuickSystemSelectLeftButton() = 0;
 	virtual void populateList(const std::vector<FileData*>& files) = 0;


### PR DESCRIPTION
Can occur when the selected game is no more visible in the new ( filters, dynamic collections, show folders... )