### PR TITLE
Clean-all when clicking on "refresh"

### DIFF
--- a/es-app/src/ApiSystem.cpp
+++ b/es-app/src/ApiSystem.cpp
@@ -1372,6 +1372,7 @@ std::pair<std::string, int> ApiSystem::uninstallBatoceraStorePackage(std::string
 void ApiSystem::refreshBatoceraStorePackageList()
 {
 	executeScript("batocera-store refresh");
+	executeScript("batocera-store clean-all");
 }
 
 void ApiSystem::updateBatoceraStorePackageList()


### PR DESCRIPTION
After discussing with the rest of the team, this seems to be a preferred solution (remove all cached pacman packages on refresh).