### PR TITLE
Startup System : Add option "RESTORE LAST SELECTED" + Fixes

### DIFF
--- a/es-app/src/FileData.h
+++ b/es-app/src/FileData.h
@@ -124,7 +124,7 @@ public:
 	void checkCrc32(bool force = false);
 
 	void importP2k(const std::string& p2k);
-	void convertP2kFile();
+	std::string convertP2kFile();
 	bool hasP2kFile();
 
 	bool hasKeyboardMapping();

--- a/es-app/src/SystemData.cpp
+++ b/es-app/src/SystemData.cpp
@@ -21,6 +21,10 @@
 #include <unordered_set>
 #include <algorithm>
 
+#if WIN32
+#include "Win32ApiSystem.h"
+#endif
+
 using namespace Utils;
 
 std::vector<SystemData*> SystemData::sSystemVector;
@@ -1630,10 +1634,18 @@ KeyMappingFile SystemData::getKeyboardMapping()
 
 	if (Utils::FileSystem::exists(getKeyboardMappingFilePath()))
 		ret = KeyMappingFile::load(getKeyboardMappingFilePath());
-#if !WIN32
+#if WIN32
+	else
+	{
+		std::string win32path = Win32ApiSystem::getEmulatorLauncherPath("system.padtokey");
+		if (!win32path.empty())
+			ret = KeyMappingFile::load(win32path + "/" + getName() + ".keys");
+	}
+#else
 	else if (Utils::FileSystem::exists("/usr/share/evmapy/" + getName() + ".keys")) // Load existing predefined settings
 		ret = KeyMappingFile::load("/usr/share/evmapy/" + getName() + ".keys");
 #endif
+
 
 	ret.path = getKeyboardMappingFilePath();
 	return ret;

--- a/es-app/src/Win32ApiSystem.cpp
+++ b/es-app/src/Win32ApiSystem.cpp
@@ -1070,6 +1070,21 @@ std::string Win32ApiSystem::getEmulatorLauncherPath(const std::string variable)
 		systemConf.close();
 	}
 
+	if (Utils::String::startsWith(variable, "system."))
+	{
+		auto name = variable.substr(7);
+
+		auto dir = Utils::FileSystem::getCanonicalPath(Utils::FileSystem::getParent(path) + "/../system/" + name);
+		if (Utils::FileSystem::isDirectory(dir))
+			return dir;
+	}
+	else
+	{
+		auto dir = Utils::FileSystem::getCanonicalPath(Utils::FileSystem::getParent(path) + "/../" + variable);
+		if (Utils::FileSystem::isDirectory(dir))
+			return dir;
+	}
+
 	return "";
 }
 

--- a/es-app/src/guis/GuiBatoceraStore.h
+++ b/es-app/src/guis/GuiBatoceraStore.h
@@ -46,6 +46,7 @@ public:
 	void OnContentInstalled(int contentType, std::string contentName, bool success) override;
 
 private:
+	static std::vector<PacmanPackage> queryPackages();
 	void loadPackagesAsync(bool updatePackageList = false);
 	void loadList(bool updatePackageList, bool restoreIndex = true);
 	void processPackage(PacmanPackage package);

--- a/es-app/src/guis/GuiBezelInstallStart.cpp
+++ b/es-app/src/guis/GuiBezelInstallStart.cpp
@@ -36,9 +36,11 @@ void GuiBezelInstallStart::OnContentInstalled(int contentType, std::string conte
 {
 	if (contentType == ContentInstaller::CONTENT_BEZEL_INSTALL && success)
 	{
-		// When installed, set thebezelproject as default decorations for the system
+		auto global = SystemConf::getInstance()->get("global.bezel");
+
+		// When installed, set thebezelproject as default decorations for the system, if the global setting is not set to "AUTO"
 		auto current = SystemConf::getInstance()->get(contentName + ".bezel");
-		if (current == "" || current == "AUTO")
+		if ((current == "" || current == "AUTO") && global != "" && global != "AUTO")
 			SystemConf::getInstance()->set(contentName + ".bezel", "thebezelproject");
 	}
 	else if (contentType == ContentInstaller::CONTENT_BEZEL_UNINSTALL && success)

--- a/es-app/src/guis/GuiCollectionSystemsOptions.cpp
+++ b/es-app/src/guis/GuiCollectionSystemsOptions.cpp
@@ -203,6 +203,7 @@ void GuiCollectionSystemsOptions::initializeMenu()
 
 	auto systemfocus_list = std::make_shared< OptionListComponent<std::string> >(mWindow, _("START ON SYSTEM"), false);
 	systemfocus_list->add(_("NONE"), "", startupSystem == "");
+	systemfocus_list->add(_("RESTORE LAST SELECTED"), "lastsystem", startupSystem == "lastsystem");
 
 	if (SystemData::isManufacturerSupported() && Settings::getInstance()->getString("SortSystems") == "manufacturer")
 	{
@@ -229,7 +230,11 @@ void GuiCollectionSystemsOptions::initializeMenu()
 	}
 
 	addWithLabel(_("START ON SYSTEM"), systemfocus_list);
-	addSaveFunc([systemfocus_list] { Settings::getInstance()->setString("StartupSystem", systemfocus_list->getSelected()); });
+	addSaveFunc([systemfocus_list] 
+	{ 
+		Settings::getInstance()->setString("StartupSystem", systemfocus_list->getSelected()); 
+		Settings::getInstance()->setString("LastSystem", "");
+	});
 
 	// START ON GAMELIST
 	auto startOnGamelist = std::make_shared<SwitchComponent>(mWindow);

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -2706,7 +2706,7 @@ void GuiMenu::openUISettings()
 	});
 
 	// Battery indicator
-	if (mWindow->getBatteryIndicator() && mWindow->getBatteryIndicator()->hasBattery())
+	if (queryBatteryInformation().hasBattery)
 	{
 		auto batteryStatus = std::make_shared<SwitchComponent>(mWindow);
 		batteryStatus->setState(Settings::getInstance()->getBool("ShowBatteryIndicator"));

--- a/es-app/src/main.cpp
+++ b/es-app/src/main.cpp
@@ -668,6 +668,7 @@ int main(int argc, char* argv[])
 
 	ImageIO::saveImageCache();
 	MameNames::deinit();
+	ViewController::saveState();
 	CollectionSystemManager::deinit();
 	SystemData::deleteSystems();
 

--- a/es-app/src/views/SystemView.cpp
+++ b/es-app/src/views/SystemView.cpp
@@ -1594,3 +1594,11 @@ void SystemView::activateExtras(int cursor, bool activate)
 	if (activate)
 		preloadExtraNeighbours(cursor);
 }
+
+SystemData* SystemView::getActiveSystem()
+{
+	if (mCursor < 0 || mCursor >= mEntries.size())
+		return nullptr;
+
+	return mEntries[mCursor].object;
+}

--- a/es-app/src/views/SystemView.h
+++ b/es-app/src/views/SystemView.h
@@ -73,6 +73,8 @@ public:
 
 	void reloadTheme(SystemData* system);
 
+	SystemData* getActiveSystem();
+
 protected:
 	void onCursorChanged(const CursorState& state) override;
 

--- a/es-app/src/views/ViewController.h
+++ b/es-app/src/views/ViewController.h
@@ -25,6 +25,8 @@ public:
 	};
 
 	static void init(Window* window);
+	static void saveState();
+
 	static ViewController* get();
 
 	virtual ~ViewController();

--- a/es-core/src/Settings.cpp
+++ b/es-core/src/Settings.cpp
@@ -68,7 +68,7 @@ void Settings::setDefaults()
 	mBoolMap["SplashScreen"] = true;
 	mBoolMap["SplashScreenProgress"] = true;
 	mBoolMap["StartupOnGameList"] = false;
-	mStringMap["StartupSystem"] = "";
+	mStringMap["StartupSystem"] = "lastsystem";
 
 #if WIN32
 	mBoolMap["ShowOnlyExit"] = true;

--- a/es-core/src/components/ControllerActivityComponent.h
+++ b/es-core/src/components/ControllerActivityComponent.h
@@ -49,7 +49,7 @@ protected:
 
 protected:
 	Vector2f	getTextureSize(std::shared_ptr<TextureResource> texture);
-	int			renderTexture(float x, std::shared_ptr<TextureResource> texture, unsigned int color);
+	int			renderTexture(float x, float w, std::shared_ptr<TextureResource> texture, unsigned int color);
 
 	float mSpacing;
 	Alignment mHorizontalAlignment;

--- a/es-core/src/platform.cpp
+++ b/es-core/src/platform.cpp
@@ -188,6 +188,10 @@ bool isFastShutdown()
 
 std::string queryIPAdress()
 {
+#ifdef DEVTEST
+	return "127.0.0.1";
+#endif
+
 	std::string result;
 
 #if WIN32
@@ -281,6 +285,18 @@ BatteryInformation queryBatteryInformation()
 	ret.isCharging = false;
 	ret.level = 0;
 
+#ifdef DEVTEST
+	ret.hasBattery = true;
+	ret.isCharging = true;
+	ret.level = 33;
+
+	time_t     clockNow = time(0);
+	struct tm  clockTstruct = *localtime(&clockNow);
+	ret.level = clockTstruct.tm_min;
+
+	return ret;
+#endif
+
 #ifdef WIN32
 	SYSTEM_POWER_STATUS systemPowerStatus;
 	if (GetSystemPowerStatus(&systemPowerStatus))
@@ -296,13 +312,6 @@ BatteryInformation queryBatteryInformation()
 	}
 	else
 		ret.hasBattery = false;
-
-
-#ifdef DEVTEST
-	ret.hasBattery = true;
-	ret.isCharging = false;
-	ret.level = 33;
-#endif
 
 	return ret;
 


### PR DESCRIPTION
- Content Downloader : Refresh Xml when content installed or removed.
- Battery indicator : Fix option missing after being disabled.
- Battery indicator : Fix text superposition.
- Win32 : Add padtokey paths resolutions relative to emulatorLauncherPath.
- p2k compatibility : stop converting when scrapping -> Convert only on demand