### PR TITLE
Fix : GridView compatibility with retropie was broken with some themes.

### DIFF
--- a/es-core/src/InputManager.cpp
+++ b/es-core/src/InputManager.cpp
@@ -380,7 +380,10 @@ bool InputManager::tryLoadInputConfig(std::string path, InputConfig* config, boo
 			// found a correct guid
 			found_guid = true; // no more need to check the name only
 			configNode = item;
-#if !WIN32
+#if WIN32
+			found_exact = true;
+			break;
+#else
 			if (strcmp(config->getDeviceName().c_str(), item.attribute("deviceName").value()) == 0) {
 				// found the exact device
 				found_exact = true;
@@ -422,7 +425,7 @@ bool InputManager::loadInputConfig(InputConfig* config)
 
 #if WIN32
 	// Find exact device
-	if (tryLoadInputConfig(path, config, true))
+	if (tryLoadInputConfig(path, config, false))
 		return true;
 #else
 	// Find exact device

--- a/es-core/src/ThemeData.cpp
+++ b/es-core/src/ThemeData.cpp
@@ -1030,6 +1030,8 @@ void ThemeData::parseElement(const pugi::xml_node& root, const std::map<std::str
 			// Exception for menuIcons that can be extended
 			if (element.type == "menuIcons")
 				type = PATH;
+			else if (std::string(node.name()) == "animate" && std::string(root.name()) == "imagegrid")
+				node.set_name("animateSelection");
 			else
 			{
 				LOG(LogWarning) << "Unknown property type \"" << node.name() << "\" (for element of type " << root.name() << ").";

--- a/es-core/src/components/GridTileComponent.cpp
+++ b/es-core/src/components/GridTileComponent.cpp
@@ -446,7 +446,7 @@ void GridTileComponent::applyThemeToProperties(const ThemeData::ThemeElement* el
 
 	// Retrocompatibility for Background properties
 	if (elem->has("backgroundImage"))
-		properties.Background.path = elem->get<std::string>("backgroundImage");
+		properties.Background.setImagePath(elem->get<std::string>("backgroundImage"));
 
 	if (elem->has("backgroundCornerSize"))
 		properties.Background.cornerSize = elem->get<Vector2f>("backgroundCornerSize");

--- a/es-core/src/components/GridTileComponent.cpp
+++ b/es-core/src/components/GridTileComponent.cpp
@@ -952,7 +952,10 @@ void GridTileComponent::setSelected(bool selected, bool allowAnimation, Vector3f
 	mSelected = selected;
 
 	if (!mSelected)
+	{
+		mBackground.setAnimateTiming(0);
 		stopVideo();
+	}
 
 	if (selected)
 	{

--- a/es-core/src/components/GridTileComponent.h
+++ b/es-core/src/components/GridTileComponent.h
@@ -6,6 +6,7 @@
 #include "ImageComponent.h"
 #include "TextComponent.h"
 #include "ThemeData.h"
+#include "resources/TextureResource.h"
 
 class VideoComponent;
 
@@ -132,9 +133,14 @@ public:
 		cornerSize = Vector2f(16, 16);
 		path = ":/frame.png";
 		animateTime = 0;
+		mTexture = TextureResource::get(path, false, true);
 	}
 
-
+	void setImagePath(const std::string _path)
+	{
+		path = _path;
+		mTexture = TextureResource::get(path, false, true);
+	}
 
 	bool applyTheme(const ThemeData::ThemeElement* elem);
 
@@ -151,8 +157,6 @@ public:
 		ctl->setImagePath(path);
 	}
 
-
-
 	bool Loaded;
 	bool Visible;
 
@@ -163,6 +167,9 @@ public:
 
 	unsigned int animateColor;
 	float animateTime;
+
+	// Store texture to avoid unloading & flickering
+	std::shared_ptr<TextureResource> mTexture;
 };
 
 struct GridTileProperties

--- a/es-core/src/components/ImageGridComponent.h
+++ b/es-core/src/components/ImageGridComponent.h
@@ -401,9 +401,7 @@ void ImageGridComponent<T>::render(const Transform4x4f& parentTrans)
 
 	bool splittedRendering = (mAnimateSelection && mAutoLayout.x() != 0);
 
-	bool shouldClip = mAutoLayout != Vector2f::Zero();
-	if (shouldClip)
-		Renderer::pushClipRect(pos, size);
+	Renderer::pushClipRect(pos, size);
 
 	// Render the selected image background on bottom of the others if needed
 	std::shared_ptr<GridTileComponent> selectedTile = NULL;
@@ -436,9 +434,8 @@ void ImageGridComponent<T>::render(const Transform4x4f& parentTrans)
 		else 
 			selectedTile->render(tileTrans);
 	}
-
-	if (shouldClip)
-		Renderer::popClipRect();
+	
+	Renderer::popClipRect();
 
 	listRenderTitleOverlay(trans);
 	GuiComponent::renderChildren(trans);

--- a/es-core/src/components/ImageGridComponent.h
+++ b/es-core/src/components/ImageGridComponent.h
@@ -401,6 +401,9 @@ void ImageGridComponent<T>::render(const Transform4x4f& parentTrans)
 
 	bool splittedRendering = (mAnimateSelection && mAutoLayout.x() != 0);
 
+	if (mAutoLayout == Vector2f::Zero() && mLastRowPartial) // If the last row is partial in Retropie, extend clip to show the entire last row 
+		size.y() = (mTileSize + mMargin).y() * (mGridDimension.y() - 2 * EXTRAITEMS);
+
 	Renderer::pushClipRect(pos, size);
 
 	// Render the selected image background on bottom of the others if needed
@@ -1044,7 +1047,7 @@ void ImageGridComponent<T>::calcGridDimension()
 		gridDimension = mAutoLayout;
 
 	mLastRowPartial = Math::floorf(gridDimension.y()) != gridDimension.y();
-	mGridDimension = Vector2i((int) gridDimension.x(), (int) gridDimension.y());
+	mGridDimension = Vector2i((int) gridDimension.x(), Math::ceilf(gridDimension.y()));
 
 	// Grid dimension validation
 	if (mGridDimension.x() < 1)

--- a/es-core/src/components/NinePatchComponent.cpp
+++ b/es-core/src/components/NinePatchComponent.cpp
@@ -141,7 +141,8 @@ void NinePatchComponent::render(const Transform4x4f& parentTrans)
 	if (!Renderer::isVisibleOnScreen(trans.translation().x(), trans.translation().y(), mSize.x(), mSize.y()))
 		return;
 
-	if (mCornerSize.x() <= 1 && mCornerSize.y() <= 1 && mCornerSize.x() == mCornerSize.y())
+	// Apply cornersize < 0 only with default ":/frame.png" image, not with customized ones
+	if (mCornerSize.x() <= 1 && mCornerSize.y() <= 1 && mCornerSize.x() == mCornerSize.y() && mPath == ":/frame.png")
 	{
 		float opacity = mOpacity / 255.0;
 

--- a/es-core/src/guis/GuiInputConfig.cpp
+++ b/es-core/src/guis/GuiInputConfig.cpp
@@ -16,11 +16,7 @@ struct InputConfigStructure
 	const char* icon;
 };
 
-#if !WIN32
 static const int inputCount = 21; // batocera
-#else
-static const int inputCount = 19; // windows
-#endif
 
 static const InputConfigStructure GUI_INPUT_CONFIG_LIST[inputCount] =
 {
@@ -64,10 +60,8 @@ static const InputConfigStructure GUI_INPUT_CONFIG_LIST[inputCount] =
   { "pagedown",        true,  "R1",     ":/help/button_r.svg" },
   { "l2",              true,  "L2",       ":/help/button_lt.svg" },
   { "r2",              true,  "R2",      ":/help/button_rt.svg" },
-#if !WIN32
   { "l3",              true,  "L3",       ":/help/button_lt.svg" },
   { "r3",              true,  "R3",      ":/help/button_rt.svg" },
-#endif
   { "hotkey",          true,  "HOTKEY",      ":/help/button_hotkey.svg" } // batocera
 };
 


### PR DESCRIPTION
+ White background when custom backgroundImage was defined and backgroundCornerSize was set at 0 on tiles 
+ clipping issue on Retropie gridviews using autolayout.