### PR TITLE
Fix for OGS (small screen)

### DIFF
--- a/es-core/src/renderers/Renderer.cpp
+++ b/es-core/src/renderers/Renderer.cpp
@@ -367,7 +367,7 @@ namespace Renderer
 
 	bool        isSmallScreen()    
 	{ 		
-		return screenWidth < 400 || screenHeight < 400; 
+		return screenWidth <= 480 || screenHeight <= 480; 
 	};
 
 	bool isClippingEnabled() { return !clipStack.empty(); }


### PR DESCRIPTION
In order to make the OGS layout as "small screen" (otherwise fonts are too small to be read).
It might have a side effect for those using 640x480 resolution -- but actually the "small screen" layout might be better for them as well. Let's see what their feedback is.