### PR TITLE
Fix gcc10 compilation (C++ std::string missing header)

### DIFF
--- a/es-app/src/FileFilterIndex.h
+++ b/es-app/src/FileFilterIndex.h
@@ -5,6 +5,7 @@
 #include <map>
 #include <vector>
 #include <unordered_set>
+#include <string>
 
 class FileData;
 class SystemData;

--- a/es-app/src/Gamelist.h
+++ b/es-app/src/Gamelist.h
@@ -4,6 +4,7 @@
 
 #include <unordered_map>
 #include <vector>
+#include <string>
 
 class SystemData;
 class FileData;

--- a/es-app/src/MetaData.h
+++ b/es-app/src/MetaData.h
@@ -5,6 +5,7 @@
 #include <map>
 #include <vector>
 #include <functional>
+#include <string>
 
 class SystemData;
 

--- a/es-core/src/Settings.h
+++ b/es-core/src/Settings.h
@@ -3,6 +3,7 @@
 #define ES_CORE_SETTINGS_H
 
 #include <map>
+#include <string>
 
 //This is a singleton for storing settings.
 class Settings

--- a/es-core/src/Sound.h
+++ b/es-core/src/Sound.h
@@ -5,6 +5,7 @@
 #include "SDL_mixer.h"
 #include <map>
 #include <memory>
+#include <string>
 
 class ThemeData;
 


### PR DESCRIPTION
Compiles both with GCC 9.3 and GCC 10.1