### PR TITLE
Misc fixes & enhancements

### DIFF
--- a/es-app/src/FileData.h
+++ b/es-app/src/FileData.h
@@ -87,7 +87,7 @@ public:
 
 	inline bool isPlaceHolder() { return mType == PLACEHOLDER; };
 
-	virtual inline void refreshMetadata() { return; };
+	virtual inline void refreshMetadata() { };
 
 	virtual std::string getKey();
 	const bool isArcadeAsset();
@@ -116,6 +116,8 @@ public:
 	void setMetadata(const std::string& key, const std::string& value) { getMetadata().set(key, value); }
 
 	void detectLanguageAndRegion(bool overWrite);
+
+	void deleteGameFiles();
 
 private:
 	MetaDataList mMetadata;

--- a/es-app/src/MetaData.cpp
+++ b/es-app/src/MetaData.cpp
@@ -201,7 +201,7 @@ void MetaDataList::set(MetaDataId id, const std::string& value)
 	if (prev != mMap.cend() && prev->second == value)
 		return;
 
-	if (getType(id) == MD_PATH && mRelativeTo != nullptr) // if it's a path, resolve relative paths				
+	if (mGameTypeMap[id] == MD_PATH && mRelativeTo != nullptr) // if it's a path, resolve relative paths				
 		mMap[id] = Utils::FileSystem::createRelativePath(value, mRelativeTo->getStartPath(), true);
 	else
 		mMap[id] = Utils::String::trim(value);
@@ -222,7 +222,7 @@ const std::string MetaDataList::get(MetaDataId id, bool resolveRelativePaths) co
 	auto it = mMap.find(id);
 	if (it != mMap.end())
 	{
-		if (resolveRelativePaths && getType(id) == MD_PATH && mRelativeTo != nullptr) // if it's a path, resolve relative paths				
+		if (resolveRelativePaths && mGameTypeMap[id] == MD_PATH && mRelativeTo != nullptr) // if it's a path, resolve relative paths				
 			return Utils::FileSystem::resolveRelativePath(it->second, mRelativeTo->getStartPath(), true);
 
 		return it->second;

--- a/es-app/src/MetaData.h
+++ b/es-app/src/MetaData.h
@@ -133,6 +133,8 @@ public:
 	int getInt(const std::string& key) const;
 	float getFloat(const std::string& key) const;
 
+	MetaDataType getType(MetaDataId id) const;
+
 	bool wasChanged() const;
 	void resetChangedFlag();
 	const void setDirty() 
@@ -154,7 +156,7 @@ private:
 	bool mWasChanged;
 	SystemData*		mRelativeTo;
 
-	inline MetaDataType getType(MetaDataId id) const;
+
 	inline MetaDataId getId(const std::string& key) const;
 
 	static std::vector<MetaDataDecl> mMetaDataDecls;

--- a/es-app/src/guis/GuiCollectionSystemsOptions.cpp
+++ b/es-app/src/guis/GuiCollectionSystemsOptions.cpp
@@ -164,7 +164,14 @@ void GuiCollectionSystemsOptions::initializeMenu()
 	addSaveFunc([this, toggleSystemNameInCollections]
 	{
 		if (Settings::getInstance()->setBool("CollectionShowSystemInfo", toggleSystemNameInCollections->getState()))
+		{
+			for (auto sys : SystemData::sSystemVector)
+				for (auto file : sys->getRootFolder()->getFilesRecursive(GAME, false))
+					file->refreshMetadata();
+
+			FileData::resetSettings();
 			setVariable("reloadAll", true);
+		}
 	});
 
 #if defined(WIN32) && !defined(_DEBUG)		

--- a/es-app/src/guis/GuiGamelistOptions.cpp
+++ b/es-app/src/guis/GuiGamelistOptions.cpp
@@ -463,8 +463,13 @@ void GuiGamelistOptions::openMetaDataEd()
 	{
 		deleteBtnFunc = [this, file, system]
 		{
+			auto pThis = this;
+
 			CollectionSystemManager::get()->deleteCollectionFiles(file);
-			ViewController::get()->getGameListView(system).get()->remove(file, true);
+			file->deleteGameFiles();
+			ViewController::get()->getGameListView(system).get()->remove(file);
+
+			delete pThis;
 		};
 	}
 

--- a/es-app/src/guis/GuiMetaDataEd.cpp
+++ b/es-app/src/guis/GuiMetaDataEd.cpp
@@ -251,7 +251,6 @@ GuiMetaDataEd::GuiMetaDataEd(Window* window, MetaDataList* md, const std::vector
 		buttons.push_back(std::make_shared<ButtonComponent>(mWindow, _("SCRAPE"), _("SCRAPE"), std::bind(&GuiMetaDataEd::fetch, this)));
 
 	buttons.push_back(std::make_shared<ButtonComponent>(mWindow, _("SAVE"), _("SAVE"), [&] { save(); delete this; }));
-	buttons.push_back(std::make_shared<ButtonComponent>(mWindow, _("CANCEL"), _("CANCEL"), [&] { delete this; }));
 
 	if(mDeleteFunc)
 	{
@@ -259,6 +258,8 @@ GuiMetaDataEd::GuiMetaDataEd(Window* window, MetaDataList* md, const std::vector
 		auto deleteBtnFunc = [this, deleteFileAndSelf] { mWindow->pushGui(new GuiMsgBox(mWindow, _("THIS WILL DELETE THE ACTUAL GAME FILE(S)!\nARE YOU SURE?"), _("YES"), deleteFileAndSelf, _("NO"), nullptr)); };
 		buttons.push_back(std::make_shared<ButtonComponent>(mWindow, _("DELETE"), _("DELETE"), deleteBtnFunc));
 	}
+
+	buttons.push_back(std::make_shared<ButtonComponent>(mWindow, _("CANCEL"), _("CANCEL"), [&] { delete this; }));
 
 	mButtons = makeButtonGrid(mWindow, buttons);
 	mGrid.setEntry(mButtons, Vector2i(0, 2), true, false);

--- a/es-app/src/views/SystemView.cpp
+++ b/es-app/src/views/SystemView.cpp
@@ -419,14 +419,13 @@ bool SystemView::input(InputConfig* config, Input input)
 			setCursor(SystemData::getRandomSystem());
 			return true;
 		}
-#ifndef WIN32
+
 		// batocera
 		if(config->isMappedTo("select", input))
 		{
 			GuiMenu::openQuitMenu_batocera_static(mWindow, true);        
 			return true;
 		}
-#endif
 
 	}else{
 		if(config->isMappedLike("left", input) ||
@@ -438,7 +437,7 @@ bool SystemView::input(InputConfig* config, Input input)
 			config->isMappedLike("l2", input) ||
 			config->isMappedLike("r2", input))
 			listInput(0);
-
+		/*
 #ifdef WIN32
 		// batocera
 		if(!UIModeController::getInstance()->isUIModeKid() && config->isMappedTo("select", input) && Settings::getInstance()->getBool("ScreenSaverControls"))
@@ -447,7 +446,7 @@ bool SystemView::input(InputConfig* config, Input input)
 			mWindow->renderScreenSaver();
 			return true;
 		}
-#endif
+#endif*/
 	}
 
 	return GuiComponent::input(config, input);

--- a/es-app/src/views/ViewController.cpp
+++ b/es-app/src/views/ViewController.cpp
@@ -41,6 +41,7 @@ ViewController::ViewController(Window* window)
 {
 	mSystemListView = nullptr;
 	mState.viewing = NOTHING;
+	mDeferPlayViewTransition = false;
 }
 
 ViewController::~ViewController()
@@ -231,7 +232,13 @@ void ViewController::goToGameList(SystemData* system, bool forceImmediate)
 	if (AudioManager::isInitialized())
 		AudioManager::getInstance()->changePlaylist(system->getTheme());
 
-	playViewTransition(forceImmediate);
+	if (forceImmediate)
+		playViewTransition(forceImmediate);
+	else
+	{
+		cancelAnimation(0);
+		mDeferPlayViewTransition = true;
+	}
 }
 
 void ViewController::playViewTransition(bool forceImmediate)
@@ -614,12 +621,16 @@ bool ViewController::input(InputConfig* config, Input input)
 
 void ViewController::update(int deltaTime)
 {
-	if(mCurrentView)
-	{
+	if (mCurrentView)
 		mCurrentView->update(deltaTime);
-	}
 
 	updateSelf(deltaTime);
+
+	if (mDeferPlayViewTransition)
+	{
+		mDeferPlayViewTransition = false;
+		mWindow->postToUiThread([this](Window* w) { playViewTransition(false); });
+	}
 }
 
 void ViewController::render(const Transform4x4f& parentTrans)
@@ -703,6 +714,9 @@ void ViewController::preload()
 
 void ViewController::reloadGameListView(IGameListView* view, bool reloadTheme)
 {
+	if (view == nullptr)
+		return;
+
 	if (reloadTheme)
 		ThemeData::setDefaultTheme(nullptr);
 

--- a/es-app/src/views/ViewController.h
+++ b/es-app/src/views/ViewController.h
@@ -112,7 +112,7 @@ private:
 	Transform4x4f mCamera;
 	float mFadeOpacity;
 	bool mLockInput;
-
+	bool	mDeferPlayViewTransition;
 	State mState;
 };
 

--- a/es-app/src/views/gamelist/BasicGameListView.cpp
+++ b/es-app/src/views/gamelist/BasicGameListView.cpp
@@ -206,31 +206,24 @@ void BasicGameListView::launch(FileData* game)
 	ViewController::get()->launch(game);
 }
 
-void BasicGameListView::remove(FileData *game, bool deleteFile)
+void BasicGameListView::remove(FileData *game)
 {
-	if (deleteFile)
-		Utils::FileSystem::removeFile(game->getPath());  // actually delete the file on the filesystem
 	FolderData* parent = game->getParent();
 	if (getCursor() == game)                     // Select next element in list, or prev if none
 	{
-		std::vector<FileData*> siblings = parent->getChildrenListToDisplay();
-		auto gameIter = std::find(siblings.cbegin(), siblings.cend(), game);
-		unsigned int gamePos = (int)std::distance(siblings.cbegin(), gameIter);
-		if (gameIter != siblings.cend())
-		{
-			if ((gamePos + 1) < siblings.size())
-			{
-				setCursor(siblings.at(gamePos + 1));
-			} else if (gamePos > 1) {
-				setCursor(siblings.at(gamePos - 1));
-			}
-		}
+		std::vector<FileData*> siblings = mList.getObjects();
+
+		int gamePos = getCursorIndex();
+		if ((gamePos + 1) < (int)siblings.size())
+			setCursor(siblings.at(gamePos + 1));
+		else if ((gamePos - 1) > 0)
+			setCursor(siblings.at(gamePos - 1));
 	}
+
 	mList.remove(game);
 	if(mList.size() == 0)
-	{
 		addPlaceholder();
-	}
+
 	delete game;                                 // remove before repopulating (removes from parent)
 	onFileChanged(parent, FILE_REMOVED);           // update the view, with game removed
 }

--- a/es-app/src/views/gamelist/BasicGameListView.h
+++ b/es-app/src/views/gamelist/BasicGameListView.h
@@ -36,7 +36,7 @@ protected:
 	virtual std::string getQuickSystemSelectRightButton() override;
 	virtual std::string getQuickSystemSelectLeftButton() override;
 	virtual void populateList(const std::vector<FileData*>& files) override;
-	virtual void remove(FileData* game, bool deleteFile) override;
+	virtual void remove(FileData* game) override;
 	virtual void addPlaceholder();
 
 	TextListComponent<FileData*> mList;

--- a/es-app/src/views/gamelist/GridGameListView.cpp
+++ b/es-app/src/views/gamelist/GridGameListView.cpp
@@ -292,32 +292,24 @@ void GridGameListView::launch(FileData* game)
 	ViewController::get()->launch(game);
 }
 
-void GridGameListView::remove(FileData *game, bool deleteFile)
+void GridGameListView::remove(FileData *game)
 {
-	if (deleteFile)
-		Utils::FileSystem::removeFile(game->getPath());  // actually delete the file on the filesystem
-
 	FolderData* parent = game->getParent();
 	if (getCursor() == game)                     // Select next element in list, or prev if none
-	{
-		std::vector<FileData*> siblings = parent->getChildrenListToDisplay();
-		auto gameIter = std::find(siblings.cbegin(), siblings.cend(), game);
-		int gamePos = (int)std::distance(siblings.cbegin(), gameIter);
-		if (gameIter != siblings.cend())
-		{
-			if ((gamePos + 1) < (int)siblings.size())
-			{
-				setCursor(siblings.at(gamePos + 1));
-			} else if ((gamePos - 1) > 0) {
-				setCursor(siblings.at(gamePos - 1));
-			}
-		}
+	{		
+		std::vector<FileData*> siblings = mGrid.getObjects();
+
+		int gamePos = getCursorIndex();
+		if ((gamePos + 1) < (int)siblings.size())
+			setCursor(siblings.at(gamePos + 1));
+		else if ((gamePos - 1) > 0)
+			setCursor(siblings.at(gamePos - 1));			
 	}
+
 	mGrid.remove(game);
 	if(mGrid.size() == 0)
-	{
 		addPlaceholder();
-	}
+
 	delete game;                                 // remove before repopulating (removes from parent)
 	onFileChanged(parent, FILE_REMOVED);           // update the view, with game removed
 }

--- a/es-app/src/views/gamelist/GridGameListView.h
+++ b/es-app/src/views/gamelist/GridGameListView.h
@@ -46,7 +46,7 @@ protected:
 	virtual std::string getQuickSystemSelectRightButton() override;
 	virtual std::string getQuickSystemSelectLeftButton() override;
 	virtual void populateList(const std::vector<FileData*>& files) override;
-	virtual void remove(FileData* game, bool deleteFile) override;
+	virtual void remove(FileData* game) override;
 	virtual void addPlaceholder();
 
 	ImageGridComponent<FileData*> mGrid;

--- a/es-app/src/views/gamelist/IGameListView.h
+++ b/es-app/src/views/gamelist/IGameListView.h
@@ -33,7 +33,7 @@ public:
 	virtual void setCursor(FileData*) = 0;
 
 	virtual bool input(InputConfig* config, Input input) override;
-	virtual void remove(FileData* game, bool deleteFile) = 0;
+	virtual void remove(FileData* game) = 0;
 
 	virtual const char* getName() const = 0;
 	virtual void launch(FileData* game) = 0;

--- a/es-core/src/ImageIO.cpp
+++ b/es-core/src/ImageIO.cpp
@@ -276,7 +276,7 @@ void ImageIO::saveImageCache()
 		if (it.second.size < 0)
 			continue;
 
-		if (it.first.find("/themes/") != std::string::npos)
+		if (it.first.find("/themes/") != std::string::npos || it.first.find("/tmp/") != std::string::npos || it.first.find("/pdftmp/") != std::string::npos)
 			continue;
 
 		std::string path = Utils::FileSystem::createRelativePath(it.first, "_path_", true);
@@ -322,7 +322,7 @@ void ImageIO::updateImageCache(const std::string fn, int sz, int x, int y)
 			item.y = y;
 			item.size = sz;
 
-			if (sz > 0 && x > 0 && fn.find("/themes/") == std::string::npos)
+			if (sz > 0 && x > 0 && fn.find("/themes/") == std::string::npos && fn.find("/tmp/") == std::string::npos && fn.find("/pdftmp/") == std::string::npos)
 				sizeCacheDirty = true;
 		}
 	}
@@ -330,7 +330,7 @@ void ImageIO::updateImageCache(const std::string fn, int sz, int x, int y)
 	{
 		sizeCache[fn] = CachedFileInfo(sz, x, y);
 
-		if (sz > 0 && x > 0 && fn.find("/themes/") == std::string::npos)
+		if (sz > 0 && x > 0 && fn.find("/themes/") == std::string::npos && fn.find("/tmp/") == std::string::npos && fn.find("/pdftmp/") == std::string::npos)
 			sizeCacheDirty = true;
 	}
 }
@@ -364,7 +364,12 @@ bool ImageIO::loadImageSize(const char *fn, unsigned int *x, unsigned int *y)
 
 	auto size = Utils::FileSystem::getFileSize(fn);
 
+#if WIN32
+	FILE *f = _fsopen(fn, "rb", _SH_DENYNO);
+#else
 	FILE *f = fopen(fn, "rb");
+#endif
+
 	if (f == 0)
 	{
 		LOG(LogWarning) << "ImageIO::loadImageSize\tUnable to open file";

--- a/es-core/src/Window.cpp
+++ b/es-core/src/Window.cpp
@@ -783,7 +783,7 @@ void Window::renderRegisteredNotificationComponents(const Transform4x4f& trans)
 }
 
 void Window::postToUiThread(const std::function<void(Window*)>& func)
-{
+{	
 	std::unique_lock<std::mutex> lock(mNotificationMessagesLock);
 
 	mFunctions.push_back(func);	


### PR DESCRIPTION
- Add manual icon + Renamed "QUIT" (select) menu to QUICK ACCESS.
- Defer gamelist animation to make sure they always play. (Sometimes they did not due to loading time) 
- Refactored Game Deletion + Deleting a game now removes the associated medias.
- Some Performance improvements for collections.
- Fix SHOW SYSTEM NAME IN COLLECTIONS switch
- Fix imagecache saving pdftmp & tmp files metadatas.
