### PR TITLE
FindOpenGLES2: Use pkg-config

### DIFF
--- a/CMake/Packages/FindOpenGLES2.cmake
+++ b/CMake/Packages/FindOpenGLES2.cmake
@@ -12,15 +12,25 @@ if(NOT HINT_GLES_LIBNAME)
  set(HINT_GLES_LIBNAME GLESv2)
 endif()
 
-find_path(OPENGLES2_INCLUDE_DIR GLES2/gl2.h
-    PATHS "${CMAKE_FIND_ROOT_PATH}/usr/include"
-    HINTS ${HINT_GLES_INCDIR}
-)
+find_package(PkgConfig)
+if(PKG_CONFIG_FOUND)
+    pkg_check_modules(OPENGLES2 glesv2)
+endif()
 
-find_library(OPENGLES2_gl_LIBRARY
-    NAMES ${HINT_GLES_LIBNAME}
-    HINTS ${HINT_GLES_LIBDIR}
-)
+if(OPENGLES2_FOUND)
+    set(OPENGLES2_INCLUDE_DIR ${OPENGLES2_INCLUDE_DIRS})
+    set(OPENGLES2_gl_LIBRARY ${OPENGLES2_LIBRARIES})
+else()
+    find_path(OPENGLES2_INCLUDE_DIR GLES2/gl2.h
+        PATHS "${CMAKE_FIND_ROOT_PATH}/usr/include"
+        HINTS ${HINT_GLES_INCDIR}
+    )
+
+    find_library(OPENGLES2_gl_LIBRARY
+        NAMES ${HINT_GLES_LIBNAME}
+        HINTS ${HINT_GLES_LIBDIR}
+    )
+endif()
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(OpenGLES2


### PR DESCRIPTION
pkg-config may provide additional link flags, such as `-lmali` in the newer libmali versions.

Fixes #741