### PR TITLE
Misc new things ( Http Services, Scraper, Magazine metadata, child roms exclusion... )

### DIFF
--- a/es-app/CMakeLists.txt
+++ b/es-app/CMakeLists.txt
@@ -20,6 +20,7 @@ set(ES_HEADERS
 	${CMAKE_CURRENT_SOURCE_DIR}/src/LangParser.h
 	${CMAKE_CURRENT_SOURCE_DIR}/src/KeyboardMapping.h	
 	${CMAKE_CURRENT_SOURCE_DIR}/src/services/HttpServerThread.h
+	${CMAKE_CURRENT_SOURCE_DIR}/src/services/HttpApi.h
 	${CMAKE_CURRENT_SOURCE_DIR}/src/services/httplib.h
 	${CMAKE_CURRENT_SOURCE_DIR}/src/RetroAchievements.h
 	${CMAKE_CURRENT_SOURCE_DIR}/src/SaveState.h
@@ -117,6 +118,7 @@ set(ES_SOURCES
 	${CMAKE_CURRENT_SOURCE_DIR}/src/LangParser.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/KeyboardMapping.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/services/HttpServerThread.cpp	
+	${CMAKE_CURRENT_SOURCE_DIR}/src/services/HttpApi.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/RetroAchievements.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/SaveState.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/SaveStateRepository.cpp

--- a/es-app/src/FileData.cpp
+++ b/es-app/src/FileData.cpp
@@ -541,6 +541,140 @@ bool FileData::launchGame(Window* window, LaunchGameOptions options)
 	return exitCode == 0;
 }
 
+
+bool FileData::hasContentFiles()
+{
+	std::string ext = Utils::String::toLower(Utils::FileSystem::getExtension(mPath));
+	if (ext == ".m3u" || ext == ".cue" || ext == ".ccd" || ext == ".gdi")
+		return getSourceFileData()->getSystemEnvData()->isValidExtension(ext) && getSourceFileData()->getSystemEnvData()->mSearchExtensions.size() > 1;
+
+	return false;
+}
+
+static std::vector<std::string> getTokens(const std::string& string)
+{
+	std::vector<std::string> tokens;
+
+	bool inString = false;
+	int startPos = 0;
+	int i = 0;
+	for (;;)
+	{
+		char c = string[i];
+
+		switch (c)
+		{
+		case '\"':
+			inString = !inString;
+			if (inString)
+				startPos = i + 1;
+
+		case '\0':
+		case ' ':
+		case '\t':
+		case '\r':
+		case '\n':
+			if (!inString)
+			{
+				std::string value = string.substr(startPos, i - startPos);
+				if (!value.empty())
+					tokens.push_back(value);
+
+				startPos = i + 1;
+			}
+			break;
+		}
+
+		if (c == '\0')
+			break;
+
+		i++;
+	}
+
+	return tokens;
+}
+
+std::set<std::string> FileData::getContentFiles()
+{
+	std::set<std::string> files;
+
+	if (Utils::FileSystem::isDirectory(mPath))
+	{
+		for (auto file : Utils::FileSystem::getDirContent(mPath, true, true))
+			files.insert(file);
+	}
+	else if (hasContentFiles())
+	{
+		auto path = Utils::FileSystem::getParent(mPath);
+		auto ext = Utils::String::toLower(Utils::FileSystem::getExtension(mPath));
+
+		if (ext == ".cue")
+		{
+			std::string start = "FILE";
+
+			std::ifstream cue(WINSTRINGW(mPath));
+			if (cue && cue.is_open())
+			{
+				std::string line;
+				while (std::getline(cue, line))
+				{
+					if (!Utils::String::startsWith(line, start))
+						continue;
+
+					auto tokens = getTokens(line);
+					if (tokens.size() > 1)
+						files.insert(path + "/" + tokens[1]);
+				}
+
+				cue.close();
+			}
+		}
+		else if (ext == ".ccd")
+		{
+			std::string stem = Utils::FileSystem::getStem(mPath);
+			files.insert(path + "/" + stem + ".cue");
+			files.insert(path + "/" + stem + ".bin");
+			files.insert(path + "/" + stem + ".sub");
+		}
+		else if (ext == ".m3u")
+		{
+			std::ifstream m3u(WINSTRINGW(mPath));
+			if (m3u && m3u.is_open())
+			{
+				std::string line;
+				while (std::getline(m3u, line))
+				{
+					auto trim = Utils::String::trim(line);
+					if (trim[0] == '#' || trim[0] == '\\' || trim[0] == '/')
+						continue;
+
+					files.insert(path + "/" + trim);
+				}
+
+				m3u.close();
+			}
+		}
+		else if (ext == ".gdi")
+		{
+			std::ifstream gdi(WINSTRINGW(mPath));
+			if (gdi && gdi.is_open())
+			{
+				std::string line;
+				while (std::getline(gdi, line))
+				{
+					auto tokens = getTokens(line);
+					if (tokens.size() > 5 && tokens[4].find(".") != std::string::npos)
+						files.insert(path + "/" + tokens[4]);
+				}
+
+				gdi.close();
+			}			
+		}
+	}
+
+	return files;
+}
+
 void FileData::deleteGameFiles()
 {
 	for (auto mdd : mMetadata.getMDD())
@@ -552,6 +686,9 @@ void FileData::deleteGameFiles()
 	}
 
 	Utils::FileSystem::removeFile(getPath());
+
+	for (auto contentFile : getContentFiles())
+		Utils::FileSystem::removeFile(contentFile);
 }
 
 CollectionFileData::CollectionFileData(FileData* file, SystemData* system)

--- a/es-app/src/FileData.cpp
+++ b/es-app/src/FileData.cpp
@@ -741,16 +741,8 @@ const std::vector<FileData*> FolderData::getChildrenListToDisplay()
 {
 	std::vector<FileData*> ret;
 
-	std::string showFoldersMode = Settings::getInstance()->getString("FolderViewMode");
-
-	auto fvm = Settings::getInstance()->getString(getSystem()->getName() + ".FolderViewMode");
-	if (!fvm.empty() && fvm != "auto") showFoldersMode = fvm;
+	std::string showFoldersMode = getSystem()->getFolderViewMode();
 	
-	if ((fvm.empty() || fvm == "auto") && getSystem() == CollectionSystemManager::get()->getCustomCollectionsBundle())
-		showFoldersMode = "always";
-	else if (getSystem()->getName() == "windows_installers")
-		showFoldersMode = "always";
-
 	bool showHiddenFiles = Settings::getInstance()->getBool("ShowHiddenFiles");
 
 	auto shv = Settings::getInstance()->getString(getSystem()->getName() + ".ShowHiddenFiles");

--- a/es-app/src/FileData.h
+++ b/es-app/src/FileData.h
@@ -143,6 +143,9 @@ public:
 
 	std::string getCurrentGameSetting(const std::string& settingName);
 
+	bool hasContentFiles();
+	std::set<std::string> getContentFiles();
+
 private:
 	std::string getKeyboardMappingFilePath();
 	MetaDataList mMetadata;

--- a/es-app/src/Gamelist.cpp
+++ b/es-app/src/Gamelist.cpp
@@ -515,6 +515,7 @@ void cleanupGamelist(SystemData* system)
 				case MetaDataId::Wheel: suffix = "wheel"; break;
 				case MetaDataId::TitleShot: suffix = "titleshot"; break;
 				case MetaDataId::Manual: suffix = "manual"; folder = "/manuals/"; ext = ".pdf"; break;
+				case MetaDataId::Magazine: suffix = "magazine"; folder = "/magazines/"; ext = ".pdf"; break;
 				case MetaDataId::Map: suffix = "map"; break;
 				case MetaDataId::Cartridge: suffix = "cartridge"; break;
 				}

--- a/es-app/src/MetaData.cpp
+++ b/es-app/src/MetaData.cpp
@@ -43,6 +43,7 @@ void MetaDataList::initMetadata()
 		{ FanArt,           "fanart",      MD_PATH,                "",                 false,      _("Fan art"),              _("enter path to fanart"),	 true },
 		{ TitleShot,        "titleshot",   MD_PATH,                "",                 false,      _("Title shot"),           _("enter path to title shot"), true },
 		{ Manual,			"manual",	   MD_PATH,                "",                 false,      _("Manual"),               _("enter path to manual"),     true },
+		{ Magazine,			"magazine",	   MD_PATH,                "",                 false,      _("Magazine"),             _("enter path to magazine"),     true },
 		{ Map,			    "map",	       MD_PATH,                "",                 false,      _("Map"),                  _("enter path to map"),		 true },
 
 		// Non scrappable /editable medias

--- a/es-app/src/MetaData.h
+++ b/es-app/src/MetaData.h
@@ -68,7 +68,8 @@ enum MetaDataId
 	CheevosHash = 34,
 	CheevosId = 35,
 	ScraperId = 36,
-	BoxBack = 37
+	BoxBack = 37,
+	Magazine = 38
 };
 
 namespace MetaDataImportType
@@ -147,6 +148,8 @@ public:
 	MetaDataType getType(MetaDataId id) const;
 	MetaDataType getType(const std::string name) const;
 
+	MetaDataId getId(const std::string& key) const;
+
 	bool wasChanged() const;
 	void resetChangedFlag();
 	const void setDirty() 
@@ -168,9 +171,6 @@ private:
 	std::map<MetaDataId, std::string> mMap;
 	bool mWasChanged;
 	SystemData*		mRelativeTo;
-
-
-	inline MetaDataId getId(const std::string& key) const;
 
 	static std::vector<MetaDataDecl> mMetaDataDecls;
 

--- a/es-app/src/PlatformId.cpp
+++ b/es-app/src/PlatformId.cpp
@@ -133,6 +133,7 @@ namespace PlatformIds
 		{ "ti99_4a",				TI99 },
 		{ "pico8",					PICO8 },
 		{ "sgb",					SUPER_GAME_BOY },
+		{ "watara",					WATARA },
 
 		{ "model3",					MODEL3 },
 			

--- a/es-app/src/PlatformId.h
+++ b/es-app/src/PlatformId.h
@@ -121,6 +121,7 @@ namespace PlatformIds
 		DAPHNE,
 		SOLARUS,
 		PICO8,
+		WATARA,
 
 		VIC20,
 		TI99,

--- a/es-app/src/SystemData.cpp
+++ b/es-app/src/SystemData.cpp
@@ -2053,6 +2053,23 @@ bool SystemData::getShowParentFolder()
 	return getBoolSetting("ShowParentFolder");
 }
 
+
+std::string SystemData::getFolderViewMode()
+{
+	std::string showFoldersMode = Settings::getInstance()->getString("FolderViewMode");
+
+	auto fvm = Settings::getInstance()->getString(getName() + ".FolderViewMode");
+	if (!fvm.empty() && fvm != "auto") 
+		showFoldersMode = fvm;
+
+	if ((fvm.empty() || fvm == "auto") && this == CollectionSystemManager::get()->getCustomCollectionsBundle())
+		showFoldersMode = "always";
+	else if (getName() == "windows_installers")
+		showFoldersMode = "always";
+
+	return showFoldersMode;
+}
+
 bool SystemData::getShowFavoritesFirst()
 {
 	if (!getShowFavoritesIcon())

--- a/es-app/src/SystemData.cpp
+++ b/es-app/src/SystemData.cpp
@@ -31,6 +31,7 @@ using namespace Utils;
 std::vector<SystemData*> SystemData::sSystemVector;
 std::vector<CustomFeature> SystemData::mGlobalFeatures;
 
+
 SystemData::SystemData(const SystemMetadata& meta, SystemEnvironmentData* envData, std::vector<EmulatorData>* pEmulators, bool CollectionSystem, bool groupedSystem, bool withTheme, bool loadThemeOnlyIfElements) : // batocera
 	mMetadata(meta), mEnvData(envData), mIsCollectionSystem(CollectionSystem), mIsGameSystem(true)
 {
@@ -51,7 +52,7 @@ SystemData::SystemData(const SystemMetadata& meta, SystemEnvironmentData* envDat
 	mHidden = (std::find(hiddenSystems.cbegin(), hiddenSystems.cend(), getName()) != hiddenSystems.cend());
 		
 	// if it's an actual system, initialize it, if not, just create the data structure
-	if (!CollectionSystem && !mIsGroupSystem)
+	if (!mIsCollectionSystem && !mIsGroupSystem)
 	{
 		mRootFolder = new FolderData(mEnvData->mStartPath, this);
 		mRootFolder->getMetadata().set(MetaDataId::Name, mMetadata.fullName);
@@ -70,7 +71,10 @@ SystemData::SystemData(const SystemMetadata& meta, SystemEnvironmentData* envDat
 		}
 
 		if (!Settings::getInstance()->getBool("IgnoreGamelist")) // && !hasPlatformId(PlatformIds::IMAGEVIEWER))
-			parseGamelist(this, fileMap);
+			parseGamelist(this, fileMap);		
+		
+		if (Settings::getInstance()->getBool("RemoveMultiDiskContent"))
+			removeMultiDiskContent(fileMap);
 	}
 	else
 	{
@@ -108,6 +112,43 @@ SystemData::~SystemData()
 
 	if (mFilterIndex != nullptr)
 		delete mFilterIndex;
+}
+
+void SystemData::removeMultiDiskContent(std::unordered_map<std::string, FileData*>& fileMap)
+{	
+	if (mEnvData == nullptr ||!(mEnvData->isValidExtension(".cue") || mEnvData->isValidExtension(".ccd") || mEnvData->isValidExtension(".gdi") || mEnvData->isValidExtension(".m3u")))
+		return;
+
+	StopWatch stopWatch("RemoveMultiDiskContent - "+ getName() +" :", LogDebug);
+
+	std::vector<std::string> files;
+
+	std::stack<FolderData*> stack;
+	stack.push(mRootFolder);
+
+	while (stack.size())
+	{
+		FolderData* current = stack.top();
+		stack.pop();
+
+		for (auto it : current->getChildren())
+		{
+			if (it->getType() == GAME && it->hasContentFiles())
+			{
+				for (auto ct : it->getContentFiles())
+					files.push_back(ct);
+			}
+			else if (it->getType() == FOLDER)
+				stack.push((FolderData*)it);
+		}
+	}
+
+	for (auto file : files)
+	{
+		auto it = fileMap.find(file);
+		if (it != fileMap.cend())
+			delete it->second;
+	}
 }
 
 void SystemData::setIsGameSystemStatus()
@@ -1083,12 +1124,12 @@ SystemData* SystemData::loadSystem(pugi::xml_node system, bool fullMode)
 	md.themeFolder = system.child("theme").text().as_string(md.name.c_str());
 
 	// convert extensions list from a string into a vector of strings
-	std::vector<std::string> extensions;
+	std::set<std::string> extensions;
 	for (auto ext : readList(system.child("extension").text().get()))
 	{
 		std::string extlow = Utils::String::toLower(ext);
-		if (std::find(extensions.cbegin(), extensions.cend(), extlow) == extensions.cend())
-			extensions.push_back(extlow);
+		if (extensions.find(extlow) == extensions.cend())
+			extensions.insert(extlow);
 	}
 
 	cmd = system.child("command").text().get();

--- a/es-app/src/SystemData.h
+++ b/es-app/src/SystemData.h
@@ -130,14 +130,14 @@ struct SystemMetadata
 struct SystemEnvironmentData
 {
 	std::string mStartPath;
-	std::vector<std::string> mSearchExtensions;
+	std::set<std::string> mSearchExtensions;
 	std::string mLaunchCommand;
 	std::vector<PlatformIds::PlatformId> mPlatformIds;
 	std::string mGroup;
 
-	bool isValidExtension(const std::string extension)
+	inline bool isValidExtension(const std::string& extension)
 	{
-		return std::find(mSearchExtensions.cbegin(), mSearchExtensions.cend(), extension) != mSearchExtensions.cend();
+		return mSearchExtensions.find(extension) != mSearchExtensions.cend();
 	}
 };
 
@@ -156,7 +156,7 @@ public:
 	inline const std::string& getName() const { return mMetadata.name; }
 	inline const std::string& getFullName() const { return mMetadata.fullName; }
 	inline const std::string& getStartPath() const { return mEnvData->mStartPath; }
-	inline const std::vector<std::string>& getExtensions() const { return mEnvData->mSearchExtensions; }
+	inline const std::set<std::string>& getExtensions() const { return mEnvData->mSearchExtensions; }
 	inline const std::string& getThemeFolder() const { return mMetadata.themeFolder; }
 	inline SystemEnvironmentData* getSystemEnvData() const { return mEnvData; }
 	inline const std::vector<PlatformIds::PlatformId>& getPlatformIds() const { return mEnvData->mPlatformIds; }
@@ -321,7 +321,8 @@ private:
 	void populateFolder(FolderData* folder, std::unordered_map<std::string, FileData*>& fileMap);
 	void indexAllGameFilters(const FolderData* folder);
 	void setIsGameSystemStatus();
-	
+	void removeMultiDiskContent(std::unordered_map<std::string, FileData*>& fileMap);
+
 	static SystemData* loadSystem(pugi::xml_node system, bool fullMode = true);
 	static void loadAdditionnalConfig(pugi::xml_node& srcSystems);
 

--- a/es-app/src/SystemData.h
+++ b/es-app/src/SystemData.h
@@ -287,6 +287,7 @@ public:
 	bool getShowFavoritesIcon();
 	bool getShowCheevosIcon();
 	int  getShowFlags();
+	std::string getFolderViewMode();
 	bool getBoolSetting(const std::string& settingName);
 
 	static void resetSettings();

--- a/es-app/src/guis/GuiGameOptions.cpp
+++ b/es-app/src/guis/GuiGameOptions.cpp
@@ -49,6 +49,7 @@ GuiGameOptions::GuiGameOptions(Window* window, FileData* game) : GuiComponent(wi
 
 	bool isImageViewer = game->getSourceFileData()->getSystem()->hasPlatformId(PlatformIds::IMAGEVIEWER);
 	bool hasManual = ApiSystem::getInstance()->isScriptingSupported(ApiSystem::ScriptId::PDFEXTRACTION) && Utils::FileSystem::exists(game->getMetadata(MetaDataId::Manual));
+	bool hasMagazine = ApiSystem::getInstance()->isScriptingSupported(ApiSystem::ScriptId::PDFEXTRACTION) && Utils::FileSystem::exists(game->getMetadata(MetaDataId::Magazine));
 	bool hasMap = Utils::FileSystem::exists(game->getMetadata(MetaDataId::Map));
 	bool hasCheevos = game->hasCheevos();
 
@@ -64,6 +65,15 @@ GuiGameOptions::GuiGameOptions(Window* window, FileData* game) : GuiComponent(wi
 				close();
 			});
 		}
+
+		if (hasMagazine)
+		{
+			mMenu.addEntry(_("VIEW GAME MAGAZINE"), false, [window, game, this]
+			{
+				GuiImageViewer::showPdf(window, game->getMetadata(MetaDataId::Magazine));
+				close();
+			});
+		}		
 
 		if (hasMap)
 		{

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -871,6 +871,12 @@ void GuiMenu::openDeveloperSettings()
 	
 	s->addGroup(_("DATA MANAGEMENT"));
 
+	// ExcludeMultiDiskContent
+	auto excludeMultiDiskContent = std::make_shared<SwitchComponent>(mWindow);
+	excludeMultiDiskContent->setState(Settings::getInstance()->getBool("RemoveMultiDiskContent"));
+	s->addWithLabel(_("IGNORE MULTIFILE DISK CONTENT (CUE/GDI/CCD/M3U)"), excludeMultiDiskContent);
+	s->addSaveFunc([excludeMultiDiskContent] { Settings::getInstance()->setBool("RemoveMultiDiskContent", excludeMultiDiskContent->getState()); });
+
 	// enable filters (ForceDisableFilters)
 	auto enable_filter = std::make_shared<SwitchComponent>(mWindow);
 	enable_filter->setState(!Settings::getInstance()->getBool("ForceDisableFilters"));
@@ -892,12 +898,11 @@ void GuiMenu::openDeveloperSettings()
 	s->addWithLabel(_("PARSE GAMESLISTS ONLY"), parse_gamelists);
 	s->addSaveFunc([parse_gamelists] { Settings::getInstance()->setBool("ParseGamelistOnly", parse_gamelists->getState()); });
 
-
+	// Local Art
 	auto local_art = std::make_shared<SwitchComponent>(mWindow);
 	local_art->setState(Settings::getInstance()->getBool("LocalArt"));
 	s->addWithLabel(_("SEARCH FOR LOCAL ART"), local_art);
 	s->addSaveFunc([local_art] { Settings::getInstance()->setBool("LocalArt", local_art->getState()); });
-
 
 	s->addGroup(_("UI"));
 

--- a/es-app/src/guis/GuiMetaDataEd.cpp
+++ b/es-app/src/guis/GuiMetaDataEd.cpp
@@ -24,6 +24,7 @@
 #include "Gamelist.h"
 #include "components/OptionListComponent.h"
 #include "ApiSystem.h"
+#include "scrapers/Scraper.h"
 #include <set>
 
 GuiMetaDataEd::GuiMetaDataEd(Window* window, MetaDataList* md, const std::vector<MetaDataDecl>& mdd, ScraperSearchParams scraperParams,
@@ -232,7 +233,7 @@ GuiMetaDataEd::GuiMetaDataEd(Window* window, MetaDataList* md, const std::vector
 
 			if (iter->key == "video")
 				type = GuiFileBrowser::FileTypes::VIDEO;
-			else if (iter->key == "manual" || iter->key == "map")
+			else if (iter->key == "manual" || iter->key == "magazine" || iter->key == "map")
 				type = (GuiFileBrowser::FileTypes) (GuiFileBrowser::FileTypes::IMAGES | GuiFileBrowser::FileTypes::MANUALS);
 
 			auto updateVal = [ed, relativePath](const std::string& newVal)
@@ -399,20 +400,11 @@ bool GuiMetaDataEd::save()
 			}
 
 			if (mMetaData->getType(key) == MD_PATH && !val.empty() && filesToCopy.find(val) != filesToCopy.cend())
-			{
+			{				
 				auto rootPath = mMetaData->getRelativeRootPath();
 				auto sourceFile = Utils::FileSystem::resolveRelativePath(val, rootPath, true);
-				
-				std::string folder = "images";
-				if (key == "manual")
-					folder = "manuals";
-				else if (key == "video")
-					folder = "videos";
 
-				auto romName = mScraperParams.game->getFullPath();
-
-				auto destFile = Utils::FileSystem::getStem(romName) + "-" + key + Utils::FileSystem::getExtension(sourceFile);
-				destFile = Utils::FileSystem::combine(Utils::FileSystem::combine(rootPath, folder), destFile);
+				auto destFile = Scraper::getSaveAsPath(mScraperParams.game, mMetaData->getId(key), Utils::FileSystem::getExtension(sourceFile));
 
 				if (Utils::FileSystem::copyFile(sourceFile, destFile))
 					val = destFile;
@@ -493,7 +485,7 @@ void GuiMetaDataEd::fetchDone(const ScraperSearchResult& result)
 			continue;
 		
 		// Don't override medias when scrap result has nothing
-		if ((key == "image" || key == "thumbnail" || key == "marquee" || key == "fanart" || key == "titleshot" || key == "manual" || key == "map" || key == "video") && result.mdl.get(key).empty())
+		if ((key == "image" || key == "thumbnail" || key == "marquee" || key == "fanart" || key == "titleshot" || key == "manual" || key == "map" || key == "video" || key == "magazine") && result.mdl.get(key).empty())
 			continue;
 
 		mEditors.at(i)->setValue(result.mdl.get(key));

--- a/es-app/src/scrapers/GamesDBJSONScraper.cpp
+++ b/es-app/src/scrapers/GamesDBJSONScraper.cpp
@@ -108,6 +108,7 @@ const std::map<PlatformId, std::string> gamesdb_new_platformid_map{
 	{ ASTROCADE , "4968" },
 	{ FMTOWNS, "4932" },
 	{ PHILIPS_CDI, "4917" },
+	{ WATARA, "4959" },
 
 	// 1 = PC
 	{ PC, "1" },

--- a/es-app/src/scrapers/Scraper.cpp
+++ b/es-app/src/scrapers/Scraper.cpp
@@ -229,8 +229,6 @@ MDResolveHandle::MDResolveHandle(const ScraperSearchResult& result, const Scrape
 		std::string suffix = "image";
 		switch (url.first)
 		{
-		case MetaDataId::Thumbnail: suffix = "thumb"; break;
-		case MetaDataId::Marquee: suffix = "marquee"; break;
 		case MetaDataId::Video: suffix = "video";  resize = false; break;
 		case MetaDataId::FanArt: suffix = "fanart"; resize = false; break;
 		case MetaDataId::BoxBack: suffix = "boxback"; resize = false; break;
@@ -238,6 +236,7 @@ MDResolveHandle::MDResolveHandle(const ScraperSearchResult& result, const Scrape
 		case MetaDataId::Wheel: suffix = "wheel"; resize = false; break;		
 		case MetaDataId::TitleShot: suffix = "titleshot"; break;
 		case MetaDataId::Manual: suffix = "manual"; resize = false;  break;
+		case MetaDataId::Magazine: suffix = "magazine"; resize = false;  break;
 		case MetaDataId::Map: suffix = "map"; resize = false; break;
 		case MetaDataId::Cartridge: suffix = "cartridge"; break;
 		}
@@ -246,7 +245,7 @@ MDResolveHandle::MDResolveHandle(const ScraperSearchResult& result, const Scrape
 		if (ext.empty())
 			ext = Utils::FileSystem::getExtension(url.second.url);
 
-		std::string resourcePath = getSaveAsPath(search, suffix, ext);
+		std::string resourcePath = Scraper::getSaveAsPath(search.game, url.first, ext);
 
 		if (!search.overWriteMedias && Utils::FileSystem::exists(resourcePath))
 		{
@@ -547,27 +546,36 @@ bool resizeImage(const std::string& path, int maxWidth, int maxHeight)
 	return saved;
 }
 
-std::string getSaveAsPath(const ScraperSearchParams& params, const std::string& suffix, const std::string& extension)
+std::string Scraper::getSaveAsPath(FileData* game, const MetaDataId metadataId, const std::string& extension)
 {
-	const std::string subdirectory = params.system->getName();
-	const std::string name = Utils::FileSystem::getStem(params.game->getPath()) + "-" + suffix;
+	std::string suffix = "image";
+	std::string folder = "images";
 
-	std::string subFolder = "images";
-	if (suffix == "video")
-		subFolder = "videos";
-	else if (suffix == "manual")
-		subFolder = "manuals";
+	switch (metadataId)
+	{
+	case MetaDataId::Thumbnail: suffix = "thumb"; break;
+	case MetaDataId::Marquee: suffix = "marquee"; break;
+	case MetaDataId::Video: suffix = "video"; folder = "videos"; break;
+	case MetaDataId::FanArt: suffix = "fanart"; break;
+	case MetaDataId::BoxBack: suffix = "boxback"; break;
+	case MetaDataId::BoxArt: suffix = "box"; break;
+	case MetaDataId::Wheel: suffix = "wheel"; break;
+	case MetaDataId::TitleShot: suffix = "titleshot"; break;
+	case MetaDataId::Manual: suffix = "manual"; folder = "manuals";  break;
+	case MetaDataId::Magazine: suffix = "magazine"; folder = "magazines"; break;
+	case MetaDataId::Map: suffix = "map"; break;
+	case MetaDataId::Cartridge: suffix = "cartridge"; break;
+	}
 
-	std::string path = params.system->getRootFolder()->getPath() + "/" + subFolder + "/"; // batocera
+	auto system = game->getSourceFileData()->getSystem();
+
+	const std::string subdirectory = system->getName();
+	const std::string name = Utils::FileSystem::getStem(game->getPath()) + "-" + suffix;
+
+	std::string path = system->getRootFolder()->getPath() + "/" + folder + "/";
 
 	if(!Utils::FileSystem::exists(path))
 		Utils::FileSystem::createDirectory(path);
-
-	// batocera
-	//path += subdirectory + "/";
-	//
-	//if(!Utils::FileSystem::exists(path))
-	//	Utils::FileSystem::createDirectory(path);
 
 	path += name + extension;
 	return path;

--- a/es-app/src/scrapers/Scraper.h
+++ b/es-app/src/scrapers/Scraper.h
@@ -196,8 +196,6 @@ private:
 	int mPercent;
 };
 
-
-
 class Scraper
 {
 public:
@@ -206,6 +204,10 @@ public:
 	static Scraper* getScraper(const std::string name = "");
 	static std::vector<std::string> getScraperList();
 	static bool isValidConfiguredScraper();
+
+	//About the same as "~/.emulationstation/downloaded_images/[system_name]/[game_name].[url's extension]".
+	//Will create the "downloaded_images" and "subdirectory" directories if they do not exist.
+	static std::string getSaveAsPath(FileData* game, const MetaDataId metadataId, const std::string& url);
 
 	virtual	bool isSupportedPlatform(SystemData* system) = 0;
 
@@ -222,11 +224,6 @@ protected:
 		std::queue<std::unique_ptr<ScraperRequest>>& requests,
 		std::vector<ScraperSearchResult>& results) = 0;
 };
-
-
-//About the same as "~/.emulationstation/downloaded_images/[system_name]/[game_name].[url's extension]".
-//Will create the "downloaded_images" and "subdirectory" directories if they do not exist.
-std::string getSaveAsPath(const ScraperSearchParams& params, const std::string& suffix, const std::string& url);
 
 //You can pass 0 for maxWidth or maxHeight to automatically keep the aspect ratio.
 //Will overwrite the image at [path] with the new resized one.

--- a/es-app/src/scrapers/ScreenScraper.cpp
+++ b/es-app/src/scrapers/ScreenScraper.cpp
@@ -119,11 +119,12 @@ const std::map<PlatformId, unsigned short> screenscraper_platformid_map{
 	{ MOONLIGHT, 138 }, // "PC Windows"
 	{ MODEL3, 55 },
 	{ TI99, 205 },
+	{ WATARA, 207 },
 
 	// Windows
 	{ VISUALPINBALL, 198 },
 	{ FUTUREPINBALL, 199 },
-
+	
 	// Misc
 	{ VIC20, 73 },
 	{ ORICATMOS, 131 },

--- a/es-app/src/services/HttpApi.cpp
+++ b/es-app/src/services/HttpApi.cpp
@@ -1,0 +1,309 @@
+#include "HttpApi.h"
+
+#ifdef WIN32
+#include <Windows.h>
+#endif
+
+#include "platform.h"
+#include "Gamelist.h"
+#include "SystemData.h"
+#include "FileData.h"
+#include "views/ViewController.h"
+#include "CollectionSystemManager.h"
+#include "utils/FileSystemUtil.h"
+#include "utils/StringUtil.h"
+#include "utils/md5.h"
+#include "scrapers/Scraper.h"
+#include <unordered_map>
+
+void HttpApi::getSystemDataJson(rapidjson::PrettyWriter<rapidjson::StringBuffer>& writer, SystemData* sys)
+{
+	writer.StartObject();
+	writer.Key("name"); writer.String(sys->getName().c_str());
+	writer.Key("fullname"); writer.String(sys->getFullName().c_str());
+
+	writer.Key("hardwareType"); writer.String(sys->getSystemMetadata().hardwareType.c_str());
+	writer.Key("manufacturer"); writer.String(sys->getSystemMetadata().manufacturer.c_str());
+
+	if (sys->getSystemMetadata().releaseYear != 0)
+	{
+		writer.Key("releaseYear"); writer.Int(sys->getSystemMetadata().releaseYear);
+	}
+
+	writer.Key("theme"); writer.String(sys->getSystemMetadata().themeFolder.c_str());
+
+	// writer.Key("startpath"); writer.String(sys->getStartPath().c_str());
+	writer.Key("theme"); writer.String(sys->getThemeFolder().c_str());
+
+	auto exts = sys->getExtensions();
+	if (exts.size() > 0)
+	{
+		writer.Key("extensions");
+		writer.StartArray();
+
+		for (auto ext : exts)
+			writer.String(ext.c_str());
+
+		writer.EndArray();
+	}
+
+	writer.Key("visible"); writer.String(sys->isVisible() ? "true" : "false");
+
+	if (!sys->getSystemEnvData()->mGroup.empty())
+	{
+		writer.Key("group"); writer.String(sys->getSystemEnvData()->mGroup.c_str());
+	}
+
+	writer.Key("collection"); writer.String(sys->isCollection() ? "true" : "false");
+	writer.Key("gamesystem"); writer.String(sys->isGameSystem() ? "true" : "false");
+	writer.Key("groupsystem"); writer.String(sys->isGroupSystem() ? "true" : "false");
+
+	GameCountInfo* info = sys->getGameCountInfo();
+
+	writer.Key("totalGames"); writer.Int(info->totalGames);
+	writer.Key("visibleGames"); writer.Int(info->visibleGames);
+	writer.Key("favoriteGames"); writer.Int(info->favoriteCount);
+	writer.Key("playedGames"); writer.Int(info->gamesPlayed);
+	writer.Key("hiddenGames"); writer.Int(info->hiddenCount);
+	writer.Key("mostPlayedGame"); writer.String(info->mostPlayed.c_str());
+
+	auto theme = sys->getTheme();
+	if (theme != nullptr)
+	{
+		const ThemeData::ThemeElement* elem = theme->getElement("system", "logo", "image");
+		if (elem && elem->has("path"))
+			writer.Key("logo"); writer.String(("/systems/" + sys->getName() + "/logo").c_str());
+	}
+
+	writer.EndObject();
+}
+
+std::string HttpApi::getSystemList()
+{
+	rapidjson::StringBuffer s;
+	rapidjson::PrettyWriter<rapidjson::StringBuffer> writer(s);
+
+	writer.StartArray();
+
+	for (auto sys : SystemData::sSystemVector)
+		getSystemDataJson(writer, sys);
+
+	writer.EndArray();
+
+	return s.GetString();
+}
+
+std::string HttpApi::getFileDataId(FileData* game)
+{
+	MD5 md5;
+	md5.update(game->getPath().c_str(), game->getPath().size());
+	md5.finalize();
+	return md5.hexdigest();
+}
+
+FileData* HttpApi::findFileData(SystemData* system, const std::string& id)
+{
+	std::stack<FolderData*> stack;
+	stack.push(system->getRootFolder());
+
+	while (stack.size())
+	{
+		FolderData* current = stack.top();
+		stack.pop();
+
+		for (auto it : current->getChildren())
+		{			
+			if (it->getType() == FOLDER)
+				stack.push((FolderData*)it);
+			else if (getFileDataId(it) == id)
+				return it;
+		}
+	}
+
+	return nullptr;
+}
+
+void HttpApi::getFileDataJson(rapidjson::PrettyWriter<rapidjson::StringBuffer>& writer, FileData* game)
+{
+	if (game->getType() != GAME)
+		return;
+
+	std::string id = getFileDataId(game);
+
+	writer.StartObject();
+	writer.Key("id"); writer.String(id.c_str());
+	writer.Key("path"); writer.String(game->getPath().c_str());
+	writer.Key("name"); writer.String(game->getName().c_str());
+
+	auto meta = game->getMetadata();
+	for (auto mdd : MetaDataList::getMDD())
+	{
+		if (mdd.id == MetaDataId::Name)
+			continue;
+
+		std::string value = game->getMetadata(mdd.id);
+		if (!value.empty())
+		{
+			if (meta.getType(mdd.id) == MD_PATH)
+				value = "/systems/" + game->getSourceFileData()->getSystemName() + "/games/" + id + "/media/" + mdd.key;
+
+			if (mdd.id == MetaDataId::ScraperId)
+				writer.Key("scraperId");
+			else 
+				writer.Key(mdd.key.c_str());
+
+			writer.String(value.c_str());
+		}
+	}
+
+	writer.EndObject();
+}
+
+bool HttpApi::ImportFromJson(FileData* file, const std::string& json)
+{
+	rapidjson::Document doc;
+	doc.Parse(json.c_str());
+	if (doc.HasParseError())
+		return false;
+
+	bool changed = false;
+
+	MetaDataList& meta = file->getMetadata();
+
+	for (auto mdd : MetaDataList::getMDD())
+	{
+		if (mdd.type == MD_PATH)
+			continue;
+
+		std::string key = mdd.key == "id" ? "scraperId" : mdd.key;
+
+		if (!doc.HasMember(key.c_str()))
+			continue;
+
+		const rapidjson::Value& value = doc[key.c_str()];
+		if (!value.IsString())
+			continue;
+
+		std::string newValue = value.GetString();
+		std::string currentValue = meta.get(mdd.id);
+		if (newValue != currentValue)
+		{
+			meta.set(mdd.id, newValue);
+			changed = true;
+		}
+	}
+
+	if (changed)
+		saveToGamelistRecovery(file);
+
+	return changed;
+}
+
+bool HttpApi::ImportMedia(FileData* file, const std::string& mediaType, const std::string& contentType, const std::string& mediaBytes)
+{
+	std::string extension;
+	if (Utils::String::startsWith(contentType, "image/"))
+	{
+		extension = "." + contentType.substr(6);
+		if (extension == ".jpeg")
+			extension = ".jpg";
+		else if (extension == ".svg+xml")
+			extension = ".svg";
+
+	}
+	else if (Utils::String::startsWith(contentType, "video/"))
+	{
+		extension = "." + contentType.substr(6);
+		if (extension == ".quicktime")
+			extension = ".mov";
+	}
+	else if (Utils::String::startsWith(contentType, "application/"))
+		extension = "." + contentType.substr(12);
+	else
+		return false;
+
+	for (auto mdd : MetaDataList::getMDD())
+	{
+		if (mdd.key != mediaType && mdd.type != MD_PATH)
+			continue;
+
+		if (mdd.id == MetaDataId::Video)
+		{
+			if (extension != ".mp4" && extension != ".avi" && extension != ".mkv")
+				return false;
+		}
+		else if (mdd.id == MetaDataId::Manual || mdd.id == MetaDataId::Magazine)
+		{
+			if (extension != ".pdf" && extension != ".cbz")
+				return false;
+		}
+		else if (mdd.id == MetaDataId::Map)
+		{
+			if (extension != ".jpg" && extension != ".png" && extension != ".gif" && extension != ".pdf" && extension != ".cbz")
+				return false;
+		}
+		else if (extension != ".jpg" && extension != ".png" && extension != ".gif")
+			return false;
+
+		std::string path = Scraper::getSaveAsPath(file, mdd.id, extension);
+
+		Utils::FileSystem::writeAllText(path, mediaBytes);
+		file->setMetadata(mdd.id, path);
+		saveToGamelistRecovery(file);
+		return true;
+	}
+
+	return false;
+}
+
+std::string HttpApi::ToJson(FileData* file)
+{
+	rapidjson::StringBuffer s;
+	rapidjson::PrettyWriter<rapidjson::StringBuffer> writer(s);
+	getFileDataJson(writer, file);
+	return s.GetString();
+}
+
+std::string HttpApi::ToJson(SystemData* system)
+{
+	rapidjson::StringBuffer s;
+	rapidjson::PrettyWriter<rapidjson::StringBuffer> writer(s);
+	getSystemDataJson(writer, system);
+	return s.GetString();
+}
+
+std::string HttpApi::getSystemGames(SystemData* system)
+{
+	rapidjson::StringBuffer s;
+	rapidjson::PrettyWriter<rapidjson::StringBuffer> writer(s);
+
+	writer.StartArray();
+
+	std::vector<FileData*> files;
+
+	std::stack<FolderData*> stack;
+	stack.push(system->getRootFolder());
+
+	while (stack.size())
+	{
+		FolderData* current = stack.top();
+		stack.pop();
+
+		for (auto it : current->getChildren())
+		{
+			files.push_back(it);
+			if (it->getType() == FOLDER)
+				stack.push((FolderData*)it);
+		}
+	}
+
+	for (auto game : files)
+		getFileDataJson(writer, game);
+
+	writer.EndArray();
+
+	return s.GetString();
+}
+
+
+

--- a/es-app/src/services/HttpApi.h
+++ b/es-app/src/services/HttpApi.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <string>
+#include <rapidjson/rapidjson.h>
+#include <rapidjson/pointer.h>
+#include <rapidjson/prettywriter.h>
+#include <rapidjson/stringbuffer.h>
+
+class SystemData;
+class FileData;
+
+class HttpApi
+{
+public:
+	static std::string getSystemList();
+	static std::string getSystemGames(SystemData* system);
+
+	static std::string ToJson(SystemData* system);
+	static std::string ToJson(FileData* file);
+
+	static FileData*   findFileData(SystemData* system, const std::string& id);
+
+	static bool ImportFromJson(FileData* file, const std::string& json);
+
+	static bool ImportMedia(FileData* file, const std::string& mediaType, const std::string& contentType, const std::string& mediaBytes);
+	
+
+private:
+	static std::string getFileDataId(FileData* game);
+	static void getFileDataJson(rapidjson::PrettyWriter<rapidjson::StringBuffer>& writer, FileData* game);
+	static void getSystemDataJson(rapidjson::PrettyWriter<rapidjson::StringBuffer>& writer, SystemData* sys);
+};

--- a/es-app/src/services/HttpServerThread.cpp
+++ b/es-app/src/services/HttpServerThread.cpp
@@ -16,7 +16,40 @@
 #include "guis/GuiMenu.h"
 #include "guis/GuiMsgBox.h"
 #include "utils/FileSystemUtil.h"
+#include "HttpApi.h"
 
+/* 
+
+Misc APIS
+-----------------
+GET  /restart
+GET  /quit
+GET  /reloadgames
+POST /messagebox												-> body must contain the message text as text/plain
+POST /notify													-> body must contain the message text as text/plain
+POST /launch													-> body must contain the exact file path as text/plain
+
+System/Games APIS
+-----------------
+GET  /systems
+GET  /systems/{systemName}
+GET  /systems/{systemName}/logo
+GET  /systems/{systemName}/games/{gameId}		
+POST /systems/{systemName}/games/{gameId}						-> body must contain the game metadatas to save as application/json
+GET  /systems/{systemName}/games/{gameId}/media/{mediaType}
+POST /systems/{systemName}/games/{gameId}/media/{mediaType}		-> body must contain the file bytes to save. Content-type must be valid.
+
+Store APIs
+----------
+POST /addgames/{systemName}										-> body must contain partial gamelist.xml file as application/xml
+POST /removegames/{systemName}									-> body must contains partial gamelist.xml file as application/xml
+
+File APIs
+---------
+GET /resources/{path relative to resources}"					-> any file in resources
+GET /{path relative to resources/services}"						-> any other file in resources/services
+
+*/
 HttpServerThread::HttpServerThread(Window* window) : mWindow(window)
 {
 	LOG(LogDebug) << "HttpServerThread : Starting";
@@ -45,6 +78,39 @@ HttpServerThread::~HttpServerThread()
 	delete mThread;
 }
 
+static std::map<std::string, std::string> mimeTypes = 
+{
+	{ "txt", "text/plain" },
+	{ "html", "text/html" },
+	{ "htm", "text/html" },
+	{ "css", "text/css" },
+	{ "jpeg", "image/jpg" },
+	{ "jpg", "image/jpg" },
+	{ "png", "image/png" },
+	{ "gif", "image/gif" },
+	{ "svg", "image/svg+xml" },
+	{ "ico", "image/x-icon" },
+	{ "json", "application/json" },
+	{ "pdf", "application/pdf" },
+	{ "js", "application/javascript" },
+	{ "wasm", "application/wasm" },
+	{ "xml", "application/xml" },
+	{ "xhtml", "application/xhtml+xml" }
+};
+
+std::string HttpServerThread::getMimeType(const std::string &path)
+{
+	auto ext = Utils::String::toLower(Utils::FileSystem::getExtension(path));
+	if (ext[0] == '.')
+		ext = ext.substr(1);
+
+	auto it = mimeTypes.find(ext);
+	if (it != mimeTypes.cend())
+		return it->second;
+	
+	return "text/plain";
+}
+
 void HttpServerThread::run()
 {
 	mHttpServer = new httplib::Server();
@@ -53,13 +119,28 @@ void HttpServerThread::run()
 		res.set_redirect("/index.html");
 	});
 
+	mHttpServer->Get("/favicon.png", [](const httplib::Request& req, httplib::Response& res)
+	{
+		auto data = ResourceManager::getInstance()->getFileData(":/window_icon_256.png");
+		if (data.ptr)
+			res.set_content((char*)data.ptr.get(), data.length, "image/png");
+	});
+
 	mHttpServer->Get("/index.html", [](const httplib::Request& req, httplib::Response& res)
 	{
+		auto data = ResourceManager::getInstance()->getFileData(":/services/index.html");
+		if (data.ptr)
+		{
+			res.set_content((char*)data.ptr.get(), data.length, "text/html");
+			return;
+		}
+
 		res.set_content(
 			"<!DOCTYPE html>\r\n"
 		    "<html lang='fr'>\r\n"
 			"<head>\r\n"			
 			"<title>EmulationStation services</title>\r\n"
+			"<link rel=\"shortcut icon\" href=\"favicon.png\">\r\n"
 			"</head>\r\n"
 			"<body style='font-family: Open Sans, sans-serif;'>\r\n"
 			"<p>EmulationStation services</p>\r\n"
@@ -78,6 +159,8 @@ void HttpServerThread::run()
 
 			"</script>\r\n"
 
+			"<img src='vid.jpg'/>\r\n"
+
 			"<input type='button' value='Reload games' onClick='reloadGamelists()'/>\r\n"
 			"<br/>"
 			"<input type='button' value='Quit' onClick='quitES()'/>\r\n"
@@ -95,6 +178,195 @@ void HttpServerThread::run()
 		quitES(QuitMode::REBOOT);
 	});
 
+
+	mHttpServer->Get("/systems", [](const httplib::Request& req, httplib::Response& res)
+	{
+		res.set_content(HttpApi::getSystemList(), "application/json");
+	});
+
+	mHttpServer->Get(R"(/systems/(/?.*)/logo)", [](const httplib::Request& req, httplib::Response& res)
+	{
+		std::string systemName = req.matches[1];
+		SystemData* system = SystemData::getSystem(systemName);
+		if (system != nullptr)
+		{
+			auto theme = system->getTheme();
+			if (theme != nullptr)
+			{
+				const ThemeData::ThemeElement* elem = theme->getElement("system", "logo", "image");
+				if (elem && elem->has("path"))
+				{
+					std::string logo = elem->get<std::string>("path");
+					auto data = ResourceManager::getInstance()->getFileData(logo);
+					if (data.ptr)
+					{
+						res.set_content((char*)data.ptr.get(), data.length, getMimeType(logo).c_str());
+						return;
+					}
+				}
+			}
+		}
+
+		res.set_content("404 not found", "text/html");
+		res.status = 404;
+	});
+	
+	mHttpServer->Get(R"(/systems/(/?.*)/games)", [](const httplib::Request& req, httplib::Response& res)
+	{
+		std::string systemName = req.matches[1];
+		SystemData* system = SystemData::getSystem(systemName);
+		if (system != nullptr)
+		{
+			res.set_content(HttpApi::getSystemGames(system), "application/json");
+			return;
+		}
+		
+		res.set_content("404 system not found", "text/html");
+		res.status = 404;		
+	});
+
+	mHttpServer->Get(R"(/systems/(/?.*)/games/(/?.*)/media/(/?.*))", [](const httplib::Request& req, httplib::Response& res)
+	{
+		std::string systemName = req.matches[1];
+		SystemData* system = SystemData::getSystem(systemName);
+		if (system != nullptr)
+		{
+			std::string gameId = req.matches[2];
+			auto game = HttpApi::findFileData(system, gameId);
+			if (game != nullptr)
+			{
+				std::string metadataName = req.matches[3];
+
+				if (game->getMetadata().getType(metadataName) == MD_PATH)
+				{
+					std::string path = game->getMetadata().get(metadataName);
+					if (!path.empty())
+					{
+						auto data = ResourceManager::getInstance()->getFileData(path);
+						if (data.ptr)
+						{
+							res.set_content((char*)data.ptr.get(), data.length, getMimeType(path).c_str());
+							return;
+						}
+
+						return;
+					}
+				}
+			}
+		}
+
+		res.set_content("404 media not found", "text/html");
+		res.status = 404;
+	});
+
+	mHttpServer->Post(R"(/systems/(/?.*)/games/(/?.*)/media/(/?.*))", [this](const httplib::Request& req, httplib::Response& res)
+	{
+		if (req.body.empty())
+		{
+			res.set_content("400 bad request - body is missing", "text/html");
+			res.status = 400;
+			return;
+		}
+
+		if (!req.has_header("Content-Type"))
+		{
+			res.set_content("400 missing content-type", "text/html");
+			res.status = 400;
+			return;
+		}
+
+		std::string contentType = req.get_header_value("Content-Type");
+		
+		std::string systemName = req.matches[1];
+		SystemData* system = SystemData::getSystem(systemName);
+		if (system != nullptr)
+		{
+			std::string gameId = req.matches[2];
+			auto game = HttpApi::findFileData(system, gameId);
+			if (game != nullptr)
+			{
+				std::string metadataName = req.matches[3];
+
+				if (game->getMetadata().getType(metadataName) == MD_PATH)
+				{
+					if (HttpApi::ImportMedia(game, metadataName, contentType, req.body))
+					{
+						mWindow->postToUiThread([game]() { ViewController::get()->onFileChanged(game, FileChangeType::FILE_METADATA_CHANGED); });
+						return;
+					}
+				}
+			}
+		}
+
+		res.set_content("404 media not found", "text/html");
+		res.status = 404;
+	});
+
+
+	mHttpServer->Post(R"(/systems/(/?.*)/games/(/?.*))", [this](const httplib::Request& req, httplib::Response& res)
+	{
+		if (req.body.empty())
+		{
+			res.set_content("400 bad request - body is missing", "text/html");
+			res.status = 400;
+			return;
+		}
+
+		std::string systemName = req.matches[1];
+		SystemData* system = SystemData::getSystem(systemName);
+		if (system != nullptr)
+		{
+			std::string gameId = req.matches[2];
+			auto game = HttpApi::findFileData(system, gameId);
+			if (game != nullptr)
+			{
+				if (HttpApi::ImportFromJson(game, req.body))
+				{
+					mWindow->postToUiThread([game]() { ViewController::get()->onFileChanged(game, FileChangeType::FILE_METADATA_CHANGED); });					
+					return;
+				}
+			}
+		}
+
+		res.set_content("404 game not found", "text/html");
+		res.status = 404;
+	});
+
+
+	mHttpServer->Get(R"(/systems/(/?.*)/games/(/?.*))", [](const httplib::Request& req, httplib::Response& res)
+	{
+		std::string systemName = req.matches[1];
+		SystemData* system = SystemData::getSystem(systemName);
+		if (system != nullptr)
+		{
+			std::string gameId = req.matches[2];
+			auto game = HttpApi::findFileData(system, gameId);
+			if (game != nullptr)
+			{
+				res.set_content(HttpApi::ToJson(game), "application/json");
+				return;
+			}
+		}
+
+		res.set_content("404 game not found", "text/html");
+		res.status = 404;
+	});
+
+	mHttpServer->Get(R"(/systems/(/?.*))", [](const httplib::Request& req, httplib::Response& res)
+	{
+		std::string systemName = req.matches[1];
+		SystemData* system = SystemData::getSystem(systemName);
+		if (system != nullptr)
+		{
+			res.set_content(HttpApi::ToJson(system), "application/json");
+			return;
+		}
+
+		res.set_content("404 not found", "text/html");
+		res.status = 404;
+	});
+
+	
 	mHttpServer->Get("/reloadgames", [this](const httplib::Request& req, httplib::Response& res)
 	{	
 		Window* w = mWindow;
@@ -296,6 +568,35 @@ void HttpServerThread::run()
 		});
 
 		res.set_content("OK", "text/html");
+	});
+
+	mHttpServer->Get(R"(/resources/(/?.*))", [](const httplib::Request& req, httplib::Response& res)  // (.*)
+	{
+		std::string url = req.matches[1];
+		auto data = ResourceManager::getInstance()->getFileData(":/" + url);
+		if (data.ptr)
+			res.set_content((char*)data.ptr.get(), data.length, getMimeType(url).c_str());
+		else
+		{
+			res.set_content("404 not found", "text/html");
+			res.status = 404;
+			return;
+		}
+	});
+
+	mHttpServer->Get(R"(/(/?.*))", [](const httplib::Request& req, httplib::Response& res)  // (.*)
+	{
+		std::string url = req.matches[1];
+
+		auto data = ResourceManager::getInstance()->getFileData(":/services/" + url);
+		if (data.ptr)
+			res.set_content((char*)data.ptr.get(), data.length, getMimeType(url).c_str());
+		else 
+		{
+			res.set_content("404 not found", "text/html");
+			res.status = 404;
+			return;
+		}
 	});
 
 	try

--- a/es-app/src/services/HttpServerThread.h
+++ b/es-app/src/services/HttpServerThread.h
@@ -14,6 +14,8 @@ public:
 	HttpServerThread(Window * window);
 	virtual ~HttpServerThread();
 
+	static std::string getMimeType(const std::string &path);
+
 private:
 	Window*			mWindow;
 	bool			mRunning;

--- a/es-app/src/views/SystemView.h
+++ b/es-app/src/views/SystemView.h
@@ -52,6 +52,9 @@ struct SystemViewCarousel
 	float			transitionSpeed;
 	std::string		defaultTransition;
 	std::string		scrollSound;
+
+	bool anyLogoHasOpacityStoryboard;
+	bool anyLogoHasScaleStoryboard;
 };
 
 class SystemView : public IList<SystemViewData, SystemData*>

--- a/es-app/src/views/gamelist/DetailedContainer.cpp
+++ b/es-app/src/views/gamelist/DetailedContainer.cpp
@@ -700,11 +700,13 @@ void DetailedContainer::updateControls(FileData* file, bool isClearing, int move
 				mFlag->setImage(":/folder.svg");
 		}
 
+		bool hasManualOrMagazine = Utils::FileSystem::exists(file->getMetadata(MetaDataId::Manual)) || Utils::FileSystem::exists(file->getMetadata(MetaDataId::Magazine));
+
 		if (mManual != nullptr)
-			mManual->setVisible(Utils::FileSystem::exists(file->getMetadata(MetaDataId::Manual)));
+			mManual->setVisible(hasManualOrMagazine);
 
 		if (mNoManual != nullptr)
-			mNoManual->setVisible(!Utils::FileSystem::exists(file->getMetadata(MetaDataId::Manual)));
+			mNoManual->setVisible(!hasManualOrMagazine);
 
 		if (mMap != nullptr)
 			mMap->setVisible(Utils::FileSystem::exists(file->getMetadata(MetaDataId::Map)));

--- a/es-app/src/views/gamelist/GameNameFormatter.cpp
+++ b/es-app/src/views/gamelist/GameNameFormatter.cpp
@@ -167,7 +167,7 @@ std::string GameNameFormatter::getDisplayName(FileData* fd, bool showFolderIcon)
 	if (saves)
 		after.push_back(SAVESTATE);
 
-	bool manual = mShowManualIcon && !fd->getMetadata(MetaDataId::Manual).empty();
+	bool manual = mShowManualIcon && (!fd->getMetadata(MetaDataId::Manual).empty() || !fd->getMetadata(MetaDataId::Magazine).empty());
 	if (manual)
 		after.push_back(MANUAL);
 

--- a/es-app/src/views/gamelist/GameNameFormatter.cpp
+++ b/es-app/src/views/gamelist/GameNameFormatter.cpp
@@ -87,7 +87,10 @@ GameNameFormatter::GameNameFormatter(SystemData* system)
 		mSortId == FileSorts::RELEASEDATE_SYSTEM_ASCENDING ||
 		mSortId == FileSorts::RELEASEDATE_SYSTEM_DESCENDING;
 
-	mShowSystemName = system->isGroupSystem() || system->isCollection() && Settings::getInstance()->getBool("CollectionShowSystemInfo");
+	mShowSystemName = (system->isGroupSystem() || system->isCollection()) && Settings::getInstance()->getBool("CollectionShowSystemInfo");
+
+	if (mShowSystemName && system->isGroupSystem() && system->getFolderViewMode() != "never")
+		mShowSystemName = false;
 }
 
 std::string valueOrDefault(const std::string value, const std::string defaultValue = _("Unknown"))

--- a/es-core/src/GuiComponent.cpp
+++ b/es-core/src/GuiComponent.cpp
@@ -495,9 +495,23 @@ bool GuiComponent::isStoryBoardRunning(const std::string& name)
 	return mStoryboardAnimator != nullptr && mStoryboardAnimator->isRunning();
 }
 
-bool GuiComponent::storyBoardExists(const std::string& name)
+bool GuiComponent::storyBoardExists(const std::string& name, const std::string& propertyName)
 {
-	return mStoryBoards.size() > 0 && mStoryBoards.find(name) != mStoryBoards.cend();
+	if (mStoryBoards.size() > 0)
+	{
+		auto it = mStoryBoards.find(name);
+		if (it == mStoryBoards.cend())
+			return false;
+
+		if (propertyName.empty())
+			return true;
+		
+		for (auto animation : it->second->animations)
+			if (animation->propertyName == propertyName)
+				return true;
+	}
+
+	return false;
 }
 
 bool GuiComponent::selectStoryboard(const std::string& name)

--- a/es-core/src/GuiComponent.h
+++ b/es-core/src/GuiComponent.h
@@ -184,7 +184,7 @@ public:
 	void stopStoryboard();
 	void enableStoryboardProperty(const std::string& name, bool enable);
 
-	bool storyBoardExists(const std::string& name = "");
+	bool storyBoardExists(const std::string& name = "", const std::string& propertyName = "");
 
 	bool isStoryBoardRunning(const std::string& name = "");
 

--- a/es-core/src/Log.cpp
+++ b/es-core/src/Log.cpp
@@ -6,6 +6,7 @@
 #include <mutex>
 #include "Settings.h"
 #include <iomanip> 
+#include <SDL_timer.h>
 
 #if WIN32
 #include <Windows.h>
@@ -146,4 +147,17 @@ void Log::setupReportingLevel()
 	}
 
 	setReportingLevel(lvl);
+}
+
+StopWatch::StopWatch(const std::string& elapsedMillisecondsMessage, LogLevel level)
+{ 
+	mMessage = elapsedMillisecondsMessage; 
+	mLevel = level;
+	mStartTicks = SDL_GetTicks();
+}
+
+StopWatch::~StopWatch()
+{
+	int elapsed = SDL_GetTicks() - mStartTicks;
+	LOG(mLevel) << mMessage << " " << elapsed << "ms";
 }

--- a/es-core/src/Log.h
+++ b/es-core/src/Log.h
@@ -43,4 +43,16 @@ private:
 	LogLevel messageLevel;
 };
 
+class StopWatch
+{
+public:
+	StopWatch(const std::string& elapsedMillisecondsMessage, LogLevel level = LogDebug);
+	~StopWatch();
+
+private:
+	std::string mMessage;
+	LogLevel mLevel;
+	int mStartTicks;
+};
+
 #endif // ES_CORE_LOG_H

--- a/es-core/src/Settings.cpp
+++ b/es-core/src/Settings.cpp
@@ -111,6 +111,7 @@ void Settings::setDefaults()
 	mBoolMap["SaveGamelistsOnExit"] = true;	
 	mStringMap["ShowBattery"] = "text";	
 	mBoolMap["CheckBiosesAtLaunch"] = true;
+	mBoolMap["RemoveMultiDiskContent"] = true;
 	
 #if WIN32
 	mBoolMap["ShowNetworkIndicator"] = false;

--- a/es-core/src/utils/FileSystemUtil.cpp
+++ b/es-core/src/utils/FileSystemUtil.cpp
@@ -1270,11 +1270,7 @@ namespace Utils
 
 		std::string	readAllText(const std::string fileName)
 		{
-#if defined(_WIN32)
-			std::ifstream t(Utils::String::convertToWideString(fileName));
-#else
-			std::ifstream t(fileName);
-#endif
+			std::ifstream t(WINSTRINGW(fileName));
 
 			std::stringstream buffer;
 			buffer << t.rdbuf();
@@ -1320,6 +1316,8 @@ namespace Utils
 			// don't remove if it doesn't exists
 			if (!exists(path))
 				return true;
+
+			Utils::FileSystem::createDirectory(Utils::FileSystem::getParent(pathD));
 
 			char buf[512];
 			size_t size;

--- a/es-core/src/utils/FileSystemUtil.cpp
+++ b/es-core/src/utils/FileSystemUtil.cpp
@@ -1277,18 +1277,21 @@ namespace Utils
 			return buffer.str();
 		}
 
-		void writeAllText(const std::string fileName, const std::string text)
+		void writeAllText(const std::string& fileName, const std::string& text)
 		{
-			std::fstream fs;
-
 #if defined(_WIN32)
-			fs.open(Utils::String::convertToWideString(fileName), std::fstream::out);
+			FILE* file = _wfopen(Utils::String::convertToWideString(fileName).c_str(), L"wb");
 #else
-			fs.open(fileName.c_str(), std::fstream::out);
+			FILE* file = fopen(fileName.c_str(), "rb");
 #endif
+			if (file == nullptr)
+				return;		
 
-			fs << text;
-			fs.close();
+			void* buffer = (void*) text.data();
+			size_t size = text.size();
+
+			fwrite(buffer, 1, size, file);
+			fclose(file);
 		}
 
 		bool renameFile(const std::string src, const std::string dst, bool overWrite)

--- a/es-core/src/utils/FileSystemUtil.h
+++ b/es-core/src/utils/FileSystemUtil.h
@@ -66,7 +66,7 @@ namespace Utils
 		Utils::Time::DateTime getFileModificationDate(const std::string& _path);
 
 		std::string	readAllText(const std::string fileName);
-		void		writeAllText(const std::string fileName, const std::string text);
+		void		writeAllText(const std::string& fileName, const std::string& text);
 		bool		copyFile(const std::string src, const std::string dst);
 		void		deleteDirectoryFiles(const std::string path, bool deleteDirectory = false);
 		bool		renameFile(const std::string src, const std::string dst, bool overWrite = true);

--- a/es-core/src/utils/StringUtil.h
+++ b/es-core/src/utils/StringUtil.h
@@ -53,4 +53,10 @@ namespace Utils
 
 } // Utils::
 
+#if defined(_WIN32)
+#define WINSTRINGW(x) Utils::String::convertToWideString(x)
+#else
+#define WINSTRINGW(x) x
+#endif
+
 #endif // ES_CORE_UTILS_STRING_UTIL_H

--- a/resources/services/index.html
+++ b/resources/services/index.html
@@ -1,0 +1,145 @@
+<!DOCTYPE html>
+<html lang='fr'>
+<head>			
+	<title>EmulationStation Web services</title>
+	<link rel="shortcut icon" href="favicon.png">
+	<link href="main.css" rel="stylesheet">
+</head>
+
+<body>
+
+<div class="title">
+	<img height="24" style="vertical-align: middle;" src="favicon.png">
+	<span>EmulationStation Web services</span>
+</div>
+
+<script type='text/javascript'>
+
+function quitES() {
+	var xhr = new XMLHttpRequest();			
+	xhr.open('GET', '/quit');
+	xhr.send(); 
+}
+
+function reloadGamelists() {
+	var xhr = new XMLHttpRequest();
+	xhr.open('GET', '/reloadgames');
+	xhr.send(); 
+}
+
+function showGames(arr) {
+    var out = "<table width=100% border=0 cellpadding=4 cellspacing=0>";
+    var i;
+    for(i = 0; i < arr.length; i++) {	
+		out += '<tr class="system">';		
+		out += '<td width="72px" align="center"><img height=48 style="max-width:100px" src="' + arr[i].image + '"></td>';		
+		out += '<td>';
+		out += '<table width=100%>';
+		out += '<tr><td>' + arr[i].name + '</td></tr>';
+		if (arr[i].desc) {
+			out += '<tr><td><div class="desc">' + arr[i].desc + '</div></td></tr>';
+		}
+		out += '</table>';
+		out += '</td>';
+		out += '<tr/>';
+    }
+	
+	out += "</table>";
+    document.getElementById("gameList").innerHTML = out;
+}
+
+
+function loadGames(name) {
+	var xhr = new XMLHttpRequest();
+	
+	xhr.onreadystatechange = function() {
+		if (this.readyState == 4 && this.status == 200) {
+			var myArr = JSON.parse(this.responseText);
+			showGames(myArr);
+		}
+	};
+
+	xhr.open('GET', '/systems/' + name + '/games');
+	xhr.send(); 
+	
+}
+
+
+var xmlhttp = new XMLHttpRequest();
+var url = "/systems";
+
+xmlhttp.onreadystatechange = function() {
+    if (this.readyState == 4 && this.status == 200) {
+        var myArr = JSON.parse(this.responseText);
+        showSystems(myArr);
+    }
+};
+xmlhttp.open("GET", url, true);
+xmlhttp.send();
+
+function showSystems(arr) {
+    var out = "<table width=30% cellpadding=8>";
+    var i;
+    for(i = 0; i < arr.length; i++) {
+	
+		if (arr[i].visible == "true") {
+			out += '<tr class="system">';
+			if (arr[i].logo) {
+				out += '<td align="center"><a onclick="javascript:loadGames(\''+ arr[i].name +'\')" href="#"><img height=25 style="max-width:100px" src="' + arr[i].logo + '"></a></td>';
+			} else {
+				out += '<td align="center">' + arr[i].fullname + '</td>';
+			}
+			
+		//	out += '<td>Games : ' + arr[i].totalGames + '</td>';
+			
+			out += '<tr/>';
+		}
+    }
+	
+	out += "</table>";
+    document.getElementById("systemList").innerHTML = out;
+}
+</script>
+
+<!-- <img src="resources/vid.jpg"/> -->
+
+<div id="toolbar" class="toolbar">
+	<input class="toolbarbutton" type='button' value='Reload games' onClick='reloadGamelists()'/>
+	<input class="toolbarbutton" type='button' value='Exit EmulationStation' onClick='quitES()'/>
+</div>
+
+<table height='100%' width='100%' cellpadding=0 cellspacing=0 border=0>
+<tr>
+ <td valign="top" width='120px'>
+ 
+
+   <div id="systemList" style="color:white;background-color:#202020; overflow-y:scroll"></div>
+ </td>
+ <td valign="top">
+   <div id="gameList" style="height:300px;color:white;background-color:#202020; overflow-y:scroll"></div>
+ </td>
+</tr> 
+</table>
+
+
+<script type='text/javascript'>
+function resize() {
+	var heights = window.innerHeight;	
+	var toolbar = document.getElementById("toolbar");
+	
+	var systemList = document.getElementById("systemList");
+	if (systemList) {
+		systemList.style.height = (heights - toolbar.offsetTop - toolbar.offsetHeight) + "px";
+	}
+	
+	var systemList = document.getElementById("gameList");
+	if (gameList) {
+		gameList.style.height = (heights - toolbar.offsetTop - toolbar.offsetHeight) + "px";
+	}
+}
+
+resize();
+window.onresize = function() { 	resize(); };		
+</script>
+</body>
+</html>

--- a/resources/services/main.css
+++ b/resources/services/main.css
@@ -1,0 +1,44 @@
+html, body { 
+	margin:0px; 
+	padding:0px; 
+	font-family: Open Sans, sans-serif; 
+	font-size:12px;
+	height:100%;
+	overflow:hidden;
+}
+
+.title { 
+	background-color:#F0F0F0; 	
+	padding:4px 8px;
+	text-align: left;
+	font-size:16px;
+}
+
+.desc { 
+	color:#A0A0A0; 	
+	font-size:8px;
+	text-overflow: ellipsis;
+  overflow: hidden;
+  height:22px
+}
+
+.system:hover {
+	background-color:#303030;
+}
+
+.toolbar {
+	background-color:#304070FF;
+}
+
+.toolbarbutton {
+	color:white;
+	background-color:#304070FF;
+	border:none;
+	font-size:12px;
+	padding:6px 8px;
+}
+
+
+.toolbarbutton:hover {
+	background-color:#405080FF;
+}


### PR DESCRIPTION
Please, once this PR merged, when you'll bump it, add this line to  batocera-emulationstation.mk: 
`$(INSTALL) -m 0644 -D $(@D)/resources/services/*.* $(TARGET_DIR)/usr/share/emulationstation/resources/services`
Just after this line : https://github.com/batocera-linux/batocera.linux/blob/master/package/batocera/emulationstation/batocera-emulationstation/batocera-emulationstation.mk#L80

+ Http Services : Add some APIs to list system/games, get medias, files & resources.
+ Scraper : Add watara support 
+ Metadatas : Add 'magazine' metadata 
+ Add option to exclude cue/ccd/m3u child roms 
+ Fix Game names : Don't show system name in group systems, if child system folders are displayed (ports/amiga/msx...)
+ SystemView storyboards : Add support for "scroll" event on logo elements ( <image name="logo"><storyboard event="scroll"> )


