### PR TITLE
Redesigned OnScreen Keyboard + Quick search on systemView

### DIFF
--- a/es-app/src/ApiSystem.cpp
+++ b/es-app/src/ApiSystem.cpp
@@ -275,7 +275,10 @@ std::pair<std::string, int> ApiSystem::scrape(BusyComponent* ui)
 
 bool ApiSystem::ping() 
 {
-	return executeScript("timeout 1 ping -c 1 -t 1000 google.com");
+	if (!executeScript("timeout 1 ping -c 1 -t 1000 8.8.8.8")) // ping Google DNS
+		return executeScript("timeout 2 ping -c 1 -t 2000 8.8.4.4"); // ping Google secondary DNS & give 2 seconds
+
+	return true;
 }
 
 bool ApiSystem::canUpdate(std::vector<std::string>& output) 

--- a/es-app/src/SystemData.cpp
+++ b/es-app/src/SystemData.cpp
@@ -1205,13 +1205,14 @@ std::string SystemData::getGamelistPath(bool forWrite) const
 	if(Utils::FileSystem::exists(filePath))
 		return filePath;
 
-	//filePath = "/userdata/system/configs/emulationstation/gamelists/" + mName + "/gamelist.xml"; // batocera
-	if(forWrite) // make sure the directory exists if we're going to write to it, or crashes will happen
-		Utils::FileSystem::createDirectory(Utils::FileSystem::getParent(filePath));
-	if(forWrite || Utils::FileSystem::exists(filePath))
-		return filePath;
+	std::string localPath = Utils::FileSystem::getEsConfigPath() + "/gamelists/" + mMetadata.name + "/gamelist.xml";
+	if (Utils::FileSystem::exists(localPath))
+		return localPath;
 
-	return "/etc/emulationstation/gamelists/" + mMetadata.name + "/gamelist.xml";
+	if (forWrite)
+		Utils::FileSystem::createDirectory(Utils::FileSystem::getParent(filePath));
+	
+	return filePath;
 }
 
 std::string SystemData::getThemePath() const
@@ -1222,11 +1223,14 @@ std::string SystemData::getThemePath() const
 	// 3. default system theme from currently selected theme set [CURRENT_THEME_PATH]/theme.xml
 
 	// first, check game folder
-	/*
-	std::string localThemePath = mRootFolder->getPath() + "/theme.xml";
-	if(Utils::FileSystem::exists(localThemePath))
-		return localThemePath;
-		*/
+	
+	if (!mEnvData->mStartPath.empty())
+	{
+		std::string rootThemePath = mRootFolder->getPath() + "/theme.xml";
+		if (Utils::FileSystem::exists(rootThemePath))
+			return rootThemePath;
+	}
+
 	// not in game folder, try system theme in theme sets
 	std::string localThemePath = ThemeData::getThemeFromCurrentSet(mMetadata.themeFolder);
 	if (Utils::FileSystem::exists(localThemePath))

--- a/es-app/src/Win32ApiSystem.cpp
+++ b/es-app/src/Win32ApiSystem.cpp
@@ -22,6 +22,9 @@
 #define VERSIONURL "https://github.com/fabricecaruso/batocera-emulationstation/releases/download/continuous-stable/version.info"
 #define UPDATEURL  "https://github.com/fabricecaruso/batocera-emulationstation/releases/download/continuous-stable/EmulationStation-Win32.zip"
 
+#define LAUNCHERURL "https://github.com/fabricecaruso/batocera-ports/releases/download/continuous/batocera-ports.zip"
+
+
 std::string getUrlFromUpdateType(std::string url)
 {
 	std::string updatesType = Settings::getInstance()->getString("updates.type");
@@ -895,10 +898,83 @@ std::pair<std::string, int> Win32ApiSystem::updateSystem(const std::function<voi
 
 		Utils::FileSystem::deleteDirectoryFiles(path);
 
+		updateEmulatorLauncher(func);
+
 		return std::pair<std::string, int>("done.", 0);
 	}
 
 	return std::pair<std::string, int>("done.", 0);
+}
+
+void Win32ApiSystem::updateEmulatorLauncher(const std::function<void(const std::string)>& func)
+{
+	std::string updatesType = Settings::getInstance()->getString("updates.type");
+	if (updatesType != "beta")
+		return;
+
+	// Check emulatorLauncher exists
+	std::string emulatorLauncherPath = Utils::FileSystem::getExePath() + "/emulatorLauncher.exe";
+	if (!Utils::FileSystem::exists(emulatorLauncherPath))
+		emulatorLauncherPath = Utils::FileSystem::getEsConfigPath() + "/emulatorLauncher.exe";
+	if (!Utils::FileSystem::exists(emulatorLauncherPath))
+		emulatorLauncherPath = Utils::FileSystem::getParent(Utils::FileSystem::getEsConfigPath()) + "/emulatorLauncher.exe";
+	
+	if (!Utils::FileSystem::exists(emulatorLauncherPath))
+		return;
+
+	emulatorLauncherPath = Utils::FileSystem::getParent(emulatorLauncherPath);
+
+	std::string url = LAUNCHERURL;
+	std::string fileName = Utils::FileSystem::getFileName(url);
+	std::string path = Utils::FileSystem::getHomePath() + "/.emulationstation/update";
+
+	if (Utils::FileSystem::exists(path))
+		Utils::FileSystem::deleteDirectoryFiles(path);
+
+	Utils::FileSystem::createDirectory(path);
+
+	std::string zipFile = path + "/" + fileName;
+
+	if (downloadFile(url, zipFile, "batocera-ports", func))
+	{
+		if (func != nullptr)
+			func(std::string("Extracting batocera-ports"));
+
+		unzipFile(Utils::FileSystem::getPreferredPath(zipFile), Utils::FileSystem::getPreferredPath(path));
+		Utils::FileSystem::removeFile(zipFile);
+
+		auto files = Utils::FileSystem::getDirContent(path, true, true);
+		for (auto file : files)
+		{
+			std::string relative = Utils::FileSystem::createRelativePath(file, path, false);
+			if (Utils::String::startsWith(relative, "./"))
+				relative = relative.substr(2);
+
+			std::string localPath = emulatorLauncherPath + "/" + relative;
+
+			if (Utils::FileSystem::isDirectory(file))
+			{
+				if (!Utils::FileSystem::exists(localPath))
+					Utils::FileSystem::createDirectory(localPath);
+			}
+			else
+			{
+				if (Utils::FileSystem::exists(localPath))
+				{
+					Utils::FileSystem::removeFile(localPath + ".old");
+					rename(localPath.c_str(), (localPath + ".old").c_str());
+				}
+
+				if (Utils::FileSystem::copyFile(file, localPath))
+				{
+					Utils::FileSystem::removeFile(localPath + ".old");
+					Utils::FileSystem::removeFile(file);
+				}
+			}
+		}
+
+		Utils::FileSystem::deleteDirectoryFiles(path);
+	}
 }
 
 bool Win32ApiSystem::canUpdate(std::vector<std::string>& output)

--- a/es-app/src/Win32ApiSystem.h
+++ b/es-app/src/Win32ApiSystem.h
@@ -48,6 +48,9 @@ protected:
 	bool executeScript(const std::string command) override;
 	std::pair<std::string, int> executeScript(const std::string command, const std::function<void(const std::string)>& func) override;
 	std::vector<std::string> executeEnumerationScript(const std::string command) override;
+
+private:
+	void updateEmulatorLauncher(const std::function<void(const std::string)>& func);
 };
 
 

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -2946,11 +2946,11 @@ void GuiMenu::openNetworkSettings_batocera(bool selectWifiEnable)
 	auto s = new GuiSettings(mWindow, _("NETWORK SETTINGS").c_str());
 	s->addGroup(_("INFORMATIONS"));
 
-	auto status = std::make_shared<TextComponent>(mWindow, ApiSystem::getInstance()->ping() ? _("CONNECTED") : _("NOT CONNECTED"), font, color);
-	s->addWithLabel(_("STATUS"), status);
-
 	auto ip = std::make_shared<TextComponent>(mWindow, ApiSystem::getInstance()->getIpAdress(), font, color);
 	s->addWithLabel(_("IP ADDRESS"), ip);
+
+	auto status = std::make_shared<TextComponent>(mWindow, ApiSystem::getInstance()->ping() ? _("CONNECTED") : _("NOT CONNECTED"), font, color);
+	s->addWithLabel(_("INTERNET STATUS"), status);
 
 	// Network Indicator
 	auto networkIndicator = std::make_shared<SwitchComponent>(mWindow);

--- a/es-app/src/scrapers/ScreenScraper.cpp
+++ b/es-app/src/scrapers/ScreenScraper.cpp
@@ -255,6 +255,12 @@ bool ScreenScraperRequest::process(HttpReq* request, std::vector<ScraperSearchRe
 	if (content.empty())
 		return false;
 
+	if (content.find("<html") == 0)
+	{
+		setError(Utils::String::removeHtmlTags(content));
+		return false;
+	}
+
 	pugi::xml_document doc;
 	pugi::xml_parse_result parseResult = doc.load(content.c_str());
 

--- a/es-app/src/views/ViewController.cpp
+++ b/es-app/src/views/ViewController.cpp
@@ -164,7 +164,7 @@ void ViewController::goToPrevGameList()
 	goToGameList(system->getPrev());
 }
 
-bool ViewController::goToGameList(std::string& systemName, bool forceImmediate)
+bool ViewController::goToGameList(const std::string& systemName, bool forceImmediate)
 {
 	auto system = SystemData::getSystem(systemName);
 	if (system != nullptr && !system->isGroupChildSystem())

--- a/es-app/src/views/ViewController.h
+++ b/es-app/src/views/ViewController.h
@@ -45,7 +45,7 @@ public:
 	void goToNextGameList();
 	void goToPrevGameList();
 	void goToGameList(SystemData* system, bool forceImmediate = false);
-	bool goToGameList(std::string& systemName, bool forceImmediate = false);
+	bool goToGameList(const std::string& systemName, bool forceImmediate = false);
 	void goToSystemView(SystemData* system, bool forceImmediate = false);
 	void goToSystemView(std::string& systemName, bool forceImmediate = false, ViewMode mode = SYSTEM_SELECT);
 	void goToStart(bool forceImmediate = false);

--- a/es-core/src/GuiComponent.cpp
+++ b/es-core/src/GuiComponent.cpp
@@ -665,6 +665,7 @@ void GuiComponent::animateTo(Vector2f from, Vector2f to, unsigned int  flags, in
 		from = to;
 
 	float scale = mScale;
+	float opacity = mOpacity;
 
 	float x1 = from.x();
 	float x2 = to.x();
@@ -683,13 +684,13 @@ void GuiComponent::animateTo(Vector2f from, Vector2f to, unsigned int  flags, in
 		if ((flags & AnimateFlags::SCALE) == AnimateFlags::SCALE)
 			mScale = 0.0f;
 
-		auto fadeFunc = [this, x1, x2, y1, y2, flags, scale](float t) {
+		auto fadeFunc = [this, x1, x2, y1, y2, flags, scale, opacity](float t) {
 
 			t -= 1; // cubic ease out
 			float pct = Math::lerp(0, 1, t*t*t + 1);
 			
 			if ((flags & AnimateFlags::OPACITY) == AnimateFlags::OPACITY)
-				setOpacity(pct*255.0);
+				setOpacity(pct * opacity);
 
 			if ((flags & AnimateFlags::SCALE) == AnimateFlags::SCALE)
 				mScale = pct * scale;
@@ -701,13 +702,13 @@ void GuiComponent::animateTo(Vector2f from, Vector2f to, unsigned int  flags, in
 				setPosition(x, y);
 		};
 
-		setAnimation(new LambdaAnimation(fadeFunc, delay), 0, [this, fadeFunc, x2, y2, flags, scale]
+		setAnimation(new LambdaAnimation(fadeFunc, delay), 0, [this, fadeFunc, x2, y2, flags, scale, opacity]
 		{			
 			if ((flags & AnimateFlags::SCALE) == AnimateFlags::SCALE)
 				mScale = scale;
 
 			if ((flags & AnimateFlags::OPACITY) == AnimateFlags::OPACITY)
-				setOpacity(255);
+				setOpacity(opacity);
 
 			float x = x2 + mSize.x() / 2 - (mSize.x() / 2 * mScale);
 			float y = y2 + mSize.y() / 2 - (mSize.y() / 2 * mScale);

--- a/es-core/src/components/BatteryIndicatorComponent.cpp
+++ b/es-core/src/components/BatteryIndicatorComponent.cpp
@@ -13,6 +13,8 @@ void BatteryIndicatorComponent::init()
 {
 	ControllerActivityComponent::init();
 
+	mHorizontalAlignment = ALIGN_RIGHT;
+
 	if (Renderer::isSmallScreen())
 	{
 		setPosition(Renderer::getScreenWidth() * 0.915, Renderer::getScreenHeight() * 0.013);

--- a/es-core/src/components/ButtonComponent.cpp
+++ b/es-core/src/components/ButtonComponent.cpp
@@ -7,7 +7,8 @@
 ButtonComponent::ButtonComponent(Window* window, const std::string& text, const std::string& helpText, const std::function<void()>& func, bool upperCase) : GuiComponent(window),
 	mBox(window, ThemeData::getMenuTheme()->Icons.button),	
 	mFocused(false), 
-	mEnabled(true)	
+	mEnabled(true),
+	mPadding(Vector4f(0, 0, 0, 0))
 {
 	auto menuTheme = ThemeData::getMenuTheme();
 
@@ -29,7 +30,11 @@ ButtonComponent::ButtonComponent(Window* window, const std::string& text, const 
 void ButtonComponent::onSizeChanged()
 {
 	auto sz = mBox.getCornerSize();
-	mBox.fitTo(mSize, Vector3f::Zero(), Vector2f(-sz.x() * 2, -sz.y() * 2));
+
+	mBox.fitTo(
+		Vector2f(mSize.x() - mPadding.x() - mPadding.z(), mSize.y() - mPadding.y() - mPadding.w()), 
+		Vector3f(mPadding.x(), mPadding.y()), 
+		Vector2f(-sz.x() * 2, -sz.y() * 2));
 }
 
 void ButtonComponent::setPressedFunc(std::function<void()> f)
@@ -112,6 +117,11 @@ void ButtonComponent::render(const Transform4x4f& parentTrans)
 
 	if (mRenderNonFocusedBackground || mFocused)
 		mBox.render(trans);
+	else
+	{
+		Renderer::setMatrix(trans);
+		Renderer::drawRect(mPadding.x(), mPadding.y(), mSize.x() - mPadding.x() - mPadding.z(), mSize.y() - mPadding.y() - mPadding.w(), 0x60606025);
+	}
 
 	if(mTextCache)
 	{
@@ -148,4 +158,14 @@ std::vector<HelpPrompt> ButtonComponent::getHelpPrompts()
 	std::vector<HelpPrompt> prompts;
 	prompts.push_back(HelpPrompt(BUTTON_OK, mHelpText.empty() ? mText.c_str() : mHelpText.c_str())); // batocera
 	return prompts;
+}
+
+
+void ButtonComponent::setPadding(const Vector4f padding)
+{
+	if (mPadding == padding)
+		return;
+
+	mPadding = padding;
+	onSizeChanged();
 }

--- a/es-core/src/components/ButtonComponent.h
+++ b/es-core/src/components/ButtonComponent.h
@@ -36,6 +36,9 @@ public:
 
 	void setRenderNonFocusedBackground(bool value) { mRenderNonFocusedBackground = value; }
 
+	Vector4f getPadding() { return mPadding; }
+	void setPadding(const Vector4f padding);
+
 private:
 	std::shared_ptr<Font> mFont;
 	std::function<void()> mPressedFunc;
@@ -61,6 +64,7 @@ private:
 	unsigned int mColorFocused;
 
 	bool mRenderNonFocusedBackground;
+	Vector4f	mPadding;
 };
 
 #endif // ES_CORE_COMPONENTS_BUTTON_COMPONENT_H

--- a/es-core/src/components/ComponentGrid.cpp
+++ b/es-core/src/components/ComponentGrid.cpp
@@ -285,8 +285,7 @@ bool ComponentGrid::moveCursor(Vector2i dir)
 
 		const GridEntry* cursorEntry;
 		//spread out on search axis+
-		while(mCursor.x() < mGridSize.x() && mCursor.y() < mGridSize.y()
-			&& mCursor.x() >= 0 && mCursor.y() >= 0)
+		while(mCursor.x() < mGridSize.x() && mCursor.y() < mGridSize.y() && mCursor.x() >= 0 && mCursor.y() >= 0)
 		{
 			cursorEntry = getCellAt(mCursor);
 			if(cursorEntry && cursorEntry->canFocus && cursorEntry != currentCursorEntry)
@@ -295,13 +294,12 @@ bool ComponentGrid::moveCursor(Vector2i dir)
 				return true;
 			}
 
-			mCursor += searchAxis;
+			mCursor += dir;
 		}
-
+		/*
 		//now again on search axis-
 		mCursor = curDirPos;
-		while(mCursor.x() >= 0 && mCursor.y() >= 0
-			&& mCursor.x() < mGridSize.x() && mCursor.y() < mGridSize.y())
+		while(mCursor.x() >= 0 && mCursor.y() >= 0 && mCursor.x() < mGridSize.x() && mCursor.y() < mGridSize.y())
 		{
 			cursorEntry = getCellAt(mCursor);
 			if(cursorEntry && cursorEntry->canFocus && cursorEntry != currentCursorEntry)
@@ -310,9 +308,9 @@ bool ComponentGrid::moveCursor(Vector2i dir)
 				return true;
 			}
 
-			mCursor -= searchAxis;
+			mCursor -= dir;
 		}
-
+		*/
 		mCursor = curDirPos;
 	}
 

--- a/es-core/src/components/ControllerActivityComponent.cpp
+++ b/es-core/src/components/ControllerActivityComponent.cpp
@@ -59,8 +59,15 @@ void ControllerActivityComponent::setColorShift(unsigned int color)
 	mColorShift = color;
 }
 
+void ControllerActivityComponent::onPositionChanged()
+{
+	mBatteryText = nullptr;
+}
+
 void ControllerActivityComponent::onSizeChanged()
 {	
+	mBatteryText = nullptr;
+
 	if (mSize.y() > 0 && mPadTexture)
 	{
 		size_t heightPx = (size_t)Math::round(mSize.y());
@@ -201,8 +208,8 @@ void ControllerActivityComponent::render(const Transform4x4f& parentTrans)
 	if ((mView & BATTERY) && mBatteryInfo.hasBattery && mBatteryImage != nullptr)
 	{
 		if (mBatteryFont == nullptr)
-			mBatteryFont = Font::get(szH * 0.66f, ThemeData::getMenuTheme()->TextSmall.font->getPath());
-
+			mBatteryFont = Font::get(szH * (Renderer::isSmallScreen() ? 0.55f : 0.70f), FONT_PATH_REGULAR);
+		
 		auto sz = mBatteryFont->sizeText(batteryText, 1.0);
 		itemsWidth += sz.x() + mSpacing;
 

--- a/es-core/src/components/ControllerActivityComponent.h
+++ b/es-core/src/components/ControllerActivityComponent.h
@@ -23,6 +23,7 @@ public:
 	ControllerActivityComponent(Window* window);
 
 	void onSizeChanged() override;
+	void onPositionChanged() override;
 
 	// Multiply all pixels in the image by this color when rendering.
 	void setColorShift(unsigned int color);

--- a/es-core/src/components/TextEditComponent.cpp
+++ b/es-core/src/components/TextEditComponent.cpp
@@ -305,7 +305,7 @@ void TextEditComponent::render(const Transform4x4f& parentTrans)
 	Renderer::popClipRect();
 
 	// draw cursor
-	if(mEditing)
+	//if(mEditing)
 	{
 		Vector2f cursorPos;
 		if(isMultiline())
@@ -318,10 +318,14 @@ void TextEditComponent::render(const Transform4x4f& parentTrans)
 			cursorPos[1] = 0;
 		}
 
-		if (mBlinkTime < BLINKTIME / 2)
+		if (!mEditing || mBlinkTime < BLINKTIME / 2)
 		{
 			float cursorHeight = mFont->getHeight() * 0.8f;
+
 			auto cursorColor = (ThemeData::getMenuTheme()->Text.color & 0xFFFFFF00) | getOpacity();
+			if (!mEditing)
+				cursorColor = (ThemeData::getMenuTheme()->Text.color & 0xFFFFFF00) | (unsigned char) (getOpacity() * 0.25f);
+
 			Renderer::drawRect(cursorPos.x(), cursorPos.y() + (mFont->getHeight() - cursorHeight) / 2, 2.0f, cursorHeight, cursorColor, cursorColor); // 0x000000FF
 		}
 	}

--- a/es-core/src/guis/GuiTextEditPopupKeyboard.cpp
+++ b/es-core/src/guis/GuiTextEditPopupKeyboard.cpp
@@ -5,44 +5,63 @@
 #include "LocaleES.h"
 #include "SystemConf.h"
 
+#define OSK_WIDTH (Renderer::isSmallScreen() ? Renderer::getScreenWidth() : Renderer::getScreenWidth() * 0.78f)
+#define OSK_HEIGHT (Renderer::isSmallScreen() ? Renderer::getScreenHeight() : Renderer::getScreenHeight() * 0.60f)
+
+#define OSK_PADDINGX (Renderer::getScreenWidth() * 0.02f)
+#define OSK_PADDINGY (Renderer::getScreenWidth() * 0.01f)
+
+#define BUTTON_GRID_HORIZ_PADDING (Renderer::getScreenWidth()*0.0052083333)
+
 std::vector<std::vector<const char*>> kbUs {
 
-	{ "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "_", "+" },
-	{ "!", "@", "#", "$", "%", "^", "&", "*", "(", ")", "-", "=" },
+	{ "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "_", "+", "DEL" },
+	{ "!", "@", "#", "$", "%", "^", "&", "*", "(", ")", "-", "=", "DEL" },
+	{ "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "_", "+", "DEL" },
 
-	{ "à", "ä", "è", "ë", "ì", "ï", "ò", "ö", "ù", "ü", "¨", "¿" },
-	{ "á", "â", "é", "ê", "í", "î", "ó", "ô", "ú", "û", "ñ", "¡" },
+	{ "q", "w", "e", "r", "t", "y", "u", "i", "o", "p", "{", "}", "OK" },
+	{ "Q", "W", "E", "R", "T", "Y", "U", "I", "O", "P", "[", "]", "OK" },
+	{ "à", "ä", "è", "ë", "ì", "ï", "ò", "ö", "ù", "ü", "¨", "¿", "OK" },
 
-	{ "q", "w", "e", "r", "t", "y", "u", "i", "o", "p", "{", "}" },
-	{ "Q", "W", "E", "R", "T", "Y", "U", "I", "O", "P", "[", "]" },
+	{ "a", "s", "d", "f", "g", "h", "j", "k", "l", ";", "\"", "|", "-rowspan-" },
+	{ "A", "S", "D", "F", "G", "H", "J", "K", "L", ":", "'", "\\", "-rowspan-" },
+	{ "á", "â", "é", "ê", "í", "î", "ó", "ô", "ú", "û", "ñ", "¡", "-rowspan-" },
 
-	{ "a", "s", "d", "f", "g", "h", "j", "k", "l", ";", "\"", "|" },
-	{ "A", "S", "D", "F", "G", "H", "J", "K", "L", ":", "'", "\\" },
+	{ "~", "z", "x", "c", "v", "b", "n", "m", ",", ".", "?", "ALT", "-colspan-" },
+	{ "`", "Z", "X", "C", "V", "B", "N", "M", "<", ">", "/", "ALT", "-colspan-" },
+	{ "€", "", "", "", "", "", "", "", "", "", "", "ALT", "-colspan-" },
 
-	{ "SHIFT", "~", "z", "x", "c", "v", "b", "n", "m", ",", ".", "?" },
-	{ "SHIFT", "`", "Z", "X", "C", "V", "B", "N", "M", "<", ">", "/" },
+	{ "SHIFT", "-colspan-", "SPACE", "-colspan-", "-colspan-", "-colspan-", "-colspan-", "-colspan-", "-colspan-", "RESET", "-colspan-", "CANCEL", "-colspan-" },
+	{ "SHIFT", "-colspan-", "SPACE", "-colspan-", "-colspan-", "-colspan-", "-colspan-", "-colspan-", "-colspan-", "RESET", "-colspan-", "CANCEL", "-colspan-" },
+	{ "SHIFT", "-colspan-", "SPACE", "-colspan-", "-colspan-", "-colspan-", "-colspan-", "-colspan-", "-colspan-", "RESET", "-colspan-", "CANCEL", "-colspan-" }
 };
 
 std::vector<std::vector<const char*>> kbFr {
-	{ "&", "é", "\"", "'", "(", "#", "è", "!", "ç", "à", ")", "-" },
-	{ "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "@", "_" },
+	{ "&", "é", "\"", "'", "(", "#", "è", "!", "ç", "à", ")", "-", "DEL" },
+	{ "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "@", "_", "DEL" },
+	{ "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "@", "_", "DEL" },
 	
-	{ "à", "ä", "ë", "ì", "ï", "ò", "ö", "ü", "\\", "|", "§", "°" },
-	{ "á", "â", "ê", "í", "î", "ó", "ô", "ú", "û", "ñ", "¡", "¿" },
-	
-	{ "a", "z", "e", "r", "t", "y", "u", "i", "o", "p", "^", "$" },
-	{ "A", "Z", "E", "R", "T", "Y", "U", "I", "O", "P", "¨", "*" },
+	{ "a", "z", "e", "r", "t", "y", "u", "i", "o", "p", "^", "$", "OK" },
+	{ "A", "Z", "E", "R", "T", "Y", "U", "I", "O", "P", "¨", "*", "OK" },
+	{ "à", "ä", "ë", "ì", "ï", "ò", "ö", "ü", "\\", "|", "§", "°", "OK" },
 
-	{ "q", "s", "d", "f", "g", "h", "j", "k", "l", "m", "ù", "`" },
-	{ "Q", "S", "D", "F", "G", "H", "J", "K", "L", "M", "%", "£" },
-	
-	{ "SHIFT", "<", "w", "x", "c", "v", "b", "n", ",", ";", ":", "=" },
-	{ "SHIFT", ">", "W", "X", "C", "V", "B", "N", "?", ".", "/", "+" }
+	{ "q", "s", "d", "f", "g", "h", "j", "k", "l", "m", "ù", "`", "-rowspan-" },
+	{ "Q", "S", "D", "F", "G", "H", "J", "K", "L", "M", "%", "£", "-rowspan-" },
+	{ "á", "â", "ê", "í", "î", "ó", "ô", "ú", "û", "ñ", "¡", "¿", "-rowspan-" },
+
+	{ "<", "w", "x", "c", "v", "b", "n", ",", ";", ":", "=", "ALT", "-colspan-" },
+	{ ">", "W", "X", "C", "V", "B", "N", "?", ".", "/", "+", "ALT", "-colspan-" },
+	{ "€", "", "", "", "", "", "", "", "", "", "", "ALT", "-colspan-" },
+
+	{ "SHIFT", "-colspan-", "SPACE", "-colspan-", "-colspan-", "-colspan-", "-colspan-", "-colspan-", "-colspan-", "RESET", "-colspan-", "CANCEL", "-colspan-" },
+	{ "SHIFT", "-colspan-", "SPACE", "-colspan-", "-colspan-", "-colspan-", "-colspan-", "-colspan-", "-colspan-", "RESET", "-colspan-", "CANCEL", "-colspan-" },
+	{ "SHIFT", "-colspan-", "SPACE", "-colspan-", "-colspan-", "-colspan-", "-colspan-", "-colspan-", "-colspan-", "RESET", "-colspan-", "CANCEL", "-colspan-" }
 };
+
 
 GuiTextEditPopupKeyboard::GuiTextEditPopupKeyboard(Window* window, const std::string& title, const std::string& initValue,
 	const std::function<void(const std::string&)>& okCallback, bool multiLine, const std::string acceptBtnText)
-	: GuiComponent(window), mBackground(window, ":/frame.png"), mGrid(window, Vector2i(1, 7)), mMultiLine(multiLine)
+	: GuiComponent(window), mBackground(window, ":/frame.png"), mGrid(window, Vector2i(1, 6)), mMultiLine(multiLine)
 {
 	setTag("popup");
 
@@ -58,37 +77,8 @@ GuiTextEditPopupKeyboard::GuiTextEditPopupKeyboard(Window* window, const std::st
 	addChild(&mGrid);
 
 	mTitle = std::make_shared<TextComponent>(mWindow, Utils::String::toUpper(title), theme->Title.font, theme->Title.color, ALIGN_CENTER);
-
-	// Accept/Cancel/Delete/Space buttons
-	std::vector<std::shared_ptr<ButtonComponent> > buttons;
-
-	buttons.push_back(std::make_shared<ButtonComponent>(mWindow, acceptBtnText, acceptBtnText, [this, okCallback] { okCallback(mText->getValue()); delete this; }));
-	auto space = std::make_shared<ButtonComponent>(mWindow, _("SPACE"), _("SPACE"), [this] {
-		mText->startEditing();
-		mText->textInput(" ");
-		mText->stopEditing();
-	});
-
-	if (Renderer::isSmallScreen())
-		space->setSize(space->getSize().x(), space->getSize().y());
-	else
-		space->setSize(space->getSize().x() * 3, space->getSize().y());
-
-	buttons.push_back(space);
-	buttons.push_back(std::make_shared<ButtonComponent>(mWindow, _("DELETE"), _("DELETE A CHAR"), [this] {
-		mText->startEditing();
-		mText->textInput("\b");
-		mText->stopEditing();
-	}));
-
-	buttons.push_back(std::make_shared<ButtonComponent>(mWindow, _("RESET"), _("RESET"), [this, okCallback] { okCallback(""); delete this; }));
-
-	buttons.push_back(std::make_shared<ButtonComponent>(mWindow, _("CANCEL"), _("DISCARD CHANGES"), [this] { delete this; }));
-
-	// Add buttons
-	mButtons = makeButtonGrid(mWindow, buttons);
-
-	mKeyboardGrid = std::make_shared<ComponentGrid>(mWindow, Vector2i(12, 5));
+	
+	mKeyboardGrid = std::make_shared<ComponentGrid>(mWindow, Vector2i(kbUs[0].size(), kbUs.size() / 3));
 
 	mText = std::make_shared<TextEditComponent>(mWindow);
 	mText->setValue(initValue);
@@ -100,7 +90,7 @@ GuiTextEditPopupKeyboard::GuiTextEditPopupKeyboard(Window* window, const std::st
 	mGrid.setEntry(mTitle, Vector2i(0, 0), false, true);
 
 	// Text edit add
-	mGrid.setEntry(mText, Vector2i(0, 1), true, false, Vector2i(1, 1), GridFlags::BORDER_TOP | GridFlags::BORDER_BOTTOM);
+	mGrid.setEntry(mText, Vector2i(0, 1), true, false, Vector2i(1, 1), GridFlags::BORDER_TOP);
 
 	std::vector< std::vector< std::shared_ptr<ButtonComponent> > > buttonList;
 
@@ -121,33 +111,82 @@ GuiTextEditPopupKeyboard::GuiTextEditPopupKeyboard(Window* window, const std::st
 		if (language == "fr")
 			layout = &kbFr;
 
-		for (unsigned int i = 0; i < 5; i++)
-		{
+		for (unsigned int i = 0; i < layout->size() / 3; i++)
+		{			
 			std::vector<std::shared_ptr<ButtonComponent>> buttons;
-			for (unsigned int j = 0; j < 12; j++)
+			for (unsigned int j = 0; j < (*layout)[i].size(); j++)
 			{
-				std::string lower = (*layout)[2 * i][j];
-				std::string upper = (*layout)[2 * i + 1][j];
+				std::string lower = (*layout)[3 * i][j];
+				if (lower.empty() || lower == "-rowspan-" || lower == "-colspan-")
+					continue;
+
+				std::string upper = (*layout)[3 * i + 1][j];
+				std::string alted = (*layout)[3 * i + 2][j];
 
 				std::shared_ptr<ButtonComponent> button = nullptr;
+
+				if (lower == "DEL")
+				{
+					lower = _U("\uF177");
+					upper = _U("\uF177");
+					alted = _U("\uF177");
+				}
+				else if (lower == "OK")
+				{
+					lower = _U("\uF058");
+					upper = _U("\uF058");
+					alted = _U("\uF058");
+				}
+				else if (lower == "SPACE")
+				{
+					lower = " ";
+					upper = " ";
+				}
+				else if (lower != "SHIFT" && lower.length() > 1)
+				{
+					lower = _(lower.c_str());
+					upper = _(upper.c_str());
+					alted = _(alted.c_str());
+				}
 
 				if (lower == "SHIFT")
 				{
 					// Special case for shift key
-					mShiftButton = std::make_shared<ButtonComponent>(mWindow, _U("\uF176"), _("SHIFTS FOR UPPER,LOWER, AND SPECIAL"), [this] {
-						shiftKeys();
-					}, false);
-					
+					mShiftButton = std::make_shared<ButtonComponent>(mWindow, _U("\uF176"), _("SHIFTS FOR UPPER,LOWER, AND SPECIAL"), [this] { shiftKeys(); }, false);					
 					button = mShiftButton;
 				}
+				else if (lower == "ALT")
+				{
+					mAltButton = std::make_shared<ButtonComponent>(mWindow, _U("\uF141"), _("ALT GR"), [this] { altKeys(); }, false);
+					button = mAltButton;
+				}
 				else
-					button = makeButton(lower, upper);					
+					button = makeButton(lower, upper, alted);
 
+				button->setPadding(Vector4f(BUTTON_GRID_HORIZ_PADDING / 4.0f, BUTTON_GRID_HORIZ_PADDING / 4.0f, BUTTON_GRID_HORIZ_PADDING / 4.0f, BUTTON_GRID_HORIZ_PADDING / 4.0f));
 				button->setRenderNonFocusedBackground(false);
 				buttons.push_back(button);
 
-				button->setSize(getButtonSize());
-				mKeyboardGrid->setEntry(button, Vector2i(j, i), true, false);
+				int colSpan = 1;
+				for (unsigned int cs = j + 1; cs < (*layout)[i].size(); cs++)
+				{
+					if (std::string((*layout)[3 * i][cs]) == "-colspan-")
+						colSpan++;
+					else
+						break;
+				}
+				
+				int rowSpan = 1;
+				for (unsigned int cs = (3 * i) + 3; cs < layout->size(); cs += 3)
+				{
+					if (std::string((*layout)[cs][j]) == "-rowspan-")
+						rowSpan++;
+					else
+						break;
+				}
+
+				mKeyboardGrid->setEntry(button, Vector2i(j, i), true, true, Vector2i(colSpan, rowSpan));
+
 				buttonList.push_back(buttons);
 			}
 		}		
@@ -156,12 +195,12 @@ GuiTextEditPopupKeyboard::GuiTextEditPopupKeyboard(Window* window, const std::st
 
 	// Add keyboard keys
 	mGrid.setEntry(mKeyboardGrid, Vector2i(0, 2), true, true, Vector2i(2, 4));
-	mGrid.setEntry(mButtons, Vector2i(0, 6), true, false);
 
 	// Determine size from text size
 	float textHeight = mText->getFont()->getHeight();
 	if (multiLine)
 		textHeight *= 6;
+
 	mText->setSize(0, textHeight);
 
 	mGrid.setUnhandledInputCallback([this](InputConfig* config, Input input) -> bool 
@@ -173,19 +212,14 @@ GuiTextEditPopupKeyboard::GuiTextEditPopupKeyboard(Window* window, const std::st
 		}
 		else if (config->isMappedLike("up", input)) 
 		{
-			mGrid.moveCursor(Vector2i(0, 5));
+			mGrid.moveCursor(Vector2i(0, kbUs.size() / 2));
 			return true;
 		}
 		else if (config->isMappedLike("left", input))
 		{		
 			if (mGrid.getSelectedComponent() == mKeyboardGrid)
 			{
-				mKeyboardGrid->moveCursor(Vector2i(11, 0));
-				return true;
-			}
-			else if (mGrid.getSelectedComponent() == mButtons)
-			{
-				mButtons->moveCursor(Vector2i(4, 0));
+				mKeyboardGrid->moveCursor(Vector2i(kbUs[0].size() - 1, 0));
 				return true;
 			}
 		}
@@ -193,12 +227,7 @@ GuiTextEditPopupKeyboard::GuiTextEditPopupKeyboard(Window* window, const std::st
 		{
 			if (mGrid.getSelectedComponent() == mKeyboardGrid)
 			{
-				mKeyboardGrid->moveCursor(Vector2i(-11, 0));
-				return true;
-			}
-			else if (mGrid.getSelectedComponent() == mButtons)
-			{
-				mButtons->moveCursor(Vector2i(-4, 0));
+				mKeyboardGrid->moveCursor(Vector2i(-kbUs[0].size() + 1, 0));
 				return true;
 			}
 		}
@@ -206,30 +235,24 @@ GuiTextEditPopupKeyboard::GuiTextEditPopupKeyboard(Window* window, const std::st
 		return false;
 	});
 
+	
 	// If multiline, set all diminsions back to default, else draw size for keyboard.
 	if (mMultiLine) 
 	{
 		if (Renderer::isSmallScreen())
-			setSize(Renderer::getScreenWidth(), Renderer::getScreenHeight());
+			setSize(OSK_WIDTH, Renderer::getScreenHeight());
 		else
-			setSize(Renderer::getScreenWidth() * 0.5f, mTitle->getFont()->getHeight() + textHeight + mKeyboardGrid->getSize().y() + 40);
+			setSize(OSK_WIDTH, mTitle->getFont()->getHeight() + textHeight + mKeyboardGrid->getSize().y() + 40);
 
 		setPosition((Renderer::getScreenWidth() - mSize.x()) / 2, (Renderer::getScreenHeight() - mSize.y()) / 2);
 	}
-	else 
+	else
 	{
-		if (Renderer::isSmallScreen())
-			setSize(Renderer::getScreenWidth(), Renderer::getScreenHeight());
-		else // Set size based on ScreenHieght * .08f by the amount of keyboard rows there are.
-			setSize(Renderer::getScreenWidth() * 0.95f, mTitle->getFont()->getHeight() + textHeight + 40 + (Renderer::getScreenHeight() * 0.085f) * 6);
-
+		//setSize(OSK_WIDTH, mTitle->getFont()->getHeight() + textHeight + 40 + (Renderer::getScreenHeight() * 0.085f) * 6);
+		setSize(OSK_WIDTH, OSK_HEIGHT);
 		setPosition((Renderer::getScreenWidth() - mSize.x()) / 2, (Renderer::getScreenHeight() - mSize.y()) / 2);
-	}	
-	/*
-	mWindow->postToUiThread([this](Window* w)
-	{
-		mText->startEditing();
-	});*/
+		animateTo(Vector2f((Renderer::getScreenWidth() - mSize.x()) / 2, (Renderer::getScreenHeight() - mSize.y()) / 2));
+	}
 }
 
 
@@ -237,29 +260,18 @@ void GuiTextEditPopupKeyboard::onSizeChanged()
 {
 	mBackground.fitTo(mSize, Vector3f::Zero(), Vector2f(-32, -32));
 
-	mText->setSize(mSize.x() - 40, mText->getSize().y());
+	mText->setSize(mSize.x() - OSK_PADDINGX - OSK_PADDINGX, mText->getSize().y());
 
 	// update grid
 	mGrid.setRowHeightPerc(0, mTitle->getFont()->getHeight() / mSize.y());
 	mGrid.setRowHeightPerc(2, mKeyboardGrid->getSize().y() / mSize.y());
-	mGrid.setRowHeightPerc(6, mButtons->getSize().y() / mSize.y());
-
 	mGrid.setSize(mSize);
 
-	// force the keyboard size and position here
-	// for an unknown reason, without setting that, the position is "sometimes" (1/2 on s905x for example) not displayed correctly
-	// as if a variable were not correctly initialized
+	auto pos = mKeyboardGrid->getPosition();
+	auto sz = mKeyboardGrid->getSize();
 
-	if (Renderer::isSmallScreen())  // small screens // batocera
-	{
-		mKeyboardGrid->setSize(getButtonSize().x() * 12.0f, getButtonSize().y() * 5.0f);
-		mKeyboardGrid->setPosition(Renderer::getScreenWidth() * 0.05f / 2.00f, mTitle->getFont()->getHeight() + mText->getFont()->getHeight() + 15 + 6);
-	}
-	else
-	{
-		mKeyboardGrid->setSize(getButtonSize().x() * 12.2f, getButtonSize().y() * 5.2f); // Small margin between buttons
-		mKeyboardGrid->setPosition(Renderer::getScreenWidth() * 0.05f / 2.00f, mTitle->getFont()->getHeight() + mText->getFont()->getHeight() + 40 + 6);
-	}
+	mKeyboardGrid->setSize(mSize.x() - OSK_PADDINGX - OSK_PADDINGX, sz.y() - OSK_PADDINGY); // Small margin between buttons
+	mKeyboardGrid->setPosition(OSK_PADDINGX, pos.y());	
 }
 
 bool GuiTextEditPopupKeyboard::input(InputConfig* config, Input input)
@@ -328,26 +340,59 @@ bool GuiTextEditPopupKeyboard::input(InputConfig* config, Input input)
 
 	return false;
 }
-/*
-void GuiTextEditPopupKeyboard::update(int deltatime) {
-
-}*/
 
 // Shifts the keys when user hits the shift button.
 void GuiTextEditPopupKeyboard::shiftKeys() 
 {
+	if (mAlt && !mShift)
+		altKeys();
+
 	mShift = !mShift;
 
 	if (mShift)
+	{
+		mShiftButton->setRenderNonFocusedBackground(true);
 		mShiftButton->setColorShift(0xFF0000FF);
+	}
 	else
+	{
+		mShiftButton->setRenderNonFocusedBackground(false);
 		mShiftButton->removeColorShift();
+	}
 
 	for (auto & kb : keyboardButtons)
 	{
 		const std::string& text = mShift ? kb.shiftedKey : kb.key;
+		auto sz = kb.button->getSize();
 		kb.button->setText(text, text, false);
-		kb.button->setSize(getButtonSize());
+		kb.button->setSize(sz);
+	}
+}
+
+void GuiTextEditPopupKeyboard::altKeys()
+{
+	if (mShift && !mAlt)
+		shiftKeys();
+
+	mAlt = !mAlt;
+
+	if (mAlt)
+	{
+		mAltButton->setRenderNonFocusedBackground(true);
+		mAltButton->setColorShift(0xFF0000FF);
+	}
+	else
+	{
+		mAltButton->setRenderNonFocusedBackground(false);
+		mAltButton->removeColorShift();
+	}
+
+	for (auto & kb : keyboardButtons)
+	{
+		const std::string& text = mAlt ? kb.altedKey : kb.key;
+		auto sz = kb.button->getSize();
+		kb.button->setText(text, text, false);
+		kb.button->setSize(sz);
 	}
 }
 
@@ -366,13 +411,46 @@ std::vector<HelpPrompt> GuiTextEditPopupKeyboard::getHelpPrompts()
 	return prompts;
 }
 
-std::shared_ptr<ButtonComponent> GuiTextEditPopupKeyboard::makeButton(const std::string& key, const std::string& shiftedKey)
+std::shared_ptr<ButtonComponent> GuiTextEditPopupKeyboard::makeButton(const std::string& key, const std::string& shiftedKey, const std::string& altedKey)
 {
-	std::shared_ptr<ButtonComponent> button = std::make_shared<ButtonComponent>(mWindow, key, key, [this, key, shiftedKey] 
+	std::shared_ptr<ButtonComponent> button = std::make_shared<ButtonComponent>(mWindow, key, key, [this, key, shiftedKey, altedKey]
 	{
+		if (key == _U("\uF058") || key.find("OK") != std::string::npos)
+		{
+			mOkCallback(mText->getValue());
+			delete this;
+			return;
+		}
+		else if (key == _U("\uF177") || key == "DEL")
+		{
+			mText->startEditing(); mText->textInput("\b"); mText->stopEditing();
+			return;
+		}
+		else if (key == _("SPACE") || key == " ")
+		{
+			mText->startEditing(); mText->textInput(" "); mText->stopEditing();
+			return;
+		}
+		else if (key == _("RESET"))
+		{
+			mOkCallback(""); 
+			delete this;
+			return;
+		}
+		else if (key == _("CANCEL"))
+		{
+			delete this;
+			return;
+		}
+
+		if (mAlt && altedKey.empty())
+			return;
+
 		mText->startEditing();
 
-		if (mShift)
+		if (mAlt)
+			mText->textInput(altedKey.c_str());
+		else if (mShift)
 			mText->textInput(shiftedKey.c_str());
 		else
 			mText->textInput(key.c_str());
@@ -380,18 +458,7 @@ std::shared_ptr<ButtonComponent> GuiTextEditPopupKeyboard::makeButton(const std:
 		mText->stopEditing();
 	}, false);
 	
-	KeyboardButton kb(button, key, shiftedKey);
+	KeyboardButton kb(button, key, shiftedKey, altedKey);
 	keyboardButtons.push_back(kb);
 	return button;
-}
-
-const Vector2f GuiTextEditPopupKeyboard::getButtonSize()
-{
-	if (Renderer::isSmallScreen())
-	{
-		float height = (Renderer::getScreenHeight() - mText->getSize().y() - mTitle->getSize().y() - mButtons->getSize().y()) / 6.0;
-		return Vector2f((Renderer::getScreenWidth() * 0.95f) / 12.0f, height);
-	}
-
-	return Vector2f((Renderer::getScreenWidth() * 0.89f) / 12.0f, mText->getFont()->getHeight() + 6.0f);
 }

--- a/es-core/src/guis/GuiTextEditPopupKeyboard.h
+++ b/es-core/src/guis/GuiTextEditPopupKeyboard.h
@@ -25,15 +25,18 @@ private:
 		std::shared_ptr<ButtonComponent> button;
 		const std::string key;
 		const std::string shiftedKey;
-		KeyboardButton(const std::shared_ptr<ButtonComponent> b, const std::string& k, const std::string& sk) : button(b), key(k), shiftedKey(sk) {};
+		const std::string altedKey;
+		KeyboardButton(const std::shared_ptr<ButtonComponent> b, const std::string& k, const std::string& sk, const std::string& ak) : button(b), key(k), shiftedKey(sk), altedKey(ak) {};
 	};
 	
-	std::shared_ptr<ButtonComponent> makeButton(const std::string& key, const std::string& shiftedKey);
+	std::shared_ptr<ButtonComponent> makeButton(const std::string& key, const std::string& shiftedKey, const std::string& altedKey);
 	std::vector<KeyboardButton> keyboardButtons;
-	std::shared_ptr<ButtonComponent> mShiftButton;
-	const Vector2f getButtonSize();
+	
+	std::shared_ptr<ButtonComponent> mShiftButton;	
+	std::shared_ptr<ButtonComponent> mAltButton;
 
 	void shiftKeys();
+	void altKeys();
 
 	NinePatchComponent mBackground;
 	ComponentGrid mGrid;
@@ -41,11 +44,11 @@ private:
 	std::shared_ptr<TextComponent> mTitle;
 	std::shared_ptr<TextEditComponent> mText;
 	std::shared_ptr<ComponentGrid> mKeyboardGrid;
-	std::shared_ptr<ComponentGrid> mButtons;
 	
 	std::function<void(const std::string&)> mOkCallback;
 
 	bool mMultiLine;
 	bool mShift = false;	
+	bool mAlt = false;
 };
 


### PR DESCRIPTION
- Add Quick search on systemView
- Fix battery indicator alignement
- GridComponent (menus&osk) : fix navigation through spanned cells
- SystemData : restored old Retropie search for gamelists in .emulationstation/gamelists folder, when default gamelist is not found.
- Windows Only : Add batocera-ports to updater when in beta channel.