### PR TITLE
Add "Has Achievements" metadata

### DIFF
--- a/es-app/src/FileFilterIndex.cpp
+++ b/es-app/src/FileFilterIndex.cpp
@@ -32,7 +32,8 @@ FileFilterIndex::FileFilterIndex()
 		{ LANG_FILTER, 	    &langIndexAllKeys,      &filterByLang,	    &langIndexFilteredKeys, 	"lang",		    false,				"",				_("LANGUAGE") },
 		{ REGION_FILTER, 	&regionIndexAllKeys,    &filterByRegion,	&regionIndexFilteredKeys, 	"region",		false,				"",				_("REGION") },
 		{ KIDGAME_FILTER, 	&kidGameIndexAllKeys, 	&filterByKidGame,	&kidGameIndexFilteredKeys, 	"kidgame",		false,				"",				_("KIDGAME") },
-		{ PLAYED_FILTER, 	&playedIndexAllKeys,    &filterByPlayed,	&playedIndexFilteredKeys, 	"played",		false,				"",				_("ALREADY PLAYED") }
+		{ PLAYED_FILTER, 	&playedIndexAllKeys,    &filterByPlayed,	&playedIndexFilteredKeys, 	"played",		false,				"",				_("ALREADY PLAYED") },
+		{ CHEEVOS_FILTER, 	&cheevosIndexAllKeys,   &filterByCheevos,	&cheevosIndexFilteredKeys, 	"cheevos",		false,				"",				_("HAS ACHIEVEMENTS") }
 	};
 
 	std::vector<FilterDataDecl> filterDataDecl = std::vector<FilterDataDecl>(filterDecls, filterDecls + sizeof(filterDecls) / sizeof(filterDecls[0]));
@@ -100,7 +101,9 @@ void FileFilterIndex::importIndex(FileFilterIndex* indexToImport)
 		{ &langIndexAllKeys, &(indexToImport->langIndexAllKeys) },
 		{ &regionIndexAllKeys, &(indexToImport->regionIndexAllKeys) },
 		{ &kidGameIndexAllKeys, &(indexToImport->kidGameIndexAllKeys) },
+		{ &cheevosIndexAllKeys, &(indexToImport->cheevosIndexAllKeys) },
 		{ &playedIndexAllKeys, &(indexToImport->playedIndexAllKeys) }
+
 	};
 
 	std::vector<IndexImportStructure> indexImportDecl = std::vector<IndexImportStructure>(indexStructDecls, indexStructDecls + sizeof(indexStructDecls) / sizeof(indexStructDecls[0]));
@@ -138,6 +141,7 @@ void FileFilterIndex::resetIndex()
 
 	clearIndex(langIndexAllKeys);
 	clearIndex(regionIndexAllKeys);
+	clearIndex(cheevosIndexAllKeys);
 
 	manageIndexEntry(&favoritesIndexAllKeys, "FALSE", false);
 	manageIndexEntry(&favoritesIndexAllKeys, "TRUE", false);
@@ -147,6 +151,9 @@ void FileFilterIndex::resetIndex()
 
 	manageIndexEntry(&playedIndexAllKeys, "FALSE", false);
 	manageIndexEntry(&playedIndexAllKeys, "TRUE", false);
+
+	manageIndexEntry(&cheevosIndexAllKeys, "FALSE", false);
+	manageIndexEntry(&cheevosIndexAllKeys, "TRUE", false);
 }
 
 std::string FileFilterIndex::getIndexableKey(FileData* game, FilterIndexType type, bool getSecondary)
@@ -258,7 +265,16 @@ std::string FileFilterIndex::getIndexableKey(FileData* game, FilterIndexType typ
 			key = (key.length() >= 4 && key[0] >= '1' && key[0] <= '2') ? key.substr(0, 4) : "";
 			break;
 		}
+
+		case CHEEVOS_FILTER:
+		{
+			if (getSecondary)
+				break;
+
+			key = game->getMetadata(MetaDataId::Cheevos);
+			break;
 	}
+}
 		
 	if (key.empty() || (type == RATINGS_FILTER && key == "0 STARS")) 
 		return UNKNOWN_LABEL;
@@ -911,6 +927,8 @@ bool CollectionFilter::load(const std::string file)
 			langIndexFilteredKeys.insert(node.text().as_string());
 		else if (name == "region")
 			regionIndexFilteredKeys.insert(node.text().as_string());
+		else if (name == "cheevos")
+			cheevosIndexFilteredKeys.insert(node.text().as_string());
 	}
 
 	for (auto& it : mFilterDecl)
@@ -963,6 +981,9 @@ bool CollectionFilter::save()
 
 	for (auto key : regionIndexFilteredKeys)
 		root.append_child("region").text().set(key.c_str());
+
+	for (auto key : cheevosIndexFilteredKeys)
+		root.append_child("cheevos").text().set(key.c_str());
 
 	if (!doc.save_file(mPath.c_str()))
 	{

--- a/es-app/src/FileFilterIndex.h
+++ b/es-app/src/FileFilterIndex.h
@@ -23,7 +23,8 @@ enum FilterIndexType
 	PLAYED_FILTER = 8,
 	LANG_FILTER = 9,
 	REGION_FILTER = 10,
-	FAVORITES_FILTER = 11
+	FAVORITES_FILTER = 11,
+	CHEEVOS_FILTER = 12
 };
 
 struct FilterDataDecl
@@ -57,7 +58,7 @@ public:
 	
 	virtual int showFile(FileData* game);
 	virtual bool isFiltered() { return (!mTextFilter.empty() || filterByGenre || filterByPlayers || filterByPubDev 
-		|| filterByRatings || filterByFavorites || filterByKidGame || filterByPlayed || filterByLang || filterByRegion || filterByYear); };
+		|| filterByRatings || filterByFavorites || filterByKidGame || filterByPlayed || filterByLang || filterByRegion || filterByYear || filterByCheevos); };
 
 	bool isKeyBeingFilteredBy(std::string key, FilterIndexType type);
 	std::vector<FilterDataDecl> getFilterDataDecls();
@@ -101,6 +102,7 @@ protected:
 	bool filterByPlayed;
 	bool filterByLang;
 	bool filterByRegion;
+	bool filterByCheevos;
 
 	std::map<std::string, int> genreIndexAllKeys;
 	std::map<std::string, int> playersIndexAllKeys;
@@ -112,6 +114,7 @@ protected:
 	std::map<std::string, int> playedIndexAllKeys;
 	std::map<std::string, int> langIndexAllKeys;
 	std::map<std::string, int> regionIndexAllKeys;
+	std::map<std::string, int> cheevosIndexAllKeys;
 
 	std::unordered_set<std::string> genreIndexFilteredKeys;
 	std::unordered_set<std::string> playersIndexFilteredKeys;
@@ -123,6 +126,7 @@ protected:
 	std::unordered_set<std::string> playedIndexFilteredKeys;
 	std::unordered_set<std::string> langIndexFilteredKeys;
 	std::unordered_set<std::string> regionIndexFilteredKeys;
+	std::unordered_set<std::string> cheevosIndexFilteredKeys;
 
 	std::string mTextFilter;
 	bool		mUseRelevency;

--- a/es-app/src/MetaData.cpp
+++ b/es-app/src/MetaData.cpp
@@ -69,7 +69,8 @@ void MetaDataList::initMetadata()
 		{ GameTime,         "gametime",    MD_INT,                 "0",                true,       _("Game time"),            _("how long the game has been played in total (seconds)"), false },
 
 		{ Language,         "lang",        MD_STRING,              "",                 false,       _("Languages"),            _("Languages"),				false },
-		{ Region,           "region",      MD_STRING,              "",                 false,       _("Region"),               _("Region"),					false }
+		{ Region,           "region",      MD_STRING,              "",                 false,       _("Region"),               _("Region"),					false },
+		{ Cheevos,          "cheevos",     MD_BOOL,                "false",            false,       _("Has Achievements"),     _("Has Achievements"),		false }
 	};
 	
 	mMetaDataDecls = std::vector<MetaDataDecl>(gameDecls, gameDecls + sizeof(gameDecls) / sizeof(gameDecls[0]));

--- a/es-app/src/MetaData.h
+++ b/es-app/src/MetaData.h
@@ -63,7 +63,8 @@ enum MetaDataId
 	Manual = 30,
 	BoxArt = 31,
 	Wheel = 32,
-	Mix = 33
+	Mix = 33,
+	Cheevos = 34
 };
 
 namespace MetaDataImportType


### PR DESCRIPTION
This will add a metadata option to filter games that use retro achievements. Right now its a manual entry, but I was talking to @fabricecaruso and he will make it a scrapable option for this to be automatic in the future. 



