### PR TITLE
Retroachievements : Fix hashes calculation for some zip files

### DIFF
--- a/es-app/src/ApiSystem.cpp
+++ b/es-app/src/ApiSystem.cpp
@@ -837,7 +837,7 @@ std::string ApiSystem::getMD5(const std::string fileName, bool fromZipContents)
 
 	if (fromZipContents && ext == ".7z")
 	{
-		tmpZipDirectory = Utils::FileSystem::getTempPath() + "/" + Utils::FileSystem::getStem(fileName);
+		tmpZipDirectory = Utils::FileSystem::combine(Utils::FileSystem::getTempPath(), Utils::FileSystem::getStem(fileName));
 		Utils::FileSystem::deleteDirectoryFiles(tmpZipDirectory);
 
 		if (unzipFile(fileName, tmpZipDirectory))

--- a/es-app/src/ApiSystem.cpp
+++ b/es-app/src/ApiSystem.cpp
@@ -930,37 +930,28 @@ bool ApiSystem::unzipFile(const std::string fileName, const std::string destFold
 		
 	if (Utils::String::toLower(Utils::FileSystem::getExtension(fileName)) == ".zip")
 	{
-		// 10 Mb max : If file is too big, prefer external decompression
-		if (getSevenZipCommand().empty())
-		{			
-			LOG(LogDebug) << "unzipFile is using ZipFile";
+		LOG(LogDebug) << "unzipFile is using ZipFile";
 
-			try
+		Utils::Zip::ZipFile file;
+		if (file.load(fileName))
+		{
+			for (auto name : file.namelist())
 			{
-				Utils::Zip::ZipFile file;
-				if (file.load(fileName))
+				if (Utils::String::endsWith(name, "/"))
 				{
-					for (auto name : file.namelist())
-					{
-						if (Utils::String::endsWith(name, "/"))
-						{
-							Utils::FileSystem::createDirectory(destFolder + "/" + name.substr(0, name.length() - 1));
-							continue;
-						}
-
-						file.extract(name, destFolder);
-					}
-
-					LOG(LogDebug) << "unzipFile << OK";
-					return true;
+					Utils::FileSystem::createDirectory(destFolder + "/" + name.substr(0, name.length() - 1));
+					continue;
 				}
+
+				file.extract(name, destFolder);
 			}
-			catch (...)
-			{
-				LOG(LogDebug) << "unzipFile << KO";
-				return false;
-			}
+
+			LOG(LogDebug) << "unzipFile << OK";
+			return true;
 		}
+
+		LOG(LogDebug) << "unzipFile << KO Bad format ?" << fileName;
+		return false;
 	}
 	
 	LOG(LogDebug) << "unzipFile is using 7z";

--- a/es-app/src/Gamelist.cpp
+++ b/es-app/src/Gamelist.cpp
@@ -193,22 +193,7 @@ std::vector<FileData*> loadGamelistFile(const std::string xmlpath, SystemData* s
 void clearTemporaryGamelistRecovery(SystemData* system)
 {	
 	auto path = getGamelistRecoveryPath(system);
-
-	auto files = Utils::FileSystem::getDirContent(path, true);
-	if (files.size() > 0)
-	{
-		for (auto file : files)
-			if (!Utils::FileSystem::isDirectory(file))
-				Utils::FileSystem::removeFile(file);
-
-		std::reverse(std::begin(files), std::end(files));
-
-		for (auto file : files)
-			if (Utils::FileSystem::isDirectory(file))
-				rmdir(file.c_str());
-	}
-
-	rmdir(path.c_str());
+	Utils::FileSystem::deleteDirectoryFiles(path, true);
 }
 
 void parseGamelist(SystemData* system, std::unordered_map<std::string, FileData*>& fileMap)

--- a/es-app/src/RetroAchievements.cpp
+++ b/es-app/src/RetroAchievements.cpp
@@ -535,10 +535,7 @@ std::string RetroAchievements::getCheevosHash( SystemData* system, const std::st
 		ret = ApiSystem::getInstance()->getMD5(contentFile, false);
 
 	if (!tmpZipDirectory.empty())
-	{
-		Utils::FileSystem::deleteDirectoryFiles(tmpZipDirectory);
-		Utils::FileSystem::removeFile(tmpZipDirectory);
-	}
+		Utils::FileSystem::deleteDirectoryFiles(tmpZipDirectory, true);
 
 	return ret;
 }

--- a/es-app/src/RetroAchievements.cpp
+++ b/es-app/src/RetroAchievements.cpp
@@ -514,7 +514,7 @@ std::string RetroAchievements::getCheevosHash( SystemData* system, const std::st
 
 	if (fromZipContents)
 	{
-		tmpZipDirectory = Utils::FileSystem::getTempPath() + "/" + Utils::FileSystem::getStem(fileName);
+		tmpZipDirectory = Utils::FileSystem::combine(Utils::FileSystem::getTempPath(), Utils::FileSystem::getStem(fileName));
 		Utils::FileSystem::deleteDirectoryFiles(tmpZipDirectory);		
 
 		if (ApiSystem::getInstance()->unzipFile(fileName, tmpZipDirectory))

--- a/es-app/src/RetroAchievements.cpp
+++ b/es-app/src/RetroAchievements.cpp
@@ -515,7 +515,7 @@ std::string RetroAchievements::getCheevosHash( SystemData* system, const std::st
 	if (fromZipContents)
 	{
 		tmpZipDirectory = Utils::FileSystem::getTempPath() + "/" + Utils::FileSystem::getStem(fileName);
-		Utils::FileSystem::deleteDirectoryFiles(tmpZipDirectory);
+		Utils::FileSystem::deleteDirectoryFiles(tmpZipDirectory);		
 
 		if (ApiSystem::getInstance()->unzipFile(fileName, tmpZipDirectory))
 		{

--- a/es-app/src/guis/GuiImageViewer.cpp
+++ b/es-app/src/guis/GuiImageViewer.cpp
@@ -469,8 +469,7 @@ GuiImageViewer::~GuiImageViewer()
 	}
 
 	auto pdfFolder = Utils::FileSystem::getPdfTempPath();
-	Utils::FileSystem::deleteDirectoryFiles(pdfFolder);
-	Utils::FileSystem::removeDirectory(pdfFolder);
+	Utils::FileSystem::deleteDirectoryFiles(pdfFolder, true);
 }
 
 bool GuiImageViewer::input(InputConfig* config, Input input)

--- a/es-app/src/guis/GuiImageViewer.cpp
+++ b/es-app/src/guis/GuiImageViewer.cpp
@@ -468,11 +468,9 @@ GuiImageViewer::~GuiImageViewer()
 		delete mPdfThreads;
 	}
 
-	Utils::FileSystem::getTempPath();
-
 	auto pdfFolder = Utils::FileSystem::getPdfTempPath();
 	Utils::FileSystem::deleteDirectoryFiles(pdfFolder);
-	Utils::FileSystem::removeDirectory(pdfFolder.c_str());
+	Utils::FileSystem::removeDirectory(pdfFolder);
 }
 
 bool GuiImageViewer::input(InputConfig* config, Input input)

--- a/es-app/src/guis/GuiKeyboardLayout.cpp
+++ b/es-app/src/guis/GuiKeyboardLayout.cpp
@@ -62,8 +62,8 @@ GuiKeyboardLayout::GuiKeyboardLayout(Window* window, const std::function<void(co
 GuiKeyboardLayout::~GuiKeyboardLayout()
 {
 #if WIN32
-	Utils::FileSystem::removeFile(Utils::FileSystem::getGenericPath(Utils::FileSystem::getEsConfigPath() + "/tmp/kblayout-1.svg"));
-	Utils::FileSystem::removeFile(Utils::FileSystem::getGenericPath(Utils::FileSystem::getEsConfigPath() + "/tmp/kblayout-2.svg"));
+	Utils::FileSystem::removeFile(Utils::FileSystem::getGenericPath(Utils::FileSystem::getTempPath() + "/kblayout-1.svg"));
+	Utils::FileSystem::removeFile(Utils::FileSystem::getGenericPath(Utils::FileSystem::getTempPath() + "/kblayout-2.svg"));
 #else
 	Utils::FileSystem::removeFile("/tmp/kblayout-1.svg");
 	Utils::FileSystem::removeFile("/tmp/kblayout-2.svg");
@@ -156,7 +156,7 @@ void GuiKeyboardLayout::selectKey(const std::string& keyName)
 	svg = Utils::String::replace(svg, "inkscape:connector-curvature=\"0\"", "");
 
 #if WIN32
-	auto newPath = Utils::FileSystem::getGenericPath(Utils::FileSystem::getEsConfigPath() + "/tmp/kblayout"+ std::string(mImageToggle ? "-1" : "-2") +".svg");
+	auto newPath = Utils::FileSystem::getGenericPath(Utils::FileSystem::getTempPath() + "/kblayout"+ std::string(mImageToggle ? "-1" : "-2") +".svg");
 #else
 	auto newPath = "/tmp/kblayout" + std::string(mImageToggle ? "-1" : "-2") + ".svg";
 #endif

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -1754,38 +1754,18 @@ void GuiMenu::openGamesSettings_batocera()
 	}
 
 	// smoothing
-	/*
-	auto smoothing_enabled = std::make_shared<OptionListComponent<std::string>>(mWindow, _("SMOOTH GAMES"));
-	smoothing_enabled->addRange({ { _("AUTO"), "auto" },{ _("ON") , "1" },{ _("OFF") , "0" } }, SystemConf::getInstance()->get("global.smooth"));
-	s->addWithLabel(_("SMOOTH GAMES"), smoothing_enabled);
-	s->addSaveFunc([smoothing_enabled] { SystemConf::getInstance()->set("global.smooth", smoothing_enabled->getSelected()); });
-	*/
 	auto smoothing_enabled = std::make_shared<SwitchComponent>(mWindow);
 	smoothing_enabled->setState(SystemConf::getInstance()->get("global.smooth") == "1");
 	s->addWithLabel(_("SMOOTH GAMES"), smoothing_enabled);
 	s->addSaveFunc([smoothing_enabled] { SystemConf::getInstance()->set("global.smooth", smoothing_enabled->getState() ? "1": "auto"); });
 
 	// rewind
-	/*
-	auto rewind_enabled = std::make_shared<OptionListComponent<std::string>>(mWindow, _("REWIND"));
-	rewind_enabled->addRange({ { _("AUTO"), "auto" },{ _("ON") , "1" },{ _("OFF") , "0" } }, SystemConf::getInstance()->get("global.rewind"));
-	s->addWithLabel(_("REWIND"), rewind_enabled);
-	s->addSaveFunc([rewind_enabled] { SystemConf::getInstance()->set("global.rewind", rewind_enabled->getSelected()); });
-	*/
 	auto rewind_enabled = std::make_shared<SwitchComponent>(mWindow);
 	rewind_enabled->setState(SystemConf::getInstance()->get("global.rewind") == "1");
 	s->addWithLabel(_("REWIND"), rewind_enabled);
 	s->addSaveFunc([rewind_enabled] { SystemConf::getInstance()->set("global.rewind", rewind_enabled->getState() ? "1" : "auto"); });
 	
-
 	// Integer scale
-	/*
-	auto integerscale_enabled = std::make_shared<OptionListComponent<std::string>>(mWindow, _("INTEGER SCALE (PIXEL PERFECT)"));
-	integerscale_enabled->addRange({ { _("AUTO"), "auto" },{ _("ON") , "1" },{ _("OFF") , "0" } }, SystemConf::getInstance()->get("global.integerscale"));
-	s->addWithLabel(_("INTEGER SCALE (PIXEL PERFECT)"), integerscale_enabled);
-	s->addSaveFunc([integerscale_enabled] { SystemConf::getInstance()->set("global.integerscale", integerscale_enabled->getSelected()); });
-	*/
-
 	auto integerscale_enabled = std::make_shared<SwitchComponent>(mWindow);
 	integerscale_enabled->setState(SystemConf::getInstance()->get("global.integerscale") == "1");
 	s->addWithLabel(_("INTEGER SCALE (PIXEL PERFECT)"), integerscale_enabled);
@@ -1793,7 +1773,6 @@ void GuiMenu::openGamesSettings_batocera()
 
 	// autosave/load
 	auto autosave_enabled = std::make_shared<OptionListComponent<std::string>>(mWindow, _("AUTO SAVE/LOAD"));
-//	autosave_enabled->addRange({ { _("AUTO"), "auto" },{ _("ON") , "1" },{ _("OFF") , "0" } }, SystemConf::getInstance()->get("global.autosave"));
 	autosave_enabled->addRange({ { _("OFF"), "auto" },{ _("ON") , "1" },{ _("SHOW SAVE SNAPSHOTS") , "2" } }, SystemConf::getInstance()->get("global.autosave"));
 	s->addWithLabel(_("AUTO SAVE/LOAD"), autosave_enabled);
 	s->addSaveFunc([autosave_enabled] 
@@ -3509,7 +3488,7 @@ void GuiMenu::popSystemConfigurationGui(Window* mWindow, SystemData* systemData)
 void GuiMenu::popGameConfigurationGui(Window* mWindow, FileData* fileData)
 {
 	popSpecificConfigurationGui(mWindow,
-		fileData->getCleanName(), // Utils::FileSystem::getFileName(fileData->getFileName()),
+		fileData->getCleanName(),
 		fileData->getConfigurationName(),
 		fileData->getSourceFileData()->getSystem(),
 		fileData);
@@ -3602,9 +3581,7 @@ void GuiMenu::popSpecificConfigurationGui(Window* mWindow, std::string title, st
 	if (systemData->isFeatureSupported(currentEmulator, currentCore, EmulatorFeatures::smooth))
 	{
 		auto smoothing_enabled = std::make_shared<OptionListComponent<std::string>>(mWindow, _("SMOOTH GAMES"));
-		smoothing_enabled->add(_("AUTO"), "auto", SystemConf::getInstance()->get(configName + ".smooth") != "0" && SystemConf::getInstance()->get(configName + ".smooth") != "1");
-		smoothing_enabled->add(_("ON"), "1", SystemConf::getInstance()->get(configName + ".smooth") == "1");
-		smoothing_enabled->add(_("OFF"), "0", SystemConf::getInstance()->get(configName + ".smooth") == "0");
+		smoothing_enabled->addRange({ { _("AUTO"), "auto" },{ _("ON") , "1" },{ _("OFF"), "0" } }, SystemConf::getInstance()->get(configName + ".smooth"));
 		systemConfiguration->addWithLabel(_("SMOOTH GAMES"), smoothing_enabled);
 		systemConfiguration->addSaveFunc([configName, smoothing_enabled] { SystemConf::getInstance()->set(configName + ".smooth", smoothing_enabled->getSelected()); });
 	}
@@ -3613,13 +3590,7 @@ void GuiMenu::popSpecificConfigurationGui(Window* mWindow, std::string title, st
 	if (systemData->isFeatureSupported(currentEmulator, currentCore, EmulatorFeatures::rewind))
 	{
 		auto rewind_enabled = std::make_shared<OptionListComponent<std::string>>(mWindow, _("REWIND"));
-		/*
-		rewind_enabled->add(_("AUTO"), "auto", SystemConf::getInstance()->get(configName + ".rewind") != "0" && SystemConf::getInstance()->get(configName + ".rewind") != "1");
-		rewind_enabled->add(_("ON"), "1", SystemConf::getInstance()->get(configName + ".rewind") == "1");
-		rewind_enabled->add(_("OFF"), "0", SystemConf::getInstance()->get(configName + ".rewind") == "0");
-		*/
-		rewind_enabled->addRange({ { _("AUTO"), "auto" }, { _("ON") , "1" }, { _("OFF"), "0" }, { _("SHOW SAVE SNAPSHOTS") , "2" } }, SystemConf::getInstance()->get(configName + ".rewind"));
-
+		rewind_enabled->addRange({ { _("AUTO"), "auto" }, { _("ON") , "1" }, { _("OFF"), "0" } }, SystemConf::getInstance()->get(configName + ".rewind"));
 		systemConfiguration->addWithLabel(_("REWIND"), rewind_enabled);
 		systemConfiguration->addSaveFunc([configName, rewind_enabled] { SystemConf::getInstance()->set(configName + ".rewind", rewind_enabled->getSelected()); });
 	}
@@ -3629,12 +3600,6 @@ void GuiMenu::popSpecificConfigurationGui(Window* mWindow, std::string title, st
 	{
 		auto autosave_enabled = std::make_shared<OptionListComponent<std::string>>(mWindow, _("AUTO SAVE/LOAD"));
 		autosave_enabled->addRange({ { _("AUTO"), "auto" }, { _("ON") , "1" }, { _("OFF"), "0" }, { _("SHOW SAVE SNAPSHOTS") , "2" } }, SystemConf::getInstance()->get(configName + ".autosave"));
-		/*
-		autosave_enabled->add(_("AUTO"), "auto", autosave != "0" && autosave != "1" && autosave != "2");
-		autosave_enabled->add(_("ON"), "1", autosave == "1");
-		autosave_enabled->add(_("OFF"), "0", autosave == "0");
-		autosave_enabled->add(_("SHOW SAVE SNAPSHOTS"), "2", autosave == "2");
-		*/
 		systemConfiguration->addWithLabel(_("AUTO SAVE/LOAD"), autosave_enabled);
 		systemConfiguration->addSaveFunc([configName, autosave_enabled] { SystemConf::getInstance()->set(configName + ".autosave", autosave_enabled->getSelected()); });
 	}
@@ -3667,9 +3632,7 @@ void GuiMenu::popSpecificConfigurationGui(Window* mWindow, std::string title, st
 	if (systemData->isFeatureSupported(currentEmulator, currentCore, EmulatorFeatures::pixel_perfect))
 	{
 		auto integerscale_enabled = std::make_shared<OptionListComponent<std::string>>(mWindow, _("INTEGER SCALE (PIXEL PERFECT)"));
-		integerscale_enabled->add(_("AUTO"), "auto", SystemConf::getInstance()->get(configName + ".integerscale") != "0" && SystemConf::getInstance()->get(configName + ".integerscale") != "1");
-		integerscale_enabled->add(_("ON"), "1", SystemConf::getInstance()->get(configName + ".integerscale") == "1");
-		integerscale_enabled->add(_("OFF"), "0", SystemConf::getInstance()->get(configName + ".integerscale") == "0");
+		integerscale_enabled->addRange({ { _("AUTO"), "auto" },{ _("ON") , "1" },{ _("OFF"), "0" } }, SystemConf::getInstance()->get(configName + ".integerscale"));
 		systemConfiguration->addWithLabel(_("INTEGER SCALE (PIXEL PERFECT)"), integerscale_enabled);
 		systemConfiguration->addSaveFunc([integerscale_enabled, configName] { SystemConf::getInstance()->set(configName + ".integerscale", integerscale_enabled->getSelected()); });
 	}
@@ -3881,13 +3844,10 @@ void GuiMenu::popSpecificConfigurationGui(Window* mWindow, std::string title, st
 	// ps2 full boot
 	if (systemData->isFeatureSupported(currentEmulator, currentCore, EmulatorFeatures::fullboot))
 	{
-		auto fullboot_enabled = std::make_shared<OptionListComponent<std::string>>(mWindow, _("FULL BOOT"));
-		fullboot_enabled->add(_("AUTO"), "auto", SystemConf::getInstance()->get(configName + ".fullboot") != "0" && SystemConf::getInstance()->get(configName + ".fullboot") != "1");
-		fullboot_enabled->add(_("ON"), "1", SystemConf::getInstance()->get(configName + ".fullboot") == "1");
-		fullboot_enabled->add(_("OFF"), "0", SystemConf::getInstance()->get(configName + ".fullboot") == "0");
-
 		if (SystemData::es_features_loaded || (!SystemData::es_features_loaded && systemData->getName() == "ps2")) // only for ps2			
 		{
+			auto fullboot_enabled = std::make_shared<OptionListComponent<std::string>>(mWindow, _("FULL BOOT"));
+			fullboot_enabled->addRange({ { _("AUTO"), "auto" },{ _("ON") , "1" },{ _("OFF"), "0" } }, SystemConf::getInstance()->get(configName + ".fullboot"));
 			systemConfiguration->addWithLabel(_("FULL BOOT"), fullboot_enabled);
 			systemConfiguration->addSaveFunc([fullboot_enabled, configName] { SystemConf::getInstance()->set(configName + ".fullboot", fullboot_enabled->getSelected()); });
 		}
@@ -3896,13 +3856,10 @@ void GuiMenu::popSpecificConfigurationGui(Window* mWindow, std::string title, st
 	// wii emulated wiimotes
 	if (systemData->isFeatureSupported(currentEmulator, currentCore, EmulatorFeatures::emulated_wiimotes))
 	{
-		auto emulatedwiimotes_enabled = std::make_shared<OptionListComponent<std::string>>(mWindow, _("EMULATED WIIMOTES"));
-		emulatedwiimotes_enabled->add(_("AUTO"), "auto", SystemConf::getInstance()->get(configName + ".emulatedwiimotes") != "0" && SystemConf::getInstance()->get(configName + ".emulatedwiimotes") != "1");
-		emulatedwiimotes_enabled->add(_("ON"), "1", SystemConf::getInstance()->get(configName + ".emulatedwiimotes") == "1");
-		emulatedwiimotes_enabled->add(_("OFF"), "0", SystemConf::getInstance()->get(configName + ".emulatedwiimotes") == "0");
-
 		if (SystemData::es_features_loaded || (!SystemData::es_features_loaded && systemData->getName() == "wii"))  // only for wii
 		{
+			auto emulatedwiimotes_enabled = std::make_shared<OptionListComponent<std::string>>(mWindow, _("EMULATED WIIMOTES"));
+			emulatedwiimotes_enabled->addRange({ { _("AUTO"), "auto" },{ _("ON") , "1" },{ _("OFF"), "0" } }, SystemConf::getInstance()->get(configName + ".emulatedwiimotes"));
 			systemConfiguration->addWithLabel(_("EMULATED WIIMOTES"), emulatedwiimotes_enabled);
 			systemConfiguration->addSaveFunc([emulatedwiimotes_enabled, configName] { SystemConf::getInstance()->set(configName + ".emulatedwiimotes", emulatedwiimotes_enabled->getSelected()); });
 		}
@@ -3911,13 +3868,10 @@ void GuiMenu::popSpecificConfigurationGui(Window* mWindow, std::string title, st
 	// citra change screen layout
 	if (systemData->isFeatureSupported(currentEmulator, currentCore, EmulatorFeatures::screen_layout))
 	{
-		auto changescreen_layout = std::make_shared<OptionListComponent<std::string>>(mWindow, _("CHANGE SCREEN LAYOUT"));
-		changescreen_layout->add(_("AUTO"), "auto", SystemConf::getInstance()->get(configName + ".layout_option") != "2" && SystemConf::getInstance()->get(configName + ".layout_option") != "3");
-		changescreen_layout->add(_("LARGE SCREEN"), "2", SystemConf::getInstance()->get(configName + ".layout_option") == "2");
-		changescreen_layout->add(_("SIDE BY SIDE"), "3", SystemConf::getInstance()->get(configName + ".layout_option") == "3");
-
 		if (SystemData::es_features_loaded || (!SystemData::es_features_loaded && systemData->getName() == "3ds"))  // only for 3ds
 		{
+			auto changescreen_layout = std::make_shared<OptionListComponent<std::string>>(mWindow, _("CHANGE SCREEN LAYOUT"));
+			changescreen_layout->addRange({ { _("AUTO"), "auto" },{ _("LARGE SCREEN") , "2" },{ _("SIDE BY SIDE"), "3" } }, SystemConf::getInstance()->get(configName + ".layout_option"));
 			systemConfiguration->addWithLabel(_("CHANGE SCREEN LAYOUT"), changescreen_layout);
 			systemConfiguration->addSaveFunc([changescreen_layout, configName] { SystemConf::getInstance()->set(configName + ".layout_option", changescreen_layout->getSelected()); });
 		}
@@ -4007,6 +3961,9 @@ std::shared_ptr<OptionListComponent<std::string>> GuiMenu::createRatioOptionList
 	for (auto ratio = ratioMap->begin(); ratio != ratioMap->end(); ratio++)
 		ratio_choice->add(_(ratio->first.c_str()), ratio->second, currentRatio == ratio->second);	
 
+	if (!ratio_choice->hasSelection())
+		ratio_choice->selectFirstItem();
+	
 	return ratio_choice;
 }
 
@@ -4036,6 +3993,9 @@ std::shared_ptr<OptionListComponent<std::string>> GuiMenu::createVideoResolution
 
 		videoResolutionMode_choice->add(vname, tokens.at(0), currentVideoMode == tokens.at(0));
 	}
+
+	if (!videoResolutionMode_choice->hasSelection())
+		videoResolutionMode_choice->selectFirstItem();
 
 	return videoResolutionMode_choice;
 }

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -782,6 +782,7 @@ void GuiMenu::openDeveloperSettings()
 		auto rootPath = Utils::FileSystem::getGenericPath(Utils::FileSystem::getEsConfigPath());
 
 		Utils::FileSystem::deleteDirectoryFiles(rootPath + "/tmp/");
+		Utils::FileSystem::deleteDirectoryFiles(Utils::FileSystem::getTempPath());
 		Utils::FileSystem::deleteDirectoryFiles(Utils::FileSystem::getPdfTempPath());
 
 		ViewController::reloadAllGames(mWindow, false);

--- a/es-app/src/scrapers/ArcadeDBJSONScraper.cpp
+++ b/es-app/src/scrapers/ArcadeDBJSONScraper.cpp
@@ -153,27 +153,27 @@ void processGame(const Value& game, std::vector<ScraperSearchResult>& results)
 	// Process medias
 	auto art = findMedia(game, Settings::getInstance()->getString("ScrapperImageSrc"));
 	if (!art.empty())
-		result.urls[MetaDataId::Image] = ScraperSearchItem(art);
+		result.urls[MetaDataId::Image] = ScraperSearchItem(art, ".png");
 
 	if (!Settings::getInstance()->getString("ScrapperThumbSrc").empty() && Settings::getInstance()->getString("ScrapperThumbSrc") != Settings::getInstance()->getString("ScrapperImageSrc"))
 	{
 		auto art = findMedia(game, Settings::getInstance()->getString("ScrapperThumbSrc"));
 		if (!art.empty())
-			result.urls[MetaDataId::Thumbnail] = ScraperSearchItem(art);
+			result.urls[MetaDataId::Thumbnail] = ScraperSearchItem(art, ".png");
 	}
 
 	if (!Settings::getInstance()->getString("ScrapperLogoSrc").empty())
 	{
 		auto art = findMedia(game, Settings::getInstance()->getString("ScrapperLogoSrc"));
 		if (!art.empty())
-			result.urls[MetaDataId::Marquee] = ScraperSearchItem(art);
+			result.urls[MetaDataId::Marquee] = ScraperSearchItem(art, ".png");
 	}
 
 	if (Settings::getInstance()->getBool("ScrapeTitleShot"))
 	{
 		auto art = findMedia(game, "sstitle");
 		if (!art.empty())
-			result.urls[MetaDataId::TitleShot] = ScraperSearchItem(art);
+			result.urls[MetaDataId::TitleShot] = ScraperSearchItem(art, ".png");
 	}
 
 	if (Settings::getInstance()->getBool("ScrapeVideos"))

--- a/es-app/src/scrapers/Scraper.h
+++ b/es-app/src/scrapers/Scraper.h
@@ -125,6 +125,7 @@ public:
 	void update() override;
 
 	virtual int getPercent();
+	std::string getImageFileName() { return mSavePath; }
 
 private:
 	HttpReq* mRequest;
@@ -166,7 +167,7 @@ private:
 	class ResolvePair
 	{	
 	public:
-		ResolvePair(std::function<std::unique_ptr<AsyncHandle>()> _invoker, std::function<void()> _function, std::string _name, std::string _source)
+		ResolvePair(std::function<std::unique_ptr<ImageDownloadHandle>()> _invoker, std::function<void(ImageDownloadHandle* result)> _function, std::string _name, std::string _source)
 		{
 			func = _invoker;
 			onFinished = _function;
@@ -179,14 +180,14 @@ private:
 			handle = func();
 		}
 	
-		std::function<void()> onFinished;
+		std::function<void(ImageDownloadHandle* result)> onFinished;
 		std::string name;
 		std::string source;
 
-		std::unique_ptr<AsyncHandle> handle;
+		std::unique_ptr<ImageDownloadHandle> handle;
 
 	private:
-		std::function<std::unique_ptr<AsyncHandle>()> func;
+		std::function<std::unique_ptr<ImageDownloadHandle>()> func;
 	};
 
 	std::vector<ResolvePair*> mFuncs;

--- a/es-app/src/views/gamelist/DetailedContainer.h
+++ b/es-app/src/views/gamelist/DetailedContainer.h
@@ -113,4 +113,5 @@ protected:
 	DateTimeComponent mReleaseDate, mLastPlayed;
 
 	std::vector<MdImage> mdImages;
+	bool		mState;
 };

--- a/es-core/src/GuiComponent.cpp
+++ b/es-core/src/GuiComponent.cpp
@@ -350,11 +350,11 @@ void GuiComponent::setAnimation(Animation* anim, int delay, std::function<void()
 	auto it = mAnimationMap.find(slot);
 	if (it != mAnimationMap.cend() && it->second != nullptr)
 		oldAnim = it->second;
+	
+	if (oldAnim)
+		delete oldAnim;
 
 	mAnimationMap[slot] = new AnimationController(anim, delay, finishedCallback, reverse);
-
-	if(oldAnim)
-		delete oldAnim;
 }
 
 bool GuiComponent::stopAnimation(unsigned char slot)

--- a/es-core/src/HttpReq.cpp
+++ b/es-core/src/HttpReq.cpp
@@ -323,6 +323,10 @@ HttpReq::Status HttpReq::status()
 					int http_status_code;
 					curl_easy_getinfo(msg->easy_handle, CURLINFO_RESPONSE_CODE, &http_status_code);
 
+					char *ct = NULL;
+					if (!curl_easy_getinfo(msg->easy_handle, CURLINFO_CONTENT_TYPE, &ct) && ct)
+						req->mResponseContentType = ct;
+
 					if (http_status_code < 200 || http_status_code > 299)
 					{
 						std::string err;

--- a/es-core/src/HttpReq.h
+++ b/es-core/src/HttpReq.h
@@ -68,6 +68,7 @@ public:
 
 	std::string getUrl() { return mUrl; }
 	std::string getFilePath() { return mFilePath; }
+	std::string getResponseContentType() { return mResponseContentType; }
 
 	bool wait();
 
@@ -96,6 +97,8 @@ private:
 	std::string   mFilePath;
 	std::string   mTempStreamPath;	
 	FILE*		  mFile;
+
+	std::string   mResponseContentType;
 
 	std::string mErrorMsg;
 	std::string mUrl;

--- a/es-core/src/ImageIO.cpp
+++ b/es-core/src/ImageIO.cpp
@@ -268,6 +268,7 @@ static bool _isCachablePath(const std::string& path)
 	return 
 		path.find("/themes/") == std::string::npos && 
 		path.find("/tmp/") != std::string::npos &&
+		path.find("/emulationstation.tmp/") != std::string::npos &&
 		path.find("/pdftmp/") == std::string::npos && 
 		path.find("/saves/") != std::string::npos;
 }

--- a/es-core/src/Log.cpp
+++ b/es-core/src/Log.cpp
@@ -48,7 +48,7 @@ void Log::init()
 	remove((getLogPath() + ".bak").c_str());
 
 	// rename previous log file
-	rename(getLogPath().c_str(), (getLogPath() + ".bak").c_str());
+	Utils::FileSystem::renameFile(getLogPath(), getLogPath() + ".bak");
 
 	file = fopen(getLogPath().c_str(), "w");
 	dirty = false;

--- a/es-core/src/utils/FileSystemUtil.cpp
+++ b/es-core/src/utils/FileSystemUtil.cpp
@@ -1296,23 +1296,50 @@ namespace Utils
 
 		std::string getTempPath()
 		{
-			return Utils::FileSystem::getGenericPath(Utils::FileSystem::getEsConfigPath() + "/tmp/");
+			static std::string path;
+
+			if (!path.empty())
+				return path;
+
+#ifdef WIN32
+			// Set tmp files to local drive : usually faster since it's generally a SSD Drive
+			WCHAR lpTempPathBuffer[MAX_PATH];
+			lpTempPathBuffer[0] = 0;
+			DWORD dwRetVal = ::GetTempPathW(MAX_PATH, lpTempPathBuffer);
+			if (dwRetVal > 0 && dwRetVal <= MAX_PATH)
+				path = Utils::FileSystem::getGenericPath(Utils::String::convertFromWideString(lpTempPathBuffer)) + "/emulationstation.tmp";
+			else
+#endif
+			path = Utils::FileSystem::getGenericPath(Utils::FileSystem::getEsConfigPath() + "/tmp");
+
+			if (!Utils::FileSystem::isDirectory(path))
+				Utils::FileSystem::createDirectory(path);
+
+			return path;
 		}
 
 		std::string getPdfTempPath()
 		{
+			static std::string pdfpath;
+
+			if (!pdfpath.empty())
+				return pdfpath;
+
 #ifdef WIN32
 			// Extract PDFs to local drive : usually faster since it's generally a SSD Drive
 			WCHAR lpTempPathBuffer[MAX_PATH];
 			lpTempPathBuffer[0] = 0;
 			DWORD dwRetVal = ::GetTempPathW(MAX_PATH, lpTempPathBuffer);
-			if (dwRetVal > MAX_PATH || (dwRetVal == 0))
-				return Utils::FileSystem::getGenericPath(Utils::FileSystem::getEsConfigPath() + "/pdftmp/");
+			if (dwRetVal > 0 && dwRetVal <= MAX_PATH)
+				pdfpath = Utils::FileSystem::getGenericPath(Utils::String::convertFromWideString(lpTempPathBuffer)) + "/pdftmp";
+			else
+#endif						
+			pdfpath = Utils::FileSystem::getGenericPath(Utils::FileSystem::getEsConfigPath() + "/pdftmp");
 
-			return Utils::FileSystem::getGenericPath(Utils::String::convertFromWideString(lpTempPathBuffer)) + "/pdftmp/";
-#else
-			return Utils::FileSystem::getGenericPath(Utils::FileSystem::getEsConfigPath() + "/pdftmp/");
-#endif
+			if (!Utils::FileSystem::isDirectory(pdfpath))
+				Utils::FileSystem::createDirectory(pdfpath);
+
+			return pdfpath;
 		}
 		
 		std::string getFileCrc32(const std::string& filename)

--- a/es-core/src/utils/FileSystemUtil.cpp
+++ b/es-core/src/utils/FileSystemUtil.cpp
@@ -581,7 +581,7 @@ namespace Utils
 
 #if WIN32
 			std::string path = _path[0] == '.' ? getAbsolutePath(_path) : _path;
-			if (path.find("./") == std::string::npos)
+			if (path.find("./") == std::string::npos && path.find(".\\") == std::string::npos)
 				return path;
 #else
 			std::string path = exists(_path) ? getAbsolutePath(_path) : _path;
@@ -713,6 +713,37 @@ namespace Utils
 
 			return std::string();
 		}
+
+		std::string changeExtension(const std::string& _path, const std::string& extension)
+		{
+			if (_path.empty())
+				return _path;
+
+			std::string str = _path;
+			int length = _path.length();
+			while (--length >= 0)
+			{
+				char ch = _path[length];
+				if (ch == '.')
+				{
+					str = _path.substr(0, length);
+					break;
+				}
+
+				if (((ch == '/') || (ch == '\\')) || (ch == ':'))
+					break;
+			}
+
+			if (extension.empty())
+				return str;
+
+			if (extension.length() == 0 || extension[0] != '.')
+				str = str + ".";
+
+			return str + extension;
+		}
+
+
 
 		std::string resolveRelativePath(const std::string& _path, const std::string& _relativeTo, const bool _allowHome)
 		{
@@ -876,7 +907,7 @@ namespace Utils
 				return true;
 
 #if WIN32			
-			return RemoveDirectoryW(Utils::String::convertToWideString(_path).c_str());
+			return RemoveDirectoryW(Utils::String::convertToWideString(getPreferredPath(_path)).c_str());
 #else
 			return (rmdir(path.c_str()) == 0);
 #endif
@@ -892,7 +923,7 @@ namespace Utils
 
 #if WIN32			
 			if (isDirectory(_path))
-				return RemoveDirectoryW(Utils::String::convertToWideString(_path).c_str());
+				return RemoveDirectoryW(Utils::String::convertToWideString(getPreferredPath(_path)).c_str());
 
 			return DeleteFileW(Utils::String::convertToWideString(_path).c_str());
 #else
@@ -1202,13 +1233,17 @@ namespace Utils
 			fs.close();
 		}
 
-		bool renameFile(const std::string src, const std::string dst)
+		bool renameFile(const std::string src, const std::string dst, bool overWrite)
 		{
 			std::string path = getGenericPath(src);
 			if (!exists(path))
 				return true;
 
-#if WIN32
+			if (overWrite && Utils::FileSystem::exists(dst))
+				Utils::FileSystem::removeFile(dst);
+
+
+#if WIN32			
 			return MoveFileW(Utils::String::convertToWideString(path).c_str(), Utils::String::convertToWideString(dst).c_str());
 #else
 			return std::rename(src.c_str(), dst.c_str()) == 0;
@@ -1255,7 +1290,7 @@ namespace Utils
 			return true;
 		} // removeFile
 
-		void deleteDirectoryFiles(const std::string path)
+		void deleteDirectoryFiles(const std::string path, bool deleteDirectory)
 		{
 			std::vector<std::string> directories;
 
@@ -1270,7 +1305,10 @@ namespace Utils
 			}
 
 			for (auto file : directories)
-				removeDirectory(Utils::FileSystem::getPreferredPath(file).c_str());
+				removeDirectory(file);
+
+			if (deleteDirectory)
+				removeDirectory(path);
 		}
 
 		std::string megaBytesToString(unsigned long size)
@@ -1298,19 +1336,19 @@ namespace Utils
 		{
 			static std::string path;
 
-			if (!path.empty())
-				return path;
-
+			if (path.empty())
+			{
 #ifdef WIN32
-			// Set tmp files to local drive : usually faster since it's generally a SSD Drive
-			WCHAR lpTempPathBuffer[MAX_PATH];
-			lpTempPathBuffer[0] = 0;
-			DWORD dwRetVal = ::GetTempPathW(MAX_PATH, lpTempPathBuffer);
-			if (dwRetVal > 0 && dwRetVal <= MAX_PATH)
-				path = Utils::FileSystem::getGenericPath(Utils::String::convertFromWideString(lpTempPathBuffer)) + "/emulationstation.tmp";
-			else
+				// Set tmp files to local drive : usually faster since it's generally a SSD Drive
+				WCHAR lpTempPathBuffer[MAX_PATH];
+				lpTempPathBuffer[0] = 0;
+				DWORD dwRetVal = ::GetTempPathW(MAX_PATH, lpTempPathBuffer);
+				if (dwRetVal > 0 && dwRetVal <= MAX_PATH)
+					path = Utils::FileSystem::getGenericPath(Utils::String::convertFromWideString(lpTempPathBuffer)) + "/emulationstation.tmp";
+				else
 #endif
-			path = Utils::FileSystem::getGenericPath(Utils::FileSystem::getEsConfigPath() + "/tmp");
+					path = Utils::FileSystem::getGenericPath(Utils::FileSystem::getEsConfigPath() + "/tmp");
+			}
 
 			if (!Utils::FileSystem::isDirectory(path))
 				Utils::FileSystem::createDirectory(path);
@@ -1322,19 +1360,19 @@ namespace Utils
 		{
 			static std::string pdfpath;
 
-			if (!pdfpath.empty())
-				return pdfpath;
-
+			if (pdfpath.empty())
+			{
 #ifdef WIN32
-			// Extract PDFs to local drive : usually faster since it's generally a SSD Drive
-			WCHAR lpTempPathBuffer[MAX_PATH];
-			lpTempPathBuffer[0] = 0;
-			DWORD dwRetVal = ::GetTempPathW(MAX_PATH, lpTempPathBuffer);
-			if (dwRetVal > 0 && dwRetVal <= MAX_PATH)
-				pdfpath = Utils::FileSystem::getGenericPath(Utils::String::convertFromWideString(lpTempPathBuffer)) + "/pdftmp";
-			else
+				// Extract PDFs to local drive : usually faster since it's generally a SSD Drive
+				WCHAR lpTempPathBuffer[MAX_PATH];
+				lpTempPathBuffer[0] = 0;
+				DWORD dwRetVal = ::GetTempPathW(MAX_PATH, lpTempPathBuffer);
+				if (dwRetVal > 0 && dwRetVal <= MAX_PATH)
+					pdfpath = Utils::FileSystem::getGenericPath(Utils::String::convertFromWideString(lpTempPathBuffer)) + "/pdftmp";
+				else
 #endif						
-			pdfpath = Utils::FileSystem::getGenericPath(Utils::FileSystem::getEsConfigPath() + "/pdftmp");
+					pdfpath = Utils::FileSystem::getGenericPath(Utils::FileSystem::getEsConfigPath() + "/pdftmp");
+			}
 
 			if (!Utils::FileSystem::isDirectory(pdfpath))
 				Utils::FileSystem::createDirectory(pdfpath);

--- a/es-core/src/utils/FileSystemUtil.h
+++ b/es-core/src/utils/FileSystemUtil.h
@@ -68,8 +68,8 @@ namespace Utils
 		std::string	readAllText(const std::string fileName);
 		void		writeAllText(const std::string fileName, const std::string text);
 		bool		copyFile(const std::string src, const std::string dst);
-		void		deleteDirectoryFiles(const std::string path);
-		bool		renameFile(const std::string src, const std::string dst);
+		void		deleteDirectoryFiles(const std::string path, bool deleteDirectory = false);
+		bool		renameFile(const std::string src, const std::string dst, bool overWrite = true);
 
 		std::string megaBytesToString(unsigned long size);
 
@@ -83,6 +83,8 @@ namespace Utils
 
 		std::string getFileCrc32(const std::string& filename);
 		std::string getFileMd5(const std::string& filename);
+
+		std::string changeExtension(const std::string& _path, const std::string& extension);
 
 		class FileSystemCacheActivator
 		{

--- a/es-core/src/utils/StringUtil.cpp
+++ b/es-core/src/utils/StringUtil.cpp
@@ -442,7 +442,7 @@ namespace Utils
 		bool endsWith(const std::string& _string, const std::string& _end)
 		{
 			if (_end.size() > _string.size()) return false;
-			return std::equal(_end.rbegin(), _end.rend(), _string.rbegin());
+			return (_string.rfind(_end) == (_string.size() - _end.size()));
 		} // endsWith
 
 		std::string removeParenthesis(const std::string& _string)

--- a/es-core/src/utils/ZipFile.cpp
+++ b/es-core/src/utils/ZipFile.cpp
@@ -107,14 +107,17 @@ namespace Utils
 			for (i = 0; i < len; i++)
 				buflen += unicode_to_utf8_len(cp437_to_unicode[cp437buf[i]]);
 
-			std::string ret(buflen, 0);
-			unsigned char* utf8buf = (unsigned char*) ret.data();
+			unsigned char* utf8buf = new unsigned char[buflen];
 
 			int offset = 0;
 			for (i = 0; i < len; i++)
 				offset += unicode_to_utf8(cp437_to_unicode[cp437buf[i]], utf8buf + offset);
 
 			utf8buf[buflen - 1] = 0;			
+
+			std::string ret = (char*)utf8buf;
+			delete utf8buf;
+
 			return ret;
 		}
 

--- a/locale/lang/fr/LC_MESSAGES/emulationstation2.po
+++ b/locale/lang/fr/LC_MESSAGES/emulationstation2.po
@@ -2076,7 +2076,7 @@ msgid "GAME TIME, DESCENDING"
 msgstr "TEMPS DE JEU, DÉCROISSANT"
 
 msgid "Extracting"
-msgstr "Extration"
+msgstr "Extraction"
 
 msgid "SEARCHING RETROACHIEVEMENTS"
 msgstr "RECHERCHE DES SUCCÈS RÉTRO"


### PR DESCRIPTION
"unzipFile" is using 7zr for zip files, but it fails, so hashes are wrong because _**7z can't read zip files since batocera 29**_.
-> Use internal zip library instead