### PR TITLE
Themable gridtile.cheevos for Retroachievements 

### DIFF
--- a/es-app/src/guis/GuiImageViewer.cpp
+++ b/es-app/src/guis/GuiImageViewer.cpp
@@ -273,7 +273,7 @@ void GuiImageViewer::loadPdf(const std::string& imagePath)
 	mPdf = imagePath;
 	
 	for (int i = 0; i < pages; i++)
-		mGrid.add("", ":/blank.png", "", "", false, false, false, std::to_string(i + 1));
+		mGrid.add("", ":/blank.png", "", "", false, false, false, false, std::to_string(i + 1));
 	
 	if (pages > INITIALPAGES)
 	{
@@ -410,7 +410,7 @@ void GuiImageViewer::add(const std::string imagePath)
 	else
 		img = imagePath;
 	
-	mGrid.add("", img, vid, "", false, false, false, imagePath);
+	mGrid.add("", img, vid, "", false, false, false, false, imagePath);
 }
 
 void GuiImageViewer::setCursor(const std::string imagePath)

--- a/es-app/src/views/gamelist/BasicGameListView.cpp
+++ b/es-app/src/views/gamelist/BasicGameListView.cpp
@@ -98,11 +98,17 @@ void BasicGameListView::populateList(const std::vector<FileData*>& files)
 					continue;
 				
 				if (showFavoriteIcon)
+                  if (file->hasCheevos()) {
+					mList.add(_U("\uF091 \uF006 ") + file->getName(), file, file->getType() == FOLDER);
+                } else {
 					mList.add(_U("\uF006 ") + file->getName(), file, file->getType() == FOLDER);
+                }
 				else if (file->getType() == FOLDER)
 					mList.add(_U("\uF07C ") + file->getName(), file, true);
-				else
+				else if (file->hasCheevos())
 					mList.add(file->getName(), file, false);
+				else 
+					mList.add(_U("\uF091 ") + file->getName(), file, false);
 			}
 		}
 
@@ -115,13 +121,19 @@ void BasicGameListView::populateList(const std::vector<FileData*>& files)
 
 				if (showFavoriteIcon)
 				{
+                 if (file->hasCheevos())
+					mList.add(_U("\uF091 \uF006 ") + file->getName(), file, file->getType() == FOLDER);
+                else
 					mList.add(_U("\uF006 ") + file->getName(), file, file->getType() == FOLDER);
+                
 					continue;
 				}
 			}
 
 			if (file->getType() == FOLDER)
 				mList.add(_U("\uF07C ") + file->getName(), file, true);
+			else if (file->hasCheevos())
+				mList.add(_U("\uF091 ") + file->getName(), file, false); //  + _U(" \uF05A")
 			else
 				mList.add(file->getName(), file, false); //  + _U(" \uF05A")
 		}

--- a/es-app/src/views/gamelist/GridGameListView.cpp
+++ b/es-app/src/views/gamelist/GridGameListView.cpp
@@ -202,7 +202,7 @@ void GridGameListView::populateList(const std::vector<FileData*>& files)
 			if (showParentFolder)
 			{
 				FileData* placeholder = new FileData(PLACEHOLDER, "..", this->mRoot->getSystem());
-				mGrid.add(". .", imagePath, "", "", false, true, displayAsVirtualFolder && !imagePath.empty(), placeholder);
+				mGrid.add(". .", imagePath, "", "", false, true, false, displayAsVirtualFolder && !imagePath.empty(), placeholder);
 			}
 		}
 
@@ -223,7 +223,7 @@ void GridGameListView::populateList(const std::vector<FileData*>& files)
 			for (auto file : files)
 			{
 				if (file->getFavorite() && showFavoriteIcon)
-					mGrid.add(_U("\uF006 ") + file->getName(), getImagePath(file), file->getVideoPath(), file->getMarqueePath(), true, file->getType() != GAME, isVirtualFolder(file), file);
+					mGrid.add(_U("\uF006 ") + file->getName(), getImagePath(file), file->getVideoPath(), file->getMarqueePath(), true, file->hasCheevos(), file->getType() != GAME, isVirtualFolder(file), file);
 			}
 		}
 
@@ -236,15 +236,15 @@ void GridGameListView::populateList(const std::vector<FileData*>& files)
 
 				if (showFavoriteIcon)
 				{
-					mGrid.add(_U("\uF006 ") + file->getName(), getImagePath(file), file->getVideoPath(), file->getMarqueePath(), true, file->getType() != GAME, isVirtualFolder(file), file);
+					mGrid.add(_U("\uF006 ") + file->getName(), getImagePath(file), file->getVideoPath(), file->getMarqueePath(), true, file->hasCheevos(), file->getType() != GAME, isVirtualFolder(file), file);
 					continue;
 				}
 			}
 
 			if (file->getType() == FOLDER && Utils::FileSystem::exists(getImagePath(file)))
-				mGrid.add(_U("\uF07C ") + file->getName(), getImagePath(file), file->getVideoPath(), file->getMarqueePath(), file->getFavorite(), file->getType() != GAME, isVirtualFolder(file), file);
+				mGrid.add(_U("\uF07C ") + file->getName(), getImagePath(file), file->getVideoPath(), file->getMarqueePath(), file->getFavorite(), file->hasCheevos(), file->getType() != GAME, isVirtualFolder(file), file);
 			else
-				mGrid.add(file->getName(), getImagePath(file), file->getVideoPath(), file->getMarqueePath(), file->getFavorite(), file->getType() != GAME, isVirtualFolder(file), file);
+				mGrid.add(file->getName(), getImagePath(file), file->getVideoPath(), file->getMarqueePath(), file->getFavorite(), file->hasCheevos(), file->getType() != GAME, isVirtualFolder(file), file);
 		}
 
 		// if we have the ".." PLACEHOLDER, then select the first game instead of the placeholder
@@ -286,7 +286,7 @@ void GridGameListView::addPlaceholder()
 {
 	// empty grid - add a placeholder
 	FileData* placeholder = new FileData(PLACEHOLDER, "<" + _("No Entries Found") + ">", mRoot->getSystem());
-	mGrid.add(placeholder->getName(), "", "", "", false, false, false, placeholder);
+	mGrid.add(placeholder->getName(), "", "", "", false, false,false,false, placeholder);
 }
 
 void GridGameListView::launch(FileData* game)

--- a/es-core/src/components/GridTileComponent.cpp
+++ b/es-core/src/components/GridTileComponent.cpp
@@ -27,6 +27,7 @@ GridTileComponent::GridTileComponent(Window* window) : GuiComponent(window), mBa
 	mVideo = nullptr;
 	mMarquee = nullptr;
 	mFavorite = nullptr;
+	mCheevos = nullptr;
 	mImageOverlay = nullptr;
 	mIsDefaultImage = false;
 	
@@ -59,6 +60,7 @@ void GridTileComponent::resetProperties()
 	mDefaultProperties.Image = mSelectedProperties.Image = GridImageProperties();	
 	mDefaultProperties.Marquee = mSelectedProperties.Marquee = GridImageProperties();
 	mDefaultProperties.Favorite = mSelectedProperties.Favorite = GridImageProperties();
+	mDefaultProperties.Cheevos = mSelectedProperties.Cheevos = GridImageProperties();
 	mDefaultProperties.Background = mSelectedProperties.Background = GridNinePatchProperties();
 
 	mDefaultProperties.Background.centerColor = mDefaultProperties.Background.edgeColor = 0xAAAAEEFF;
@@ -86,6 +88,9 @@ GridTileComponent::~GridTileComponent()
 	if (mFavorite != nullptr)
 		delete mFavorite;
 
+	if (mCheevos != nullptr)
+		delete mCheevos;
+
 	if (mMarquee != nullptr)
 		delete mMarquee;
 
@@ -93,6 +98,7 @@ GridTileComponent::~GridTileComponent()
 		delete mVideo;
 
 	mFavorite = nullptr;
+    mCheevos = nullptr;
 	mMarquee = nullptr;
 	mImage = nullptr;
 	mVideo = nullptr;
@@ -212,6 +218,9 @@ void GridTileComponent::resize()
 	// Other controls ( Favorite / Marquee / Overlay )
 	if (currentProperties.Favorite.Loaded)
 		currentProperties.Favorite.updateImageComponent(mFavorite, imageOffset, imageSize, false);
+	
+    if (currentProperties.Cheevos.Loaded)
+		currentProperties.Cheevos.updateImageComponent(mCheevos, imageOffset, imageSize, false);
 
 	if (currentProperties.Marquee.Loaded)
 		currentProperties.Marquee.updateImageComponent(mMarquee, imageOffset, imageSize, true);
@@ -372,6 +381,9 @@ void GridTileComponent::renderContent(const Transform4x4f& parentTrans)
 	if (mFavorite != nullptr && mFavorite->hasImage() && mFavorite->isVisible())
 		zOrdered.push_back(mFavorite);
 
+	if (mCheevos != nullptr && mCheevos->hasImage() && mCheevos->isVisible())
+		zOrdered.push_back(mCheevos);
+
 	if (mImageOverlay != nullptr && mImageOverlay->hasImage() && mImageOverlay->isVisible())
 		zOrdered.push_back(mImageOverlay);
 
@@ -415,6 +427,19 @@ void GridTileComponent::createFavorite()
 	mFavorite->setVisible(false);
 	
 	addChild(mFavorite);
+}
+
+void GridTileComponent::createCheevos()
+{
+	if (mCheevos != nullptr)
+		return;
+
+	mCheevos = new ImageComponent(mWindow);
+	mCheevos->setOrigin(0.5f, 0.5f);
+	mCheevos->setDefaultZIndex(15);
+	mCheevos->setVisible(false);
+	
+	addChild(mCheevos);
 }
 
 void GridTileComponent::createImageOverlay()
@@ -742,6 +767,29 @@ void GridTileComponent::applyTheme(const std::shared_ptr<ThemeData>& theme, cons
 		delete mFavorite;
 		mFavorite = nullptr;
 	}
+    
+	// Apply theme to the <image name="gridtile.cheevos"> element
+	elem = theme->getElement(view, "gridtile.cheevos", "image");
+	if (elem)
+	{
+		createCheevos();
+		mCheevos->applyTheme(theme, view, "gridtile.cheevos", ThemeFlags::ALL);
+
+		mDefaultProperties.Cheevos.sizeMode = "size";
+		mDefaultProperties.Cheevos.applyTheme(elem);
+		mSelectedProperties.Cheevos = mDefaultProperties.Cheevos;
+
+		// Apply theme to the <image name="gridtile.cheevos:selected"> element
+		elem = theme->getElement(view, "gridtile.cheevos:selected", "image");
+		if (elem)
+			mSelectedProperties.Cheevos.applyTheme(elem);
+	}
+	else if (mCheevos != nullptr)
+	{
+		removeChild(mCheevos);
+		delete mCheevos;
+		mCheevos = nullptr;
+	}
 
 
 	// Apply theme to the <image name="gridtile.overlay"> element
@@ -828,6 +876,7 @@ void GridTileComponent::applyTheme(const std::shared_ptr<ThemeData>& theme, cons
 	mVideoPlayingProperties.Image.applyTheme(theme->getElement(view, "gridtile.image:videoplaying", "image"));
 	mVideoPlayingProperties.Marquee.applyTheme(theme->getElement(view, "gridtile.marquee:videoplaying", "image"));
 	mVideoPlayingProperties.Favorite.applyTheme(theme->getElement(view, "gridtile.favorite:selected", "image"));
+	mVideoPlayingProperties.Cheevos.applyTheme(theme->getElement(view, "gridtile.cheevos:selected", "image"));
 	mVideoPlayingProperties.ImageOverlay.applyTheme(theme->getElement(view, "gridtile.overlay:videoplaying", "image"));
 }
 
@@ -884,6 +933,15 @@ void GridTileComponent::setMarquee(const std::string& path)
 	else
 		mMarquee->setImage(path, false, MaxSizeInfo(mSize), false);
 
+	resize();
+}
+
+void GridTileComponent::setCheevos(bool cheevos)
+{
+	if (mCheevos == nullptr)
+		return;
+
+	mCheevos->setVisible(cheevos);
 	resize();
 }
 
@@ -1179,6 +1237,7 @@ GridTileProperties GridTileComponent::getCurrentProperties(bool mixValues)
 		prop.Marquee.mixProperties(from->Marquee, to->Marquee, pc);
 				
 		prop.Favorite.mixProperties(from->Favorite, to->Favorite, pc);
+		prop.Cheevos.mixProperties(from->Cheevos, to->Cheevos, pc);
 		prop.ImageOverlay.mixProperties(from->ImageOverlay, to->ImageOverlay, pc);
 	}
 	else if (mSelected && mVideo != nullptr && mVideo->isPlaying() && !mVideo->isFading())

--- a/es-core/src/components/GridTileComponent.h
+++ b/es-core/src/components/GridTileComponent.h
@@ -188,6 +188,7 @@ struct GridTileProperties
 	GridImageProperties		Image;
 	GridImageProperties		Marquee;
 	GridImageProperties		Favorite;
+	GridImageProperties		Cheevos;
 	GridImageProperties		ImageOverlay;
 };
 
@@ -216,6 +217,7 @@ public:
 	void setMarquee(const std::string& path);
 	
 	void setFavorite(bool favorite);
+	void setCheevos(bool favorite);
 	bool hasFavoriteMedia() { return mFavorite != nullptr; }
 
 	void setSelected(bool selected, bool allowAnimation = true, Vector3f* pPosition = NULL, bool force = false);	
@@ -248,6 +250,7 @@ private:
 	void	createVideo();
 	void	createMarquee();
 	void	createFavorite();
+	void	createCheevos();
 	void	createImageOverlay();
 	void	startVideo();
 	void	stopVideo();
@@ -286,6 +289,7 @@ private:
 	ImageComponent* mImage;
 	ImageComponent* mMarquee;
 	ImageComponent* mFavorite;
+	ImageComponent* mCheevos;
 	ImageComponent* mImageOverlay;
 
 	bool mVideoPlaying;	

--- a/es-core/src/components/ImageGridComponent.h
+++ b/es-core/src/components/ImageGridComponent.h
@@ -45,6 +45,7 @@ struct ImageGridData
 	std::string marqueePath;
 	std::string videoPath;
 	bool		favorite;
+	bool		cheevos;
 	bool		folder;
 	bool		virtualFolder;
 };
@@ -71,7 +72,7 @@ public:
 
 	ImageGridComponent(Window* window);
 
-	void add(const std::string& name, const std::string& imagePath, const std::string& videoPath, const std::string& marqueePath, bool favorite, bool folder, bool virtualFolder, const T& obj);
+	void add(const std::string& name, const std::string& imagePath, const std::string& videoPath, const std::string& marqueePath, bool favorite, bool cheevos, bool folder, bool virtualFolder, const T& obj);
 	
 	void setImage(const std::string& imagePath, const T& obj);
 	std::string getImage(const T& obj);
@@ -205,7 +206,7 @@ ImageGridComponent<T>::ImageGridComponent(Window* window) : IList<ImageGridData,
 }
 
 template<typename T>
-void ImageGridComponent<T>::add(const std::string& name, const std::string& imagePath, const std::string& videoPath, const std::string& marqueePath, bool favorite, bool folder, bool virtualFolder, const T& obj)
+void ImageGridComponent<T>::add(const std::string& name, const std::string& imagePath, const std::string& videoPath, const std::string& marqueePath, bool favorite, bool cheevos, bool folder, bool virtualFolder, const T& obj)
 {
 	typename IList<ImageGridData, T>::Entry entry;
 	entry.name = name;
@@ -214,6 +215,7 @@ void ImageGridComponent<T>::add(const std::string& name, const std::string& imag
 	entry.data.videoPath = videoPath;
 	entry.data.marqueePath = marqueePath;
 	entry.data.favorite = favorite;
+	entry.data.cheevos = cheevos;
 	entry.data.folder = folder;
 	entry.data.virtualFolder = virtualFolder;
 
@@ -1089,6 +1091,7 @@ void ImageGridComponent<T>::updateTileAtPos(int tilePos, int imgPos, bool allowA
 		}
 
 		tile->setFavorite(mEntries.at(imgPos).data.favorite);
+		tile->setCheevos(mEntries.at(imgPos).data.cheevos);
 
 		// Video
 		if (mAllowVideo && imgPos == mCursor)


### PR DESCRIPTION
This will add a themable cheevos icon (similar to the favorite star) for games that have cheevos, used in conjunction with the cheevos scan.

I tried this on my branch (EmuELEC), I have not tried it on the Batocera ES directly, before merging someone should test this first just to make sure nothing else breaks in Batocera. 

A (very bad) example image using:
```
    <image name="gridtile.cheevos">
         <path>./assets/trophy.svg</path>
         <pos>0.0 0.4</pos>
        <maxSize>0.15 0.15</maxSize>
        <origin>0 1</origin>
         <color>282828</color>
      </image>
        
      <image name="gridtile.cheevos:selected">
         <path>./assets/trophy.svg</path>
         <color>${cgtbgedgeselect}</color>
      </image>
```
![20201227011240576](https://user-images.githubusercontent.com/18634770/103176945-89f90200-483b-11eb-9962-0f675f455fd1.png)
