### PR TITLE
Removed RetroAchievement avatar on small screens

### DIFF
--- a/es-app/src/guis/GuiRetroAchievements.cpp
+++ b/es-app/src/guis/GuiRetroAchievements.cpp
@@ -35,7 +35,7 @@ GuiRetroAchievements::GuiRetroAchievements(Window* window, RetroAchievementInfo 
 		return;
 	}
 
-	if (!ra.userpic.empty() && Utils::FileSystem::exists(ra.userpic))
+	if (!ra.userpic.empty() && Utils::FileSystem::exists(ra.userpic) && !Renderer::isSmallScreen())
 	{
 		auto image = std::make_shared<ImageComponent>(mWindow);
 		image->setImage(ra.userpic);


### PR DESCRIPTION
Only the very bottom of a `TitleIcon` is displayed, and it feels like wasted real estate on small screens like OGA