### PR TITLE
nicer po output

### DIFF
--- a/locale/CMakeLists.txt
+++ b/locale/CMakeLists.txt
@@ -10,8 +10,14 @@ foreach (es_PO_INPUT ${es_PO_FILES})
 	MESSAGE("LANG = ${es_PO_LANG}")
 	set (es_MO_OUTPUT ${es_PO_INPUT}/LC_MESSAGES/emulationstation2.mo)
 	# update the po from the pot
-	add_custom_command (TARGET i18n COMMAND basename ${es_PO_INPUT} && ${MSGMERGE_EXECUTABLE} -U --no-fuzzy-matching ${es_PO_INPUT}/LC_MESSAGES/emulationstation2.po ${es_POT})
+	add_custom_command (TARGET i18n COMMAND ${MSGMERGE_EXECUTABLE} -U --no-fuzzy-matching ${es_PO_INPUT}/LC_MESSAGES/emulationstation2.po ${es_POT})
 	# compile the po to mo
-        add_custom_command (TARGET i18n COMMAND ${MSGFMT_EXECUTABLE} -o ${es_MO_OUTPUT} ${es_PO_INPUT}/LC_MESSAGES/emulationstation2.po --statistics)
+        add_custom_command (TARGET i18n COMMAND basename ${es_PO_INPUT} && ${MSGFMT_EXECUTABLE} -o ${es_MO_OUTPUT} ${es_PO_INPUT}/LC_MESSAGES/emulationstation2.po)
         install (FILES ${es_MO_OUTPUT} DESTINATION share/locale/${es_PO_LANG}/LC_MESSAGES RENAME emulationstation2.mo)
 endforeach (es_PO_INPUT ${es_PO_FILES})
+
+add_custom_command (TARGET i18n COMMAND echo)
+foreach (es_PO_INPUT ${es_PO_FILES})
+  add_custom_command (TARGET i18n COMMAND printf "%-5s " `basename ${es_PO_INPUT}` && LANG=C ${MSGFMT_EXECUTABLE} -o /dev/null ${es_PO_INPUT}/LC_MESSAGES/emulationstation2.po --statistics)
+endforeach (es_PO_INPUT ${es_PO_FILES})
+add_custom_command (TARGET i18n COMMAND echo)


### PR DESCRIPTION
ar    583 translated messages, 193 untranslated messages.
ca    180 translated messages, 596 untranslated messages.
cy_GB 725 translated messages, 51 untranslated messages.
de    773 translated messages, 3 untranslated messages.
el    2 translated messages, 774 untranslated messages.
es    776 translated messages.
es_MX 625 translated messages, 151 untranslated messages.
eu_ES 181 translated messages, 595 untranslated messages.
fr    771 translated messages, 5 untranslated messages.
hu    576 translated messages, 200 untranslated messages.
it    775 translated messages, 1 untranslated message.
ja_JP 771 translated messages, 5 untranslated messages.
ko    574 translated messages, 202 untranslated messages.
nb_NO 181 translated messages, 595 untranslated messages.
nl    529 translated messages, 247 untranslated messages.
nn_NO 178 translated messages, 598 untranslated messages.
oc_FR 344 translated messages, 432 untranslated messages.
pl    767 translated messages, 9 untranslated messages.
pt_BR 776 translated messages.
pt_PT 773 translated messages, 3 untranslated messages.
ru_RU 772 translated messages, 4 untranslated messages.
sv_SE 455 translated messages, 321 untranslated messages.
tr    776 translated messages.
uk_UA 605 translated messages, 171 untranslated messages.
zh_CN 645 translated messages, 131 untranslated messages.
zh_TW 773 translated messages, 3 untranslated messages.


Signed-off-by: Nicolas Adenis-Lamarre <nicolas.adenis.lamarre@gmail.com>