### PR TITLE
 Fix : Selection returning to root folder after launching a game from a subfolder

### DIFF
--- a/es-app/src/Gamelist.cpp
+++ b/es-app/src/Gamelist.cpp
@@ -38,7 +38,7 @@ FileData* findOrCreateFile(SystemData* system, const std::string& path, FileType
 		return NULL;
 	}
 
-	Utils::FileSystem::stringList pathList = Utils::FileSystem::getPathList(relative);
+	auto pathList = Utils::FileSystem::getPathList(relative);
 	auto path_it = pathList.begin();
 	FolderData* treeNode = root;
 

--- a/es-app/src/views/ViewController.cpp
+++ b/es-app/src/views/ViewController.cpp
@@ -688,7 +688,7 @@ void ViewController::reloadGameListView(IGameListView* view, bool reloadTheme)
 			{
 				if (!cursorPath.empty())
 				{
-					for (auto file : view->getFileDataEntries())
+					for (auto file : system->getRootFolder()->getFilesRecursive(GAME, true))
 					{
 						if (file->getPath() == cursorPath)
 						{

--- a/es-core/src/utils/FileSystemUtil.h
+++ b/es-core/src/utils/FileSystemUtil.h
@@ -4,6 +4,7 @@
 
 #include <list>
 #include <string>
+#include <vector>
 #include "utils/TimeUtil.h"
 
 namespace Utils
@@ -11,9 +12,9 @@ namespace Utils
 	namespace FileSystem
 	{
 		typedef std::list<std::string> stringList;
-
+		
 		stringList  getDirContent      (const std::string& _path, const bool _recursive = false, const bool includeHidden = false);
-		stringList  getPathList        (const std::string& _path);
+		std::vector<std::string>  getPathList        (const std::string& _path);
 		std::string getHomePath        ();
 		std::string getCWDPath         ();
 		std::string getExePath         ();


### PR DESCRIPTION
++ Windows only : createRelativePath not always working relative to %HOME%, making custom collections using non relative paths.