### PR TITLE
Gamelist views : Invert SEARCH / RANDOM functions on north button + Fixes

### DIFF
--- a/es-app/src/ApiSystem.cpp
+++ b/es-app/src/ApiSystem.cpp
@@ -1371,12 +1371,12 @@ std::vector<PacmanPackage> ApiSystem::getBatoceraStorePackages()
 
 std::pair<std::string, int> ApiSystem::installBatoceraStorePackage(std::string name, const std::function<void(const std::string)>& func)
 {
-	return executeScript("batocera-store install " + name, func);
+	return executeScript("batocera-store install \"" + name + "\"", func);
 }
 
 std::pair<std::string, int> ApiSystem::uninstallBatoceraStorePackage(std::string name, const std::function<void(const std::string)>& func)
 {
-	return executeScript("batocera-store remove " + name, func);
+	return executeScript("batocera-store remove \"" + name + "\"", func);
 }
 
 void ApiSystem::refreshBatoceraStorePackageList()

--- a/es-app/src/Gamelist.cpp
+++ b/es-app/src/Gamelist.cpp
@@ -92,7 +92,7 @@ FileData* findOrCreateFile(SystemData* system, const std::string& path, FileType
 			}
 
 			// create missing folder
-			FolderData* folder = new FolderData(Utils::FileSystem::getStem(treeNode->getPath()) + "/" + *path_it, system);
+			FolderData* folder = new FolderData(treeNode->getPath() + "/" + *path_it, system);
 			fileMap[key] = folder;
 			treeNode->addChild(folder);
 			treeNode = folder;

--- a/es-app/src/SystemData.cpp
+++ b/es-app/src/SystemData.cpp
@@ -123,6 +123,8 @@ void SystemData::removeMultiDiskContent(std::unordered_map<std::string, FileData
 
 	std::vector<std::string> files;
 
+	std::vector<FolderData*> folders;
+
 	std::stack<FolderData*> stack;
 	stack.push(mRootFolder);
 
@@ -139,7 +141,10 @@ void SystemData::removeMultiDiskContent(std::unordered_map<std::string, FileData
 					files.push_back(ct);
 			}
 			else if (it->getType() == FOLDER)
+			{
+				folders.push_back((FolderData*)it);
 				stack.push((FolderData*)it);
+			}
 		}
 	}
 
@@ -151,6 +156,20 @@ void SystemData::removeMultiDiskContent(std::unordered_map<std::string, FileData
 			delete it->second;
 			fileMap.erase(it);
 		}
+	}
+
+	// Remove empty folders
+	for (auto folder = folders.crbegin(); folder != folders.crend(); ++folder)
+	{
+		if ((*folder)->getChildren().size())
+			continue;
+		
+		auto it = fileMap.find((*folder)->getPath());
+		if (it != fileMap.cend())
+		{
+			fileMap.erase(it);
+			delete (*folder);
+		}		
 	}
 }
 

--- a/es-app/src/components/CarouselComponent.h
+++ b/es-app/src/components/CarouselComponent.h
@@ -100,6 +100,9 @@ private:
 	std::string		mScrollSound;
 	float			mTransitionSpeed;
 	float			mMinLogoOpacity;
+
+public:
+	bool isHorizontalCarousel() { return mType == HORIZONTAL || mType == HORIZONTAL_WHEEL; }
 };
 
 #endif // ES_APP_VIEWS_SYSTEM_VIEW_H

--- a/es-app/src/views/gamelist/BasicGameListView.cpp
+++ b/es-app/src/views/gamelist/BasicGameListView.cpp
@@ -208,50 +208,6 @@ void BasicGameListView::remove(FileData *game)
 	onFileChanged(parent, FILE_REMOVED);           // update the view, with game removed
 }
 
-std::vector<HelpPrompt> BasicGameListView::getHelpPrompts()
-{
-	std::vector<HelpPrompt> prompts;
-
-	if (Renderer::getScreenProportion() > 1.4)
-	{
-		if (mPopupSelfReference == nullptr && Settings::getInstance()->getBool("QuickSystemSelect"))
-			prompts.push_back(HelpPrompt("left/right", _("SYSTEM"))); // batocera
-
-		prompts.push_back(HelpPrompt("up/down", _("CHOOSE"))); // batocera
-	}
-	
-	prompts.push_back(HelpPrompt(BUTTON_BACK, _("BACK")));
-	prompts.push_back(HelpPrompt(BUTTON_OK, _("LAUNCH") + std::string(" / ") + _("GAME OPTIONS")));
-
-	if(!UIModeController::getInstance()->isUIModeKid())
-	  prompts.push_back(HelpPrompt("select", _("OPTIONS"))); // batocera
-
-	if (UIModeController::getInstance()->isUIModeKid())
-		prompts.push_back(HelpPrompt("x", _("SAVE SNAPSHOTS")));
-	else
-		prompts.push_back(HelpPrompt("x", _("SAVE SNAPSHOTS") + std::string(" / ") + _("FAVORITE")));
-
-	prompts.push_back(HelpPrompt("y", _("RANDOM") + std::string(" / ") + _("SEARCH")));
-	/*
-	FileData* cursor = getCursor();
-	if (cursor != nullptr && cursor->isNetplaySupported())
-		prompts.push_back(HelpPrompt("x", _("NETPLAY"))); // batocera
-	else
-		prompts.push_back(HelpPrompt("x", _("RANDOM"))); // batocera
-
-	if(mRoot->getSystem()->isGameSystem() && !UIModeController::getInstance()->isUIModeKid())
-	{
-		std::string prompt = CollectionSystemManager::get()->getEditingCollection();
-		
-		if (Utils::String::toLower(prompt) == "favorites")
-			prompts.push_back(HelpPrompt("y", _("Favorites")));
-		else
-			prompts.push_back(HelpPrompt("y", _(prompt.c_str())));
-	}*/
-
-	return prompts;
-}
-
 // batocera
 void BasicGameListView::setCursorIndex(int cursor){
 	mList.setCursorIndex(cursor);

--- a/es-app/src/views/gamelist/BasicGameListView.h
+++ b/es-app/src/views/gamelist/BasicGameListView.h
@@ -28,7 +28,6 @@ public:
 		return "basic";
 	}
 
-	virtual std::vector<HelpPrompt> getHelpPrompts() override;
 	virtual void launch(FileData* game) override;
 	virtual std::vector<FileData*> getFileDataEntries() override;
 

--- a/es-app/src/views/gamelist/CarouselGameListView.cpp
+++ b/es-app/src/views/gamelist/CarouselGameListView.cpp
@@ -157,11 +157,17 @@ void CarouselGameListView::addPlaceholder()
 
 std::string CarouselGameListView::getQuickSystemSelectRightButton()
 {
+	if (mList.isHorizontalCarousel())
+		return "r2";
+
 	return "right";
 }
 
 std::string CarouselGameListView::getQuickSystemSelectLeftButton()
 {
+	if (mList.isHorizontalCarousel())
+		return "l2";
+
 	return "left";
 }
 
@@ -191,30 +197,6 @@ void CarouselGameListView::remove(FileData *game)
 	mRoot->removeFromVirtualFolders(game);
 	delete game;                                 // remove before repopulating (removes from parent)
 	onFileChanged(parent, FILE_REMOVED);           // update the view, with game removed
-}
-
-std::vector<HelpPrompt> CarouselGameListView::getHelpPrompts()
-{
-	std::vector<HelpPrompt> prompts;
-
-	if (mPopupSelfReference == nullptr && Settings::getInstance()->getBool("QuickSystemSelect"))
-		prompts.push_back(HelpPrompt("left/right", _("SYSTEM"))); // batocera
-
-	prompts.push_back(HelpPrompt("up/down", _("CHOOSE"))); // batocera
-
-	prompts.push_back(HelpPrompt(BUTTON_OK, _("LAUNCH") + std::string(" / ") + _("GAME OPTIONS")));
-	prompts.push_back(HelpPrompt(BUTTON_BACK, _("BACK")));
-	if(!UIModeController::getInstance()->isUIModeKid())
-	  prompts.push_back(HelpPrompt("select", _("OPTIONS"))); // batocera
-
-	if (UIModeController::getInstance()->isUIModeKid())
-		prompts.push_back(HelpPrompt("x", _("SAVE SNAPSHOTS")));
-	else
-		prompts.push_back(HelpPrompt("x", _("SAVE SNAPSHOTS") + std::string(" / ") + _("FAVORITE")));
-
-	prompts.push_back(HelpPrompt("y", _("RANDOM") + std::string(" / ") + _("SEARCH")));
-
-	return prompts;
 }
 
 // batocera

--- a/es-app/src/views/gamelist/CarouselGameListView.h
+++ b/es-app/src/views/gamelist/CarouselGameListView.h
@@ -29,7 +29,6 @@ public:
 		return "gamecarousel";
 	}
 
-	virtual std::vector<HelpPrompt> getHelpPrompts() override;
 	virtual void launch(FileData* game) override;
 	virtual std::vector<FileData*> getFileDataEntries() override;
 	virtual void update(int deltaTime) override;

--- a/es-app/src/views/gamelist/GridGameListView.cpp
+++ b/es-app/src/views/gamelist/GridGameListView.cpp
@@ -303,35 +303,6 @@ void GridGameListView::onFileChanged(FileData* file, FileChangeType change)
 	ISimpleGameListView::onFileChanged(file, change);
 }
 
-std::vector<HelpPrompt> GridGameListView::getHelpPrompts()
-{
-	std::vector<HelpPrompt> prompts;
-
-	if (Renderer::getScreenProportion() > 1.4)
-	{
-		if(mPopupSelfReference == nullptr && Settings::getInstance()->getBool("QuickSystemSelect"))
-			prompts.push_back(HelpPrompt("lr", _("SYSTEM")));
-			
-		prompts.push_back(HelpPrompt("up/down/left/right", _("CHOOSE")));
-	}
-	
-
-	prompts.push_back(HelpPrompt(BUTTON_BACK, _("BACK")));
-	prompts.push_back(HelpPrompt(BUTTON_OK, _("LAUNCH") + std::string(" / ") + _("GAME OPTIONS")));
-
-	if (!UIModeController::getInstance()->isUIModeKid())
-		prompts.push_back(HelpPrompt("select", _("OPTIONS")));
-
-	if (UIModeController::getInstance()->isUIModeKid())
-		prompts.push_back(HelpPrompt("x", _("SAVE SNAPSHOTS")));
-	else
-		prompts.push_back(HelpPrompt("x", _("SAVE SNAPSHOTS") + std::string(" / ") + _("FAVORITE")));
-
-	prompts.push_back(HelpPrompt("y", _("RANDOM") + std::string(" / ") + _("SEARCH")));
-
-	return prompts;
-}
-
 void GridGameListView::setCursorIndex(int cursor)
 {
 	mGrid.setCursorIndex(cursor);

--- a/es-app/src/views/gamelist/GridGameListView.h
+++ b/es-app/src/views/gamelist/GridGameListView.h
@@ -33,7 +33,6 @@ public:
 		return "grid";
 	}
 
-	virtual std::vector<HelpPrompt> getHelpPrompts() override;
 	virtual void launch(FileData* game) override;
 	virtual void onFileChanged(FileData* file, FileChangeType change);
 

--- a/es-app/src/views/gamelist/ISimpleGameListView.h
+++ b/es-app/src/views/gamelist/ISimpleGameListView.h
@@ -50,6 +50,8 @@ public:
 	void showSelectedGameSaveSnapshots();
 	void toggleFavoritesFilter();
 
+	virtual std::vector<HelpPrompt> getHelpPrompts() override;
+
 protected:	
 	void	  updateFolderPath();
 
@@ -76,6 +78,8 @@ protected:
 	MultiStateInput mSelectButton;
 
 	ThemeData::ExtraImportType mExtraMode;
+
+	bool			mSaveStatesEnabled;
 };
 
 #endif // ES_APP_VIEWS_GAME_LIST_ISIMPLE_GAME_LIST_VIEW_H


### PR DESCRIPTION
- Content downloader : fix when package name contains a space
- Gamelist views : Invert SEARCH / RANDOM functions on north button 
- Rationalize help for gameslist views
- Fix : bad subfolder creation when using "parse gamelists only"
- Fix SystemData : Remove empty folders 