### PR TITLE
Fix : Potential 'Black' gamelist after adding a game to favorites or returning from a game.

### DIFF
--- a/es-app/src/FileData.cpp
+++ b/es-app/src/FileData.cpp
@@ -544,6 +544,9 @@ bool FileData::launchGame(Window* window, LaunchGameOptions options)
 
 bool FileData::hasContentFiles()
 {
+	if (mPath.empty())
+		return false;
+
 	std::string ext = Utils::String::toLower(Utils::FileSystem::getExtension(mPath));
 	if (ext == ".m3u" || ext == ".cue" || ext == ".ccd" || ext == ".gdi")
 		return getSourceFileData()->getSystemEnvData()->isValidExtension(ext) && getSourceFileData()->getSystemEnvData()->mSearchExtensions.size() > 1;
@@ -598,6 +601,9 @@ std::set<std::string> FileData::getContentFiles()
 {
 	std::set<std::string> files;
 
+	if (mPath.empty())
+		return files;
+
 	if (Utils::FileSystem::isDirectory(mPath))
 	{
 		for (auto file : Utils::FileSystem::getDirContent(mPath, true, true))
@@ -633,6 +639,7 @@ std::set<std::string> FileData::getContentFiles()
 		{
 			std::string stem = Utils::FileSystem::getStem(mPath);
 			files.insert(path + "/" + stem + ".cue");
+			files.insert(path + "/" + stem + ".img");
 			files.insert(path + "/" + stem + ".bin");
 			files.insert(path + "/" + stem + ".sub");
 		}

--- a/es-app/src/SystemData.cpp
+++ b/es-app/src/SystemData.cpp
@@ -147,7 +147,10 @@ void SystemData::removeMultiDiskContent(std::unordered_map<std::string, FileData
 	{
 		auto it = fileMap.find(file);
 		if (it != fileMap.cend())
+		{
 			delete it->second;
+			fileMap.erase(it);
+		}
 	}
 }
 

--- a/es-app/src/views/ViewController.cpp
+++ b/es-app/src/views/ViewController.cpp
@@ -969,6 +969,8 @@ void ViewController::reloadGameListView(IGameListView* view)
 	if (view == nullptr)
 		return;
 
+	Vector3f position = view->getPosition();
+
 	bool isCurrent = mCurrentView != nullptr && mCurrentView.get() == view;
 	if (isCurrent)
 	{
@@ -997,6 +999,7 @@ void ViewController::reloadGameListView(IGameListView* view)
 		if (isCurrent)
 		{		
 			mCurrentView = newView;
+			mCurrentView->setPosition(position);
 
 			ISimpleGameListView* view = dynamic_cast<ISimpleGameListView*>(newView.get());
 			if (view != nullptr)

--- a/es-app/src/views/gamelist/ISimpleGameListView.cpp
+++ b/es-app/src/views/gamelist/ISimpleGameListView.cpp
@@ -200,7 +200,7 @@ bool ISimpleGameListView::input(InputConfig* config, Input input)
 
 	if (mXButton.isShortPressed(config, input))
 	{
-		showSelectedGameOptions();
+		showSelectedGameSaveSnapshots();
 		return true;
 	}	
 
@@ -223,23 +223,7 @@ bool ISimpleGameListView::input(InputConfig* config, Input input)
 
 	if (config->isMappedTo("l3", input))
 	{
-		FileData* cursor = getCursor();
-		if (cursor->getType() == GAME)
-		{				
-			if (SaveStateRepository::isEnabled(cursor))
-			{
-				mWindow->pushGui(new GuiSaveState(mWindow, cursor, [this, cursor](SaveState state)
-				{
-					Sound::getFromTheme(getTheme(), getName(), "launch")->play();
-
-					LaunchGameOptions options;
-					options.saveStateInfo = state;
-					ViewController::get()->launch(cursor, options);
-				}
-				));
-			}
-		}
-
+		showSelectedGameSaveSnapshots();
 		return true;
 	}
 		
@@ -312,6 +296,28 @@ void ISimpleGameListView::showSelectedGameOptions()
 
 	Sound::getFromTheme(mTheme, getName(), "menuOpen")->play();
 	mWindow->pushGui(new GuiGameOptions(mWindow, cursor));
+}
+
+void ISimpleGameListView::showSelectedGameSaveSnapshots()
+{
+	FileData* cursor = getCursor();
+	if (cursor == nullptr || cursor->getType() != GAME)
+		return;
+
+	if (SaveStateRepository::isEnabled(cursor))
+	{
+		Sound::getFromTheme(mTheme, getName(), "menuOpen")->play();
+
+		mWindow->pushGui(new GuiSaveState(mWindow, cursor, [this, cursor](SaveState state)
+		{
+			Sound::getFromTheme(getTheme(), getName(), "launch")->play();
+
+			LaunchGameOptions options;
+			options.saveStateInfo = state;
+			ViewController::get()->launch(cursor, options);
+		}
+		));
+	}
 }
 
 void ISimpleGameListView::launchSelectedGame()

--- a/es-app/src/views/gamelist/ISimpleGameListView.h
+++ b/es-app/src/views/gamelist/ISimpleGameListView.h
@@ -47,6 +47,7 @@ public:
 	void showQuickSearch();
 	void launchSelectedGame();
 	void showSelectedGameOptions();
+	void showSelectedGameSaveSnapshots();
 	void toggleFavoritesFilter();
 
 protected:	

--- a/es-core/src/SystemConf.cpp
+++ b/es-core/src/SystemConf.cpp
@@ -39,6 +39,7 @@ static std::map<std::string, std::string> defaults =
 	{ "kodi.enabled", "1" },
 	{ "kodi.atstartup", "0" },
 	{ "audio.bgmusic", "1" },
+	{ "global.autosave", "2" },
 	{ "wifi.enabled", "0" },
 	{ "system.hostname", "BATOCERA" },
 	{ "global.retroachievements", "0" },


### PR DESCRIPTION
+ Fix : Potential 'Black' gamelist after adding a game to favorites or returning from a game.
+ Fix crash when the same file is referenced in multiple m3u files
+ Save snapshots : global.autoSave -> set default to 2 (SHOW SNAPSHOTS IF NOT EMPTY)
+ Save Snapshots : Open snapshots with X (North) button instead of Game options ( which is now on long press A ).



