### PR TITLE
Windows only : Controllers Guids have to be exact

### DIFF
--- a/es-app/src/Win32ApiSystem.cpp
+++ b/es-app/src/Win32ApiSystem.cpp
@@ -67,7 +67,9 @@ bool Win32ApiSystem::isScriptingSupported(ScriptId script)
 		executables.push_back("emulatorLauncher");
 		break;
 	case ApiSystem::BLUETOOTH:
+#if _DEBUG
 		executables.push_back("batocera-bluetooth");
+#endif
 		break;
 	case ApiSystem::RESOLUTION:
 		executables.push_back("batocera-resolution");

--- a/es-core/src/InputManager.cpp
+++ b/es-core/src/InputManager.cpp
@@ -380,21 +380,24 @@ bool InputManager::tryLoadInputConfig(std::string path, InputConfig* config, boo
 			// found a correct guid
 			found_guid = true; // no more need to check the name only
 			configNode = item;
-
+#if !WIN32
 			if (strcmp(config->getDeviceName().c_str(), item.attribute("deviceName").value()) == 0) {
 				// found the exact device
 				found_exact = true;
 				configNode = item;
 				break;
 			}
+#endif
 		}
 
+#if !WIN32
 		// check for a name if no guid is found
 		if (found_guid == false) {
 			if (strcmp(config->getDeviceName().c_str(), item.attribute("deviceName").value()) == 0) {
 				configNode = item;
 			}
 		}
+#endif
 	}
 
 	if (!configNode)
@@ -472,11 +475,11 @@ void InputManager::writeDeviceConfig(InputConfig* config)
 
 	pugi::xml_document doc;
 
-	if(Utils::FileSystem::exists(path))
+	if (Utils::FileSystem::exists(path))
 	{
 		// merge files
 		pugi::xml_parse_result result = doc.load_file(path.c_str());
-		if(!result)
+		if (!result)
 		{
 			LOG(LogError) << "Error parsing input config: " << result.description();
 		}
@@ -484,19 +487,24 @@ void InputManager::writeDeviceConfig(InputConfig* config)
 		{
 			// successfully loaded, delete the old entry if it exists
 			pugi::xml_node root = doc.child("inputList");
-			if(root)
+			if (root)
 			{
-			  // batocera
-			  pugi::xml_node oldEntry(NULL);
-			  for (pugi::xml_node item = root.child("inputConfig"); item; item = item.next_sibling("inputConfig")) {
-			    if(strcmp(config->getDeviceGUIDString().c_str(), item.attribute("deviceGUID").value()) == 0 &&
-			       strcmp(config->getDeviceName().c_str(),       item.attribute("deviceName").value()) == 0) {
-			      oldEntry = item;
-			      break;
-			    }
-			  }
-			  if(oldEntry)
-			    root.remove_child(oldEntry);
+				// batocera
+				pugi::xml_node oldEntry(NULL);
+				for (pugi::xml_node item = root.child("inputConfig"); item; item = item.next_sibling("inputConfig")) 
+				{
+					if (strcmp(config->getDeviceGUIDString().c_str(), item.attribute("deviceGUID").value()) == 0
+#if !WIN32
+						&& strcmp(config->getDeviceName().c_str(), item.attribute("deviceName").value()) == 0
+#endif
+						) 
+					{
+						oldEntry = item;
+						break;
+					}
+				}
+				if (oldEntry)
+					root.remove_child(oldEntry);
 			}
 		}
 	}

--- a/es-core/src/guis/GuiInputConfig.cpp
+++ b/es-core/src/guis/GuiInputConfig.cpp
@@ -16,7 +16,12 @@ struct InputConfigStructure
 	const char* icon;
 };
 
+#if !WIN32
 static const int inputCount = 21; // batocera
+#else
+static const int inputCount = 19; // windows
+#endif
+
 static const InputConfigStructure GUI_INPUT_CONFIG_LIST[inputCount] =
 {
   // batocera
@@ -26,8 +31,13 @@ static const InputConfigStructure GUI_INPUT_CONFIG_LIST[inputCount] =
   { "right",            false, "RIGHT",        ":/help/dpad_right.svg" },
   { "start",            true,  "START",              ":/help/button_start.svg" },
   { "select",           true,  "SELECT",             ":/help/button_select.svg" },
+#ifdef WIN32 // Invert icons on Windows : xbox controllers A/B are inverted
+  { "a",                false, "A",    ":/help/buttons_south.svg" },
+  { "b",                true,  "B",   ":/help/buttons_east.svg" },
+#else
   { "a",                false, "A",    ":/help/buttons_east.svg" },
   { "b",                true,  "B",   ":/help/buttons_south.svg" },
+#endif
   { "x",                true,  "X",   ":/help/buttons_north.svg" },
   { "y",                true,  "Y",    ":/help/buttons_west.svg" },
   //{ "LeftShoulder",     true,  "LEFT SHOULDER",      ":/help/button_l.svg" },
@@ -54,8 +64,10 @@ static const InputConfigStructure GUI_INPUT_CONFIG_LIST[inputCount] =
   { "pagedown",        true,  "R1",     ":/help/button_r.svg" },
   { "l2",              true,  "L2",       ":/help/button_lt.svg" },
   { "r2",              true,  "R2",      ":/help/button_rt.svg" },
+#if !WIN32
   { "l3",              true,  "L3",       ":/help/button_lt.svg" },
   { "r3",              true,  "R3",      ":/help/button_rt.svg" },
+#endif
   { "hotkey",          true,  "HOTKEY",      ":/help/button_hotkey.svg" } // batocera
 };
 


### PR DESCRIPTION
- Disable approximations based on name -> XInput compatible controllers can have the same name, but differents Guids.