### PR TITLE
Better timezone configuration

### DIFF
--- a/es-app/src/ApiSystem.cpp
+++ b/es-app/src/ApiSystem.cpp
@@ -1475,11 +1475,24 @@ std::vector<std::string> ApiSystem::getTimezones()
 	return ret;
 }
 
+std::string ApiSystem::getCurrentTimezone()
+{
+	LOG(LogInfo) << "ApiSystem::getCurrentTimezone";
+	auto cmd = executeEnumerationScript("batocera-timezone get");
+	std::string tz = Utils::String::join(cmd, "");
+	remove_if(tz.begin(), tz.end(), isspace);
+	if (tz.empty()) {
+		cmd = executeEnumerationScript("batocera-timezone detect");
+		tz = Utils::String::join(cmd, "");
+	}
+	return tz;
+}
+
 bool ApiSystem::setTimezone(std::string tz)
 {
 	if (tz.empty())
 		return false;
-	return executeScript("batocera-config tz " + tz);
+	return executeScript("batocera-timezone set \"" + tz + "\"");
 }
 
 std::vector<PadInfo> ApiSystem::getPadsInfo()

--- a/es-app/src/ApiSystem.h
+++ b/es-app/src/ApiSystem.h
@@ -209,6 +209,7 @@ public:
 	virtual std::string getSevenZipCommand() { return "7zr"; }
 
 	virtual std::vector<std::string> getTimezones();
+	virtual std::string getCurrentTimezone();
 	virtual bool setTimezone(std::string tz);
 
 	virtual std::vector<PadInfo> getPadsInfo();

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -1196,15 +1196,21 @@ void GuiMenu::openSystemSettings_batocera()
 	auto availableTimezones = ApiSystem::getInstance()->getTimezones();
 	if (availableTimezones.size() > 0)
 	{
-		std::string currentTZ = SystemConf::getInstance()->get("system.timezone");
+		std::string currentTZ = ApiSystem::getInstance()->getCurrentTimezone();
+
+		bool valid_tz = false;
+		for (auto list_tz : availableTimezones){
+			if (currentTZ == list_tz) {
+				valid_tz = true;
+			}
+		}
+		if (!valid_tz)
+			currentTZ = "Europe/Paris";
 
 		auto tzChoices= std::make_shared<OptionListComponent<std::string> >(mWindow, _("SELECT YOUR TIMEZONE"), false);
 
 		for (auto tz : availableTimezones)
 			tzChoices->add(_(Utils::String::toUpper(tz).c_str()), tz, currentTZ == tz);
-
-		if (!tzChoices->hasSelection())
-			tzChoices->selectFirstItem();
 
 		s->addWithLabel(_("TIMEZONE"), tzChoices);
 		s->addSaveFunc([tzChoices] {


### PR DESCRIPTION
If no timezone has been defined, try to autodetect the best timezone from the IP address, and otherwise default to "Europe/Paris" (default TZ until now). Requires scripts from https://github.com/batocera-linux/batocera.linux/pull/3882 