### PR TITLE
Fixes & misc

### DIFF
--- a/es-app/CMakeLists.txt
+++ b/es-app/CMakeLists.txt
@@ -8,6 +8,7 @@ set(ES_HEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/src/PlatformId.h    
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SystemData.h    
     ${CMAKE_CURRENT_SOURCE_DIR}/src/Gamelist.h
+	${CMAKE_CURRENT_SOURCE_DIR}/src/Genres.h
     ${CMAKE_CURRENT_SOURCE_DIR}/src/FileFilterIndex.h
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SystemScreenSaver.h
     ${CMAKE_CURRENT_SOURCE_DIR}/src/CollectionSystemManager.h
@@ -106,6 +107,7 @@ set(ES_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/PlatformId.cpp    
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SystemData.cpp    
     ${CMAKE_CURRENT_SOURCE_DIR}/src/Gamelist.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/src/Genres.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/FileFilterIndex.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SystemScreenSaver.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/CollectionSystemManager.cpp

--- a/es-app/src/CollectionSystemManager.cpp
+++ b/es-app/src/CollectionSystemManager.cpp
@@ -25,6 +25,8 @@
 #include "Win32ApiSystem.h"
 #endif
 
+#include "Genres.h"
+
 std::string myCollectionsName = "collections";
 
 #define LAST_PLAYED_MAX	50
@@ -46,15 +48,45 @@ std::vector<CollectionSystemDecl> CollectionSystemManager::getSystemDecls()
 		{ AUTO_RETROACHIEVEMENTS,"retroachievements",  _("retroachievements"),  FileSorts::FILENAME_ASCENDING,    "auto-retroachievements",        false,       true }, // batocera
 
 		// Arcade meta 
-		{ AUTO_ARCADE,           "arcade",      _("arcade"),            FileSorts::FILENAME_ASCENDING,    "arcade",				     false,       true }, // batocera
-		{ AUTO_VERTICALARCADE,  "vertical",     _("vertical arcade"),   FileSorts::FILENAME_ASCENDING,    "auto-verticalarcade",     false,       true }, // batocera
-		{ AUTO_LIGHTGUN,		"lightgun",     _("lightgun games"),    FileSorts::FILENAME_ASCENDING,    "auto-lightgun",           false,       true }, // batocera
+		{ AUTO_ARCADE,           "arcade",       _("arcade"),            FileSorts::FILENAME_ASCENDING,    "arcade",				     false,       true }, // batocera
+		{ AUTO_VERTICALARCADE,   "vertical",     _("vertical arcade"),   FileSorts::FILENAME_ASCENDING,    "auto-verticalarcade",     false,       true }, // batocera
+		{ AUTO_LIGHTGUN,		 "lightgun",     _("lightgun games"),    FileSorts::FILENAME_ASCENDING,    "auto-lightgun",           false,       true }, // batocera
 
 		// Custom collection
 		{ CUSTOM_COLLECTION,    myCollectionsName,  _("collections"),   FileSorts::FILENAME_ASCENDING,    "custom-collections",      true,        true }
 	};
 
 	auto ret = std::vector<CollectionSystemDecl>(systemDecls, systemDecls + sizeof(systemDecls) / sizeof(systemDecls[0]));
+
+	// Per Genre collections
+	for (auto genre : Genres::getGameGenres())
+	{
+		if (genre->parentId != 0)
+			continue;
+
+		if (genre->id == GENRE_LIGHTGUN) // see AUTO_LIGHTGUN instead
+			continue;
+
+		std::string shortName = genre->parent == nullptr ? genre->nom_en : genre->parent->nom_en + "_" + genre->nom_en;
+		shortName = Utils::String::toLower(shortName);
+		shortName = Utils::String::replace(shortName, " ", "");
+		shortName = Utils::String::replace(shortName, "'", "");
+		shortName = Utils::String::replace(shortName, ",", "");
+		shortName = Utils::String::replace(shortName, "-", "");
+		shortName = Utils::String::replace(shortName, "game", "");
+
+		std::string longName = genre->parent == nullptr ? genre->getLocalizedName() : genre->parent->getLocalizedName() + " / " + genre->getLocalizedName();
+
+		CollectionSystemDecl decl;
+		decl.type = (CollectionSystemType)(10000 + genre->id);
+		decl.name = "_" + shortName;
+		decl.longName = longName;
+		decl.defaultSortId = FileSorts::FILENAME_ASCENDING;
+		decl.themeFolder = "auto-" + shortName;
+		decl.isCustom = false;
+		decl.displayIfEmpty = false;
+		ret.push_back(decl);
+	}
 
 	// Arcade systems
 	for (auto arcade : PlatformIds::ArcadeSystems)
@@ -69,6 +101,7 @@ std::vector<CollectionSystemDecl> CollectionSystemManager::getSystemDecls()
 		decl.displayIfEmpty = false;
 		ret.push_back(decl);
 	}
+
 
 	return ret;
 }
@@ -819,6 +852,8 @@ void CollectionSystemManager::updateCollectionFolderMetadata(SystemData* sys)
 	rootFolder->setMetadata(MetaDataId::KidGame, "false");
 	rootFolder->setMetadata(MetaDataId::Hidden, "false");
 	rootFolder->setMetadata(MetaDataId::Favorite, "false");
+
+	rootFolder->getMetadata().resetChangedFlag();
 }
 
 void CollectionSystemManager::initCustomCollectionSystems()
@@ -905,17 +940,17 @@ void CollectionSystemManager::populateAutoCollection(CollectionSystemData* sysDa
 {
 	SystemData* newSys = sysData->system;
 	CollectionSystemDecl sysDecl = sysData->decl;
-	FolderData* rootFolder = newSys->getRootFolder(); 
+	FolderData* rootFolder = newSys->getRootFolder();
 
 	bool hiddenSystemsShowGames = Settings::getInstance()->getBool("HiddenSystemsShowGames");
 	auto hiddenSystems = Utils::String::split(Settings::getInstance()->getString("HiddenSystems"), ';');
-	
-	for(auto& system : SystemData::sSystemVector)
+
+	for (auto& system : SystemData::sSystemVector)
 	{
 		// we won't iterate all collections
 		if (!system->isGameSystem() || system->isCollection())
 			continue;
-		
+
 		if (!hiddenSystemsShowGames && std::find(hiddenSystems.cbegin(), hiddenSystems.cend(), system->getName()) != hiddenSystems.cend())
 			continue;
 
@@ -927,7 +962,7 @@ void CollectionSystemManager::populateAutoCollection(CollectionSystemData* sysDa
 			hiddenExts.push_back("." + Utils::String::toLower(ext));
 
 		std::vector<FileData*> files = system->getRootFolder()->getFilesRecursive(GAME);
-		for(auto& game : files)
+		for (auto& game : files)
 		{
 			if (system->isGroupSystem() && game->getSystem() != system)
 				continue;
@@ -943,72 +978,78 @@ void CollectionSystemManager::populateAutoCollection(CollectionSystemData* sysDa
 					continue;
 			}
 
-			switch(sysDecl.type) 
+			switch (sysDecl.type)
 			{
-				case AUTO_ALL_GAMES:
-					break;
-				case AUTO_VERTICALARCADE:
-					include = game->isVerticalArcadeGame();
-					break;
-				case AUTO_LIGHTGUN:
-					include = game->isLightGunGame();
-					break;
-				case AUTO_RETROACHIEVEMENTS:
-					include = game->hasCheevos();
-					break;
-				case AUTO_LAST_PLAYED:
-					include = game->getMetadata(MetaDataId::PlayCount) > "0";
-					break;
-				case AUTO_NEVER_PLAYED:
-					include = !(game->getMetadata(MetaDataId::PlayCount) > "0");
-					break;					
-				case AUTO_FAVORITES:
-					// we may still want to add files we don't want in auto collections in "favorites"
-					include = game->getFavorite();
-					break;
-				case AUTO_ARCADE:
-					include = isArcade;
-					break;
-				case AUTO_AT2PLAYERS: // batocera
-				case AUTO_AT4PLAYERS:
+			case AUTO_ALL_GAMES:
+				break;
+			case AUTO_VERTICALARCADE:
+				include = game->isVerticalArcadeGame();
+				break;
+			case AUTO_LIGHTGUN:
+				include = game->isLightGunGame();
+				break;
+			case AUTO_RETROACHIEVEMENTS:
+				include = game->hasCheevos();
+				break;
+			case AUTO_LAST_PLAYED:
+				include = game->getMetadata(MetaDataId::PlayCount) > "0";
+				break;
+			case AUTO_NEVER_PLAYED:
+				include = !(game->getMetadata(MetaDataId::PlayCount) > "0");
+				break;
+			case AUTO_FAVORITES:
+				// we may still want to add files we don't want in auto collections in "favorites"
+				include = game->getFavorite();
+				break;
+			case AUTO_ARCADE:
+				include = isArcade;
+				break;
+			case AUTO_AT2PLAYERS: // batocera
+			case AUTO_AT4PLAYERS:
+			{
+				std::string players = game->getMetadata(MetaDataId::Players);
+				if (players.empty())
+					include = false;
+				else
+				{
+					int min = -1;
+
+					auto split = players.rfind("+");
+					if (split != std::string::npos)
+						players = Utils::String::replace(players, "+", "-999");
+
+					split = players.rfind("-");
+					if (split != std::string::npos)
 					{
-						std::string players = game->getMetadata(MetaDataId::Players);
-						if (players.empty())
-							include = false;
-						else
-						{
-							int min = -1;
-
-							auto split = players.rfind("+");
-							if (split != std::string::npos)
-								players = Utils::String::replace(players, "+", "-999");
-
-							split = players.rfind("-");
-							if (split != std::string::npos)
-							{
-								min = atoi(players.substr(0, split).c_str());
-								players = players.substr(split + 1);
-							}
-
-							int max = atoi(players.c_str());
-							int val = (sysDecl.type == AUTO_AT2PLAYERS ? 2 : 4);
-							include = min <= 0 ? (val == max) : (min <= val && val <= max);
-						}
+						min = atoi(players.substr(0, split).c_str());
+						players = players.substr(split + 1);
 					}
-					break;
-				default:
-					if (!sysDecl.isCustom && !sysDecl.displayIfEmpty)
-						include = isArcade && game->getMetadata(MetaDataId::ArcadeSystemName) == sysDecl.themeFolder;
 
-					break;				
+					int max = atoi(players.c_str());
+					int val = (sysDecl.type == AUTO_AT2PLAYERS ? 2 : 4);
+					include = min <= 0 ? (val == max) : (min <= val && val <= max);
+				}
 			}
-							    
-			if (include) 
+			break;
+
+			default:
+				if (!sysDecl.isCustom && !sysDecl.displayIfEmpty)
+				{
+					if (sysDecl.isGenreCollection())
+						include = Genres::genreExists(&game->getMetadata(), ((int)sysDecl.type) - 10000);
+					else if (sysDecl.isArcadeSubSystem())
+						include = isArcade && game->getMetadata(MetaDataId::ArcadeSystemName) == sysDecl.themeFolder;
+				}
+
+				break;
+			}
+
+			if (include)
 			{
 				CollectionFileData* newGame = new CollectionFileData(game, newSys);
 				rootFolder->addChild(newGame);
 				newSys->addToIndex(newGame);
-			}			
+			}
 		}
 	}
 
@@ -1019,6 +1060,7 @@ void CollectionSystemManager::populateAutoCollection(CollectionSystemData* sysDa
 	}
 
 	sysData->isPopulated = true;
+	updateCollectionFolderMetadata(newSys);
 }
 
 // populates a Custom Collection System
@@ -1177,6 +1219,9 @@ void CollectionSystemManager::addEnabledCollectionsToDisplayedSystems(std::map<s
 		if (!it->second.isEnabled)
 			continue;
 
+		if (it->second.system->getTheme() == nullptr)
+			it->second.system->loadTheme();
+
 		// check if populated, otherwise populate
 		if (!it->second.isPopulated)
 		{
@@ -1186,8 +1231,22 @@ void CollectionSystemManager::addEnabledCollectionsToDisplayedSystems(std::map<s
 				populateAutoCollection(&(it->second));
 		}
 
+		bool groupableCollection = it->second.decl.isCustom;
+
+		// For Genre & Arcade auto-collections without theme Folder : Check if system logo exist. If not : allow CustomCollections Bundle
+		if (!it->second.decl.isCustom && !themeFolderExists(it->first) && (it->second.decl.isGenreCollection() || it->second.decl.isArcadeSubSystem()))
+		{
+			if (it->second.system != nullptr && it->second.system->getTheme() != nullptr)
+			{
+				auto theme = it->second.system->getTheme();
+				const ThemeData::ThemeElement* logoElem = theme->getElement("system", "logo", "image");
+				if (logoElem == nullptr || !logoElem->has("path") || theme->getSystemThemeFolder() == "default")
+					groupableCollection = true;
+			}
+		}
+
 		// check if it has its own view
-		if (!it->second.decl.isCustom || themeFolderExists(it->first) || !Settings::getInstance()->getBool("UseCustomCollectionsSystem")) // batocera
+		if (!groupableCollection || themeFolderExists(it->first) || !Settings::getInstance()->getBool("UseCustomCollectionsSystem")) // batocera
 		{
 			if (it->second.decl.displayIfEmpty || it->second.system->getRootFolder()->getChildren().size() > 0)
 			{

--- a/es-app/src/CollectionSystemManager.h
+++ b/es-app/src/CollectionSystemManager.h
@@ -38,6 +38,9 @@ struct CollectionSystemDecl
 	std::string themeFolder;
 	bool isCustom;	
     bool displayIfEmpty;
+
+	bool isArcadeSubSystem() { return (int)type >= 1000 && (int)type < 10000; }
+	bool isGenreCollection() { return (int)type >= 10000 && (int)type < 20000; }
 };
 
 struct CollectionSystemData

--- a/es-app/src/FileData.cpp
+++ b/es-app/src/FileData.cpp
@@ -27,6 +27,7 @@
 #include "resources/ResourceManager.h"
 #include "RetroAchievements.h"
 #include "SaveStateRepository.h"
+#include "Genres.h"
 
 FileData::FileData(FileType type, const std::string& path, SystemData* system)
 	: mPath(path), mType(type), mSystem(system), mParent(nullptr), mDisplayName(nullptr), mMetadata(type == GAME ? GAME_METADATA : FOLDER_METADATA) // metadata is REALLY set in the constructor!
@@ -351,10 +352,7 @@ const bool FileData::isArcadeAsset()
 const bool FileData::isVerticalArcadeGame()
 {
 	if (mSystem && mSystem->hasPlatformId(PlatformIds::ARCADE))
-	{
-		const std::string stem = Utils::FileSystem::getStem(getPath());
-		return MameNames::getInstance()->isVertical(stem);
-	}
+		return MameNames::getInstance()->isVertical(Utils::FileSystem::getStem(getPath()));
 
 	return false;
 }
@@ -362,14 +360,10 @@ const bool FileData::isVerticalArcadeGame()
 const bool FileData::isLightGunGame()
 {
 	if (mSystem && mSystem->hasPlatformId(PlatformIds::ARCADE))
-	{
-		const std::string stem = Utils::FileSystem::getStem(getPath());
-		return MameNames::getInstance()->isLightgun(stem);
-	}
+		return MameNames::getInstance()->isLightgun(Utils::FileSystem::getStem(getPath()));
 
-	return false;
+	return Genres::genreExists(&getMetadata(), GENRE_LIGHTGUN);
 }
-
 
 FileData* FileData::getSourceFileData()
 {

--- a/es-app/src/FileFilterIndex.h
+++ b/es-app/src/FileFilterIndex.h
@@ -14,18 +14,19 @@ enum FilterIndexType
 {
 	NONE = 0,
 	GENRE_FILTER = 1,
-	PLAYER_FILTER = 2,
-	PUBDEV_FILTER = 3,
-	RATINGS_FILTER = 4,
-	YEAR_FILTER = 5,
-	KIDGAME_FILTER = 6,
-	HIDDEN_FILTER = 7,
-	PLAYED_FILTER = 8,
-	LANG_FILTER = 9,
-	REGION_FILTER = 10,
-	FAVORITES_FILTER = 11,
-	CHEEVOS_FILTER = 12,
-	VERTICAL_FILTER = 13
+	FAMILY_FILTER = 2,
+	PLAYER_FILTER = 3,
+	PUBDEV_FILTER = 4,
+	RATINGS_FILTER = 5,
+	YEAR_FILTER = 6,
+	KIDGAME_FILTER = 7,
+	HIDDEN_FILTER = 8,
+	PLAYED_FILTER = 9,
+	LANG_FILTER = 10,
+	REGION_FILTER = 11,
+	FAVORITES_FILTER = 12,
+	CHEEVOS_FILTER = 13,
+	VERTICAL_FILTER = 14
 };
 
 struct FilterDataDecl
@@ -60,7 +61,7 @@ public:
 	void clearAllFilters();
 	
 	virtual int showFile(FileData* game);
-	virtual bool isFiltered() { return (!mTextFilter.empty() || filterByGenre || filterByPlayers || filterByPubDev 
+	virtual bool isFiltered() { return (!mTextFilter.empty() || filterByGenre || filterByPlayers || filterByPubDev || filterByFamily
 		|| filterByRatings || filterByFavorites || filterByKidGame || filterByPlayed || filterByLang || filterByRegion || filterByYear || filterByCheevos || filterByVertical); };
 
 	bool isKeyBeingFilteredBy(std::string key, FilterIndexType type);
@@ -84,6 +85,7 @@ protected:
 	std::string getIndexableKey(FileData* game, FilterIndexType type, bool getSecondary);
 
 	void manageGenreEntryInIndex(FileData* game, bool remove = false);
+	void manageFamilyEntryInIndex(FileData* game, bool remove = false);
 	void managePlayerEntryInIndex(FileData* game, bool remove = false);
 	void managePubDevEntryInIndex(FileData* game, bool remove = false);	
 	void manageYearEntryInIndex(FileData* game, bool remove = false);
@@ -95,6 +97,7 @@ protected:
 	void clearIndex(std::map<std::string, int> indexMap);
 
 	bool filterByGenre;
+	bool filterByFamily;
 	bool filterByPlayers;
 	bool filterByPubDev;
 	bool filterByRatings;
@@ -108,6 +111,7 @@ protected:
 	bool filterByVertical;
 
 	std::map<std::string, int> genreIndexAllKeys;
+	std::map<std::string, int> familyIndexAllKeys;
 	std::map<std::string, int> playersIndexAllKeys;
 	std::map<std::string, int> pubDevIndexAllKeys;
 	std::map<std::string, int> ratingsIndexAllKeys;
@@ -122,6 +126,7 @@ protected:
 	std::map<std::string, int> verticalIndexAllKeys;
 
 	std::unordered_set<std::string> genreIndexFilteredKeys;
+	std::unordered_set<std::string> familyIndexFilteredKeys;
 	std::unordered_set<std::string> playersIndexFilteredKeys;
 	std::unordered_set<std::string> pubDevIndexFilteredKeys;
 	std::unordered_set<std::string> ratingsIndexFilteredKeys;

--- a/es-app/src/Gamelist.cpp
+++ b/es-app/src/Gamelist.cpp
@@ -8,6 +8,7 @@
 #include "Settings.h"
 #include "SystemData.h"
 #include <pugixml/src/pugixml.hpp>
+#include "Genres.h"
 
 #ifdef WIN32
 #include <Windows.h>
@@ -177,6 +178,8 @@ std::vector<FileData*> loadGamelistFile(const std::string xmlpath, SystemData* s
 
 			if (!trustGamelist && !file->getHidden() && Utils::FileSystem::isHidden(path))
 				file->getMetadata().set(MetaDataId::Hidden, "true");
+
+			Genres::convertGenreToGenreIds(&file->getMetadata());
 
 			if (checkSize != SIZE_MAX)
 				file->getMetadata().setDirty();

--- a/es-app/src/Genres.cpp
+++ b/es-app/src/Genres.cpp
@@ -1,0 +1,341 @@
+#include "Genres.h"
+
+#include "resources/ResourceManager.h"
+#include "utils/FileSystemUtil.h"
+#include "utils/StringUtil.h"
+#include "Log.h"
+#include <pugixml/src/pugixml.hpp>
+#include <string.h>
+
+#include "SystemConf.h"
+#include "FileData.h"
+
+#include <set>
+
+std::vector<GameGenre*> Genres::mGameGenres;
+std::map<int, GameGenre*> Genres::mGenres;
+std::map<std::string, int> Genres::mAllGenresNames;
+
+void Genres::init()
+{
+	std::string xmlpath = ResourceManager::getInstance()->getResourcePath(":/genres.xml");
+	if (!Utils::FileSystem::exists(xmlpath))
+		return;
+
+	LOG(LogInfo) << "Parsing XML file \"" << xmlpath << "\"...";
+
+	pugi::xml_document doc;
+	pugi::xml_parse_result result = doc.load_file(xmlpath.c_str());
+
+	if (!result)
+	{
+		LOG(LogError) << "Error parsing XML file \"" << xmlpath << "\"!\n	" << result.description();
+		return;
+	}
+
+	pugi::xml_node root = doc.child("genres");
+	if (!root)
+	{
+		LOG(LogError) << "Could not find <genres> node in \"" << xmlpath << "\"!";
+		return;
+	}
+
+	std::vector<GameGenre*> genres;
+
+	for (pugi::xml_node genre = root.child("genre"); genre; genre = genre.next_sibling("genre"))
+	{
+		GameGenre* g = new GameGenre();
+		
+		for (pugi::xml_node node = genre.first_child(); node; node = node.next_sibling())
+		{
+			std::string name = node.name();
+			std::string value = node.text().as_string();
+
+			if (name == "id")
+				g->id = Utils::String::toInteger(value);
+			else if (name == "parent")
+				g->parentId = Utils::String::toInteger(value);
+			else if (name == "nom_fr")
+				g->nom_fr = value;
+			else if (name == "nom_de")
+				g->nom_de = value;
+			else if (name == "nom_en")
+				g->nom_en = value;
+			else if (name == "nom_es")
+				g->nom_es = value;
+			else if (name == "nom_pt")
+				g->nom_pt = value;
+			else if (name == "altname")
+				g->altNames.push_back(value);
+		}
+
+		if (g->id == 0)
+		{
+			delete g;
+			continue;
+		}
+
+		genres.push_back(g);
+	}
+
+	for (auto genre : genres)
+	{
+		if (genre->parentId == 0)
+		{
+			for (auto child : genres)
+				if (child->parentId == genre->id)
+					genre->children.push_back(child);
+		}
+		else
+		{
+			for (auto parent : genres)
+			{
+				if (parent->id == genre->parentId)
+				{
+					genre->parent = parent;
+					break;
+				}
+			}
+		}
+
+		mGenres[genre->id] = genre;
+		mGameGenres.push_back(genre);
+	}
+
+	// Pass 1 : crate genre mapping indexes
+	for (auto genre : genres)
+	{
+		if (genre->parent != nullptr)
+		{
+			if (!genre->nom_en.empty())
+				mAllGenresNames[Utils::String::toUpper(genre->parent->nom_en) + " / " + Utils::String::toUpper(genre->nom_en)] = genre->id;
+
+			if (!genre->nom_fr.empty())
+				mAllGenresNames[Utils::String::toUpper(genre->parent->nom_fr) + " / " + Utils::String::toUpper(genre->nom_fr)] = genre->id;
+
+			if (!genre->nom_de.empty())
+				mAllGenresNames[Utils::String::toUpper(genre->parent->nom_de) + " / " + Utils::String::toUpper(genre->nom_de)] = genre->id;
+
+			if (!genre->nom_es.empty())
+				mAllGenresNames[Utils::String::toUpper(genre->parent->nom_es) + " / " + Utils::String::toUpper(genre->nom_es)] = genre->id;
+
+			if (!genre->nom_pt.empty())
+				mAllGenresNames[Utils::String::toUpper(genre->parent->nom_pt) + " / " + Utils::String::toUpper(genre->nom_pt)] = genre->id;
+		
+
+			for (auto altName : genre->altNames)
+				mAllGenresNames[Utils::String::toUpper(altName)] = genre->id;
+		}
+		else
+		{
+			if (!genre->nom_fr.empty())
+				mAllGenresNames[Utils::String::toUpper(genre->nom_fr)] = genre->id;
+
+			if (!genre->nom_de.empty())
+				mAllGenresNames[Utils::String::toUpper(genre->nom_de)] = genre->id;
+
+			if (!genre->nom_en.empty())
+				mAllGenresNames[Utils::String::toUpper(genre->nom_en)] = genre->id;
+
+			if (!genre->nom_es.empty())
+				mAllGenresNames[Utils::String::toUpper(genre->nom_es)] = genre->id;
+
+			if (!genre->nom_pt.empty())
+				mAllGenresNames[Utils::String::toUpper(genre->nom_pt)] = genre->id;
+
+			for (auto altName : genre->altNames)
+				mAllGenresNames[Utils::String::toUpper(altName)] = genre->id;
+		}
+	}
+
+	// Pass-2 : add subgenre without parent label, but never overwrite
+	for (auto genre : genres)
+	{
+		if (genre->parent != nullptr)
+		{
+			if (!genre->nom_fr.empty() && mAllGenresNames.find(Utils::String::toUpper(genre->nom_fr)) == mAllGenresNames.cend())
+				mAllGenresNames[Utils::String::toUpper(genre->nom_fr)] = genre->id;
+
+			if (!genre->nom_de.empty() && mAllGenresNames.find(Utils::String::toUpper(genre->nom_de)) == mAllGenresNames.cend())
+				mAllGenresNames[Utils::String::toUpper(genre->nom_de)] = genre->id;
+
+			if (!genre->nom_en.empty() && mAllGenresNames.find(Utils::String::toUpper(genre->nom_en)) == mAllGenresNames.cend())
+				mAllGenresNames[Utils::String::toUpper(genre->nom_en)] = genre->id;
+
+			if (!genre->nom_es.empty() && mAllGenresNames.find(Utils::String::toUpper(genre->nom_es)) == mAllGenresNames.cend())
+				mAllGenresNames[Utils::String::toUpper(genre->nom_es)] = genre->id;
+
+			if (!genre->nom_pt.empty() && mAllGenresNames.find(Utils::String::toUpper(genre->nom_pt)) == mAllGenresNames.cend())
+				mAllGenresNames[Utils::String::toUpper(genre->nom_pt)] = genre->id;
+		}
+	}
+}
+
+bool Genres::genreExists(int id)
+{
+	return id > 0 && mGenres.find(id) != mGenres.cend();
+}
+
+std::string& GameGenre::getLocalizedName()
+{
+	static int locale = -1;
+
+	if (locale < 0)
+	{
+		std::string lang = SystemConf::getInstance()->get("system.language");
+
+		auto shortNameDivider = lang.find("_");
+		if (shortNameDivider != std::string::npos)
+			lang = Utils::String::toLower(lang.substr(0, shortNameDivider));
+
+		if (lang == "fr")
+			locale = 1;
+		else if (lang == "pt" || lang == "br")
+			locale = 2;
+		else if (lang == "de")
+			locale = 3;
+		else if (lang == "es")
+			locale = 4;
+		else
+			locale = 0;
+	}
+
+	if (locale == 1 && !nom_fr.empty())
+		return nom_fr;
+
+	if (locale == 2 && !nom_pt.empty())
+		return nom_pt;
+
+	if (locale == 3 && !nom_de.empty())
+		return nom_de;
+
+	if (locale == 4 && nom_es.empty())
+		return nom_es;
+
+	return nom_en;
+}
+
+std::vector<std::string> Genres::getGenreFiltersNames(MetaDataList* game)
+{
+	std::vector<std::string> ret;
+
+	auto ids = Utils::String::split(game->get(MetaDataId::GenreIds), ',', true);
+	for (auto id : ids)
+	{
+		auto g = mGenres.find(Utils::String::toInteger(id));
+		if (g != mGenres.cend())
+		{
+			if (g->second->parent != nullptr)
+			{
+				ret.push_back(std::to_string(g->second->parent->id));
+				ret.push_back(std::to_string(g->second->id));
+			}
+			else
+				ret.push_back(std::to_string(g->second->id));
+		}
+	}
+
+	return ret;
+}
+
+std::string Genres::genreStringFromIds(const std::vector<std::string>& ids, bool localized)
+{
+	std::vector<std::string> ret;
+
+	for (auto id : ids)
+	{
+		auto g = mGenres.find(Utils::String::toInteger(id));
+		if (g != mGenres.cend())
+		{
+			if (g->second->parent != nullptr)
+			{
+				if (localized)
+					ret.push_back(g->second->parent->getLocalizedName() + " / " + g->second->getLocalizedName());
+				else 
+					ret.push_back(g->second->parent->nom_en + " / " + g->second->nom_en);
+
+				continue;
+			}
+
+			ret.push_back(localized ? g->second->getLocalizedName() : g->second->nom_en);
+		}
+	}
+
+	return Utils::String::join(ret, ", ");
+}
+
+
+GameGenre* Genres::getGameGenre(const std::string& id)
+{
+	auto genre = mGenres.find(Utils::String::toInteger(id));
+	if (genre != mGenres.cend())
+		return genre->second;
+
+	return nullptr;
+}
+
+GameGenre* Genres::fromGenreName(const std::string& name)
+{
+	auto g = mAllGenresNames.find(Utils::String::toUpper(name));
+	if (g != mAllGenresNames.cend())
+		return mGenres[g->second];
+	
+	if (name.find("/") >= 0)
+	{
+		for (auto subgenre : Utils::String::splitAny(Utils::String::toUpper(name), "/", true))
+		{
+			auto sg = mAllGenresNames.find(Utils::String::trim(subgenre));
+			if (sg != mAllGenresNames.cend())
+				return mGenres[g->second];
+		}
+	}
+
+	return nullptr;
+}
+
+bool Genres::genreExists(MetaDataList* file, int id)
+{
+	auto idToFind = std::to_string(id);
+	auto ids = Utils::String::split(file->get(MetaDataId::GenreIds), ',', true);
+	for (auto id : ids)
+		if (id == idToFind)
+			return true;
+
+	return false;
+}
+
+void Genres::convertGenreToGenreIds(MetaDataList* file)
+{
+	auto genre = Utils::String::toUpper(file->get(MetaDataId::Genre));
+	if (genre.empty())
+		return;
+
+	std::set<int> ids;
+
+	auto g = mAllGenresNames.find(genre);
+	if (g != mAllGenresNames.cend())
+		ids.insert(g->second);
+	else if (genre.find(",") >= 0 || genre.find("/") >= 0)
+	{
+		for (auto subgenre : Utils::String::splitAny(genre, ",/", true))
+		{
+			auto sg = mAllGenresNames.find(Utils::String::trim(subgenre));
+			if (sg != mAllGenresNames.cend())
+				ids.insert(sg->second);
+		}
+	}
+
+	if (ids.size() > 0)
+	{
+		std::vector<std::string> list;
+		for (auto id : ids)
+			list.push_back(std::to_string(id));
+		
+		file->set(MetaDataId::GenreIds, Utils::String::join(list, ","));
+	}
+	else
+	{
+		LOG(LogDebug) << "UNKNOWN GENRE : " << genre;
+		//file->set(MetaDataId::GenreIds, "");
+	}
+}

--- a/es-app/src/Genres.h
+++ b/es-app/src/Genres.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#ifndef ES_CORE_GENRES_H
+#define ES_CORE_GENRES_H
+
+#include <string>
+#include <vector>
+#include <map>
+
+#define GENRE_LIGHTGUN 32
+#define GENRE_ADULT 413
+
+class MetaDataList;
+
+struct GameGenre
+{
+	GameGenre()
+	{
+		id = 0;
+		parentId = 0;
+		parent = nullptr;
+	}
+
+	int id;
+	int parentId;
+
+	std::string nom_en;
+	std::string nom_fr;
+	std::string nom_de;
+	std::string nom_es;
+	std::string nom_pt;
+	std::vector<std::string> altNames;
+
+	std::string& getLocalizedName();
+
+	GameGenre* parent;
+	std::vector<GameGenre*> children;
+};
+
+class Genres
+{
+public:
+	static void  init();
+	static void convertGenreToGenreIds(MetaDataList* metaData);
+
+	static bool genreExists(int id);
+	static bool genreExists(MetaDataList* file, int id);
+
+	static const std::vector<GameGenre*>& getGameGenres() { return mGameGenres; }
+
+	static GameGenre* fromGenreName(const std::string& name);
+
+	static GameGenre* getGameGenre(const std::string& id);
+
+	static std::string					genreStringFromIds(const std::vector<std::string>& ids, bool localized = true);
+
+	static std::vector<std::string>		getGenreFiltersNames(MetaDataList* game);
+
+private:
+	static std::vector<GameGenre*> mGameGenres;
+	static std::map<int, GameGenre*> mGenres;
+	static std::map<std::string, int> mAllGenresNames;
+};
+
+#endif // ES_CORE_GENRES_H

--- a/es-app/src/MetaData.cpp
+++ b/es-app/src/MetaData.cpp
@@ -47,21 +47,27 @@ void MetaDataList::initMetadata()
 		{ Map,			    "map",	       MD_PATH,                "",                 false,      _("Map"),                  _("enter path to map"),		 true },
 
 		// Non scrappable /editable medias
-		{ Cartridge,        "cartridge",   MD_PATH,                "",                 true,      _("Cartridge"),            _("enter path to cartridge"),  true },
-		{ BoxArt,			"boxart",	   MD_PATH,                "",                 true,      _("Alt BoxArt"),		      _("enter path to alt boxart"), true },
+		{ Cartridge,        "cartridge",   MD_PATH,                "",                 true,       _("Cartridge"),            _("enter path to cartridge"),  true },
+		{ BoxArt,			"boxart",	   MD_PATH,                "",                 true,       _("Alt BoxArt"),		      _("enter path to alt boxart"), true },
 		{ BoxBack,			"boxback",	   MD_PATH,                "",                 false,      _("Box backside"),		  _("enter path to box background"), true },
-		{ Wheel,			"wheel",	   MD_PATH,                "",                 true,      _("Wheel"),		          _("enter path to wheel"),      true },
-		{ Mix,			    "mix",	       MD_PATH,                "",                 true,      _("Mix"),                  _("enter path to mix"),		 true },
+		{ Wheel,			"wheel",	   MD_PATH,                "",                 true,       _("Wheel"),		          _("enter path to wheel"),      true },
+		{ Mix,			    "mix",	       MD_PATH,                "",                 true,       _("Mix"),                  _("enter path to mix"),		 true },
 		
 		{ Rating,           "rating",      MD_RATING,              "0.000000",         false,      _("Rating"),               _("enter rating"),			false },
 		{ ReleaseDate,      "releasedate", MD_DATE,                "not-a-date-time",  false,      _("Release date"),         _("enter release date"),		false },
 		{ Developer,        "developer",   MD_STRING,              "",                 false,      _("Developer"),            _("enter game developer"),	false },
 		{ Publisher,        "publisher",   MD_STRING,              "",                 false,      _("Publisher"),            _("enter game publisher"),	false },
-		{ Genre,            "genre",       MD_STRING,              "",                 false,      _("Genre"),                _("enter game genre"),		false },
+
+
+		{ Genre,            "genre",       MD_STRING,              "",                 false,      _("Genre"),                _("enter game genre"),		false }, 
+		{ Family,           "family",      MD_STRING,              "",                 false,      _("Game family"),		  _("enter game family"),		false },
+
+		// GenreIds is not serialized
+		{ GenreIds,         "genres",      MD_STRING,              "",                 false,      _("Genres"),				  _("enter game genres"),		false },
 
 		{ ArcadeSystemName, "arcadesystemname",  MD_STRING,        "",                 false,      _("Arcade system"),        _("enter game arcade system"), false },
 
-		{ Players,          "players",     MD_INT,                 "",                false,      _("Players"),              _("enter number of players"),	false },
+		{ Players,          "players",     MD_INT,                 "",                false,       _("Players"),              _("enter number of players"),	false },
 		{ Favorite,         "favorite",    MD_BOOL,                "false",            false,      _("Favorite"),             _("enter favorite"),			false },
 		{ Hidden,           "hidden",      MD_BOOL,                "false",            false,      _("Hidden"),               _("enter hidden"),			true },
 		{ KidGame,          "kidgame",     MD_BOOL,                "false",            false,      _("Kidgame"),              _("enter kidgame"),			false },
@@ -73,8 +79,8 @@ void MetaDataList::initMetadata()
 
 		{ GameTime,         "gametime",    MD_INT,                 "0",                true,       _("Game time"),            _("how long the game has been played in total (seconds)"), false },
 
-		{ Language,         "lang",        MD_STRING,              "",                 false,       _("Languages"),            _("Languages"),				false },
-		{ Region,           "region",      MD_STRING,              "",                 false,       _("Region"),               _("Region"),					false },
+		{ Language,         "lang",        MD_STRING,              "",                 false,      _("Languages"),            _("Languages"),				false },
+		{ Region,           "region",      MD_STRING,              "",                 false,      _("Region"),               _("Region"),					false },
 
 		{ CheevosHash,      "cheevosHash", MD_STRING,              "",                 true,       _("Cheevos Hash"),          _("Cheevos checksum"),	    false },
 		{ CheevosId,        "cheevosId",   MD_INT,                 "",				   true,       _("Cheevos Game ID"),       _("Cheevos Game ID"),		false },
@@ -164,6 +170,9 @@ MetaDataList MetaDataList::createFromXML(MetaDataListType type, pugi::xml_node& 
 			continue;
 		}
 
+		if (mdd.id == MetaDataId::GenreIds)
+			continue;
+
 		if (value == mdd.defaultValue)
 			continue;
 
@@ -239,6 +248,10 @@ void MetaDataList::appendToXML(pugi::xml_node& parent, bool ignoreDefaults, cons
 			parent.append_child("name").text().set(mName.c_str());
 			continue;
 		}
+
+		// Don't save GenreIds
+		if (mddIter->id == MetaDataId::GenreIds)
+			continue;
 
 		auto mapIter = mMap.find(mddIter->id);
 		if(mapIter != mMap.cend())

--- a/es-app/src/MetaData.h
+++ b/es-app/src/MetaData.h
@@ -69,7 +69,9 @@ enum MetaDataId
 	CheevosId = 35,
 	ScraperId = 36,
 	BoxBack = 37,
-	Magazine = 38
+	Magazine = 38,
+	GenreIds = 39,
+	Family = 40
 };
 
 namespace MetaDataImportType

--- a/es-app/src/SystemData.cpp
+++ b/es-app/src/SystemData.cpp
@@ -16,6 +16,7 @@
 #include "Window.h"
 #include "LocaleES.h"
 #include "utils/StringUtil.h"
+#include "utils/Randomizer.h"
 #include "views/ViewController.h"
 #include "ThreadedHasher.h"
 #include <unordered_set>
@@ -80,7 +81,7 @@ SystemData::SystemData(const SystemMetadata& meta, SystemEnvironmentData* envDat
 	else
 	{
 		// virtual systems are updated afterwards, we're just creating the data structure
-		mRootFolder = new FolderData("" + mMetadata.name, this);
+		mRootFolder = new FolderData("" + mMetadata.fullName, this);
 	}
 
 	mRootFolder->getMetadata().resetChangedFlag();
@@ -1587,13 +1588,12 @@ SystemData* SystemData::getRandomSystem()
 	//  this is a bit brute force. It might be more efficient to just to a while (!gameSystem) do random again...
 	unsigned int total = 0;
 	for(auto it = sSystemVector.cbegin(); it != sSystemVector.cend(); it++)
-	{
 		if ((*it)->isGameSystem())
-			total ++;
-	}
+			total++;
 
 	// get random number in range
-	int target = (int)Math::round((std::rand() / (float)RAND_MAX) * (total - 1));
+	int target = Randomizer::random(total);
+	//int target = (int)Math::round((std::rand() / (float)RAND_MAX) * (total - 1));
 	for (auto it = sSystemVector.cbegin(); it != sSystemVector.cend(); it++)
 	{
 		if ((*it)->isGameSystem())
@@ -1617,11 +1617,11 @@ FileData* SystemData::getRandomGame()
 {
 	std::vector<FileData*> list = mRootFolder->getFilesRecursive(GAME, true);
 	unsigned int total = (int)list.size();
-	int target = 0;
-	// get random number in range
 	if (total == 0)
 		return NULL;
-	target = (int)Math::round((std::rand() / (float)RAND_MAX) * (total - 1));
+
+	int target = Randomizer::random(total);
+	//target = (int)Math::round((std::rand() / (float)RAND_MAX) * (total - 1));
 	return list.at(target);
 }
 

--- a/es-app/src/SystemScreenSaver.cpp
+++ b/es-app/src/SystemScreenSaver.cpp
@@ -21,6 +21,7 @@
 #include "math/Vector2i.h"
 #include "SystemConf.h"
 #include "ImageIO.h"
+#include "utils/Randomizer.h"
 
 #define FADE_TIME 			500
 
@@ -45,7 +46,7 @@ SystemScreenSaver::SystemScreenSaver(Window* window) :
 	std::string path = getTitleFolder();
 	if(!Utils::FileSystem::exists(path))
 		Utils::FileSystem::createDirectory(path);
-	srand((unsigned int)time(NULL));
+	
 	mVideoChangeTime = 30000;
 }
 
@@ -372,9 +373,8 @@ std::string SystemScreenSaver::pickRandomVideo()
 	mCurrentGame = NULL;
 	if (mVideoCount == 0)
 		return "";
-	
-	rand();
-	int video = (int)(((float)rand() / float(RAND_MAX)) * (float)mVideoCount);
+		
+	int video = Randomizer::random(mVideoCount); // (int)(((float)rand() / float(RAND_MAX)) * (float)mVideoCount);
 	return pickGameListNode(video, "video");
 }
 
@@ -385,8 +385,8 @@ std::string SystemScreenSaver::pickRandomGameListImage()
 	if (mImageCount == 0)
 		return "";
 	
-	rand();
-	int image = (int)(((float)rand() / float(RAND_MAX)) * (float)mImageCount);
+	//rand();
+	int image = Randomizer::random(mImageCount); // (int)(((float)rand() / float(RAND_MAX)) * (float)mImageCount);
 	return pickGameListNode(image, "image");
 }
 
@@ -419,7 +419,7 @@ std::string SystemScreenSaver::pickRandomCustomImage(bool video)
 		if (fileCount > 0)
 		{
 			// get a random index in the range 0 to fileCount (exclusive)
-			int randomIndex = rand() % fileCount;
+			int randomIndex = Randomizer::random(fileCount); // rand() % fileCount;
 			path = matchingFiles[randomIndex];
 		}
 		else
@@ -588,7 +588,7 @@ void GameScreenSaverBase::setGame(FileData* game)
 	if (decos != "none")
 	{
 		auto sets = GuiMenu::getDecorationsSets(game->getSystem());
-		int setId = (int)(((float)rand() / float(RAND_MAX)) * (float)sets.size());
+		int setId = Randomizer::random(sets.size()); // (int)(((float)rand() / float(RAND_MAX)) * (float)sets.size());
 
 		if (decos == "systems")
 		{

--- a/es-app/src/components/CarouselComponent.h
+++ b/es-app/src/components/CarouselComponent.h
@@ -41,6 +41,7 @@ public:
 	void	applyTheme(const std::shared_ptr<ThemeData>& theme, const std::string& view, const std::string& element, unsigned int properties);
 
 	int getLastCursor() { return mLastCursor; }
+	void resetLastCursor() { mLastCursor = -1; }
 
 protected:
 	void onCursorChanged(const CursorState& state) override;

--- a/es-app/src/guis/GuiCollectionSystemsOptions.cpp
+++ b/es-app/src/guis/GuiCollectionSystemsOptions.cpp
@@ -433,6 +433,7 @@ void GuiCollectionSystemsOptions::addSystemsToMenu()
 	autoOptionList->addGroup(_("AUTOMATIC COLLECTIONS"));
 
 	bool hasGroup = false;
+	bool hasGenreGroup = false;
 
 	auto arcadeGames = CollectionSystemManager::get()->getArcadeCollection()->getRootFolder()->getFilesRecursive(GAME);
 
@@ -445,7 +446,17 @@ void GuiCollectionSystemsOptions::addSystemsToMenu()
 
         if (it->second.decl.displayIfEmpty)
             autoOptionList->add(it->second.decl.longName, it->second.decl.name, it->second.isEnabled);
-        else
+		else if (it->second.decl.isGenreCollection()) // Genre collections
+		{
+			if (!hasGenreGroup)
+			{
+				autoOptionList->addGroup(_("PER GENRE"));
+				hasGenreGroup = true;
+			}
+
+			autoOptionList->add(it->second.decl.longName, it->second.decl.name, it->second.isEnabled);
+		}
+        else if (it->second.decl.isArcadeSubSystem()) // Arcade collections
         {
 			bool hasGames = false;
 

--- a/es-app/src/guis/GuiGameOptions.cpp
+++ b/es-app/src/guis/GuiGameOptions.cpp
@@ -53,7 +53,7 @@ GuiGameOptions::GuiGameOptions(Window* window, FileData* game) : GuiComponent(wi
 	bool hasMap = Utils::FileSystem::exists(game->getMetadata(MetaDataId::Map));
 	bool hasCheevos = game->hasCheevos();
 
-	if (hasManual || hasMap || hasCheevos)
+	if (hasManual || hasMap || hasCheevos || hasMagazine)
 	{
 		mMenu.addGroup(_("GAME MEDIAS"));
 
@@ -207,19 +207,21 @@ GuiGameOptions::GuiGameOptions(Window* window, FileData* game) : GuiComponent(wi
 			});
 		}
 
-		mMenu.addEntry(isImageViewer ? _("DELETE ITEM") : _("DELETE GAME"), false, [this, game]
-		{			
-			mWindow->pushGui(new GuiMsgBox(mWindow, _("THIS WILL DELETE THE ACTUAL GAME FILE(S)!\nARE YOU SURE?"), _("YES"),
-				[this, game]
+		if (UIModeController::getInstance()->isUIModeFull())
+		{
+			mMenu.addEntry(isImageViewer ? _("DELETE ITEM") : _("DELETE GAME"), false, [this, game]
+			{
+				mWindow->pushGui(new GuiMsgBox(mWindow, _("THIS WILL DELETE THE ACTUAL GAME FILE(S)!\nARE YOU SURE?"), _("YES"),
+					[this, game]
 				{
 					deleteGame(game);
 					close();
 				},
-				_("NO"), nullptr));
+					_("NO"), nullptr));
 
-			
-		});
 
+			});
+		}
 	}
 
 	bool isCustomCollection = (mSystem->isCollection() && game->getType() == FOLDER && CollectionSystemManager::get()->isCustomCollection(mSystem->getName()));
@@ -309,7 +311,7 @@ GuiGameOptions::GuiGameOptions(Window* window, FileData* game) : GuiComponent(wi
 		fromPlaceholder = true; 
 	else if (game->getType() == FOLDER && ((FolderData*)game)->isVirtualStorage())
 		fromPlaceholder = true;
-	else if (game->getType() == FOLDER && mSystem->getName() == CollectionSystemManager::get()->getCustomCollectionsBundle()->getName())
+	else if (game->getType() == FOLDER && mSystem->isCollection()) // >getName() == CollectionSystemManager::get()->getCustomCollectionsBundle()->getName())
 		fromPlaceholder = true;
 
 	if (!fromPlaceholder && !isCustomCollection && UIModeController::getInstance()->isUIModeFull())

--- a/es-app/src/guis/GuiGamelistFilter.cpp
+++ b/es-app/src/guis/GuiGamelistFilter.cpp
@@ -5,6 +5,7 @@
 #include "SystemData.h"
 #include "guis/GuiTextEditPopup.h"
 #include "guis/GuiTextEditPopupKeyboard.h"
+#include "Genres.h"
 
 GuiGamelistFilter::GuiGamelistFilter(Window* window, SystemData* system) : GuiComponent(window), mMenu(window, _("FILTER GAMELIST BY")), mSystem(system)
 {
@@ -117,31 +118,57 @@ void GuiGamelistFilter::addFiltersToMenu()
 		ComponentListRow row;
 
 		optionList = std::make_shared< OptionListComponent<std::string> >(mWindow, menuLabel, true);
-		for (auto key : *allKeys)
-		{
-			if (key.first == "UNKNOWN")
-				optionList->add(_("Unknown"), key.first, mFilterIndex->isKeyBeingFilteredBy(key.first, type));
-			else if (key.first == "TRUE")
-				optionList->add(_("YES"), key.first, mFilterIndex->isKeyBeingFilteredBy(key.first, type));
-			else if (key.first == "FALSE")
-				optionList->add(_("NO"), key.first, mFilterIndex->isKeyBeingFilteredBy(key.first, type));
-			else
-			{
-				std::string label = key.first;
 
-				// Special display for GENRE
-				if (it->type == GENRE_FILTER)
+		if (it->type == GENRE_FILTER)
+		{
+			std::map<std::string, std::string> keyValues;
+
+			for (auto key : *allKeys)
+				keyValues[Genres::genreStringFromIds({ key.first })] = key.first;
+		
+			for (auto key : keyValues)
+			{
+				auto label = key.first;
+
+				auto split = label.find("/");
+				if (split != std::string::npos)
 				{
-					auto split = key.first.find("/");
-					if (split != std::string::npos)
-					{
-						auto parent = Utils::String::trim(label.substr(0, split));
-						if (allKeys->find(parent) != allKeys->cend())
-							label = "      " + Utils::String::trim(label.substr(split + 1));
-					}
+					auto parent = Utils::String::trim(label.substr(0, split));
+					if (keyValues.find(parent) != keyValues.cend())
+						label = "      " + Utils::String::trim(label.substr(split + 1));
 				}
 
-				optionList->add(_(label.c_str()), key.first, mFilterIndex->isKeyBeingFilteredBy(key.first, type), false);
+				optionList->add(label, key.second, mFilterIndex->isKeyBeingFilteredBy(key.second, type));
+			}
+		}
+		else
+		{
+			for (auto key : *allKeys)
+			{
+				if (key.first == "UNKNOWN")
+					optionList->add(_("Unknown"), key.first, mFilterIndex->isKeyBeingFilteredBy(key.first, type));
+				else if (key.first == "TRUE")
+					optionList->add(_("YES"), key.first, mFilterIndex->isKeyBeingFilteredBy(key.first, type));
+				else if (key.first == "FALSE")
+					optionList->add(_("NO"), key.first, mFilterIndex->isKeyBeingFilteredBy(key.first, type));
+				else
+				{
+					std::string label = key.first;
+
+					// Special display for GENRE
+					if (it->type == GENRE_FILTER)
+					{
+						auto split = key.first.find("/");
+						if (split != std::string::npos)
+						{
+							auto parent = Utils::String::trim(label.substr(0, split));
+							if (allKeys->find(parent) != allKeys->cend())
+								label = "      " + Utils::String::trim(label.substr(split + 1));
+						}
+					}
+
+					optionList->add(_(label.c_str()), key.first, mFilterIndex->isKeyBeingFilteredBy(key.first, type), false);
+				}
 			}
 		}
 

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -730,7 +730,7 @@ void GuiMenu::openDeveloperSettings()
 
 	auto webAccess = std::make_shared<SwitchComponent>(mWindow);
 	webAccess->setState(Settings::getInstance()->getBool("PublicWebAccess"));
-	s->addWithDescription(_("ENABLE PUBLIC WEB ACCESS"), _("Allow public web access API using ") + " http://" + hostName + ":1234", webAccess);
+	s->addWithDescription(_("ENABLE PUBLIC WEB ACCESS"), Utils::String::format(_("Allow public web access API using %s").c_str(), std::string("http://" + hostName + ":1234").c_str()), webAccess);
 	s->addSaveFunc([webAccess, window]
 	{ 
 		if (Settings::getInstance()->setBool("PublicWebAccess", webAccess->getState()))

--- a/es-app/src/main.cpp
+++ b/es-app/src/main.cpp
@@ -11,6 +11,7 @@
 #include "InputManager.h"
 #include "Log.h"
 #include "MameNames.h"
+#include "Genres.h"
 #include "platform.h"
 #include "PowerSaver.h"
 #include "Settings.h"
@@ -479,6 +480,7 @@ int main(int argc, char* argv[])
 	setLocale(argv[0]);	
 
 	// metadata init
+	Genres::init();
 	MetaDataList::initMetadata();
 
 	Window window;
@@ -507,6 +509,7 @@ int main(int argc, char* argv[])
 	}
 
 	MameNames::init();
+
 
 	const char* errorMsg = NULL;
 	if(!loadSystemConfigFile(splashScreen && splashScreenProgress ? &window : nullptr, &errorMsg))

--- a/es-app/src/scrapers/ArcadeDBJSONScraper.cpp
+++ b/es-app/src/scrapers/ArcadeDBJSONScraper.cpp
@@ -10,6 +10,7 @@
 #include "SystemData.h"
 #include "utils/TimeUtil.h"
 #include "utils/StringUtil.h"
+#include "Genres.h"
 
 // Current version is release 4 let's test for this value in JSON result
 #ifndef ARCADE_DB_RELEASE_VERSION
@@ -143,7 +144,10 @@ void processGame(const Value& game, std::vector<ScraperSearchResult>& results)
     }
 
 	if (game.HasMember("genre") && game["genre"].IsString())
-	    result.mdl.set(MetaDataId::Genre, getStringOrThrow(game, "genre"));
+	{
+		result.mdl.set(MetaDataId::Genre, getStringOrThrow(game, "genre"));
+		Genres::convertGenreToGenreIds(&result.mdl);
+	}
 
 	if (game.HasMember("players") && game["players"].IsInt())
 		result.mdl.set(MetaDataId::Players, std::to_string(game["players"].GetInt()));
@@ -203,7 +207,7 @@ bool ArcadeDBJSONRequest::process(HttpReq* request, std::vector<ScraperSearchRes
 		return true;
 	}
 
-    if (!doc.HasMember("release") || !doc["release"].IsInt() || doc["release"] != ARCADE_DB_RELEASE_VERSION)
+    if (!doc.HasMember("release") || !doc["release"].IsInt() || doc["release"].GetInt() < ARCADE_DB_RELEASE_VERSION)
     {
         std::string warn = "ArcadeDBJSONRequest - Response had wrong format.\n";
         LOG(LogWarning) << warn;

--- a/es-app/src/scrapers/GamesDBJSONScraper.cpp
+++ b/es-app/src/scrapers/GamesDBJSONScraper.cpp
@@ -14,7 +14,7 @@
 #include "utils/TimeUtil.h"
 #include <rapidjson/document.h>
 #include <rapidjson/error/en.h>
-
+#include "Genres.h"
 
 using namespace PlatformIds;
 using namespace rapidjson;
@@ -415,7 +415,10 @@ namespace
 			result.mdl.set(MetaDataId::Publisher, getPublisherString(game["publishers"]));
 
 		if (game.HasMember("genres") && game["genres"].IsArray())
+		{
 			result.mdl.set(MetaDataId::Genre, getGenreString(game["genres"]));
+			Genres::convertGenreToGenreIds(&result.mdl);
+		}
 
 		if (game.HasMember("players") && game["players"].IsInt())
 			result.mdl.set(MetaDataId::Players, std::to_string(game["players"].GetInt()));

--- a/es-app/src/scrapers/Scraper.cpp
+++ b/es-app/src/scrapers/Scraper.cpp
@@ -263,12 +263,14 @@ MDResolveHandle::MDResolveHandle(const ScraperSearchResult& result, const Scrape
 				[this, url](ImageDownloadHandle* result)
 				{
 					auto finalFile = result->getImageFileName();
-					mResult.mdl.set(url.first, finalFile);
+
+					if (Utils::FileSystem::getFileSize(finalFile) > 0)
+						mResult.mdl.set(url.first, finalFile);
 
 					if (mResult.urls.find(url.first) != mResult.urls.cend())
 						mResult.urls[url.first].url = "";
 				},
-				suffix, result.mdl.getName())); // "thumbnail"
+				suffix, result.mdl.getName()));
 		}
 	}
 

--- a/es-app/src/scrapers/ScreenScraper.cpp
+++ b/es-app/src/scrapers/ScreenScraper.cpp
@@ -8,11 +8,14 @@
 #include "Settings.h"
 #include "SystemData.h"
 #include <pugixml/src/pugixml.hpp>
-#include <cstring>
 #include "SystemConf.h"
-#include <thread>
 #include "LangParser.h"
 #include "ApiSystem.h"
+#include "Genres.h"
+
+#include <algorithm>
+#include <cstring>
+#include <thread>
 
 using namespace PlatformIds;
 
@@ -485,11 +488,34 @@ void ScreenScraperRequest::processGame(const pugi::xml_document& xmldoc, std::ve
 		// Genre fallback language: EN. ( Xpath: Data/jeu[0]/genres/genre[*] )		
 		if (game.child("genres"))
 		{
+			bool adultGame = false;
+
+			std::set<std::string> genreIds;
+
 			std::string genre;
 			std::string subgenre;
 
 			for (pugi::xml_node node : game.child("genres").children("genre"))
 			{
+				if (strcmp(node.attribute("langue").value(), "en") == 0)
+				{
+					std::string name = node.text().get();
+					auto typeGenre = Genres::fromGenreName(name);
+					if (typeGenre != nullptr)
+					{
+						adultGame |= (typeGenre->id == GENRE_ADULT);
+
+						if (typeGenre->parentId != 0)
+							genreIds.erase(std::to_string(typeGenre->parentId));
+
+						bool childexists = std::find_if(typeGenre->children.cbegin(), typeGenre->children.cend(),
+							[genreIds](GameGenre* ch) { return genreIds.find(std::to_string(ch->id)) != genreIds.cend(); }) != typeGenre->children.cend();
+
+						if (!childexists)
+							genreIds.insert(std::to_string(typeGenre->id));
+					}
+				}
+
 				if (strcmp(node.attribute("principale").value(), "1") == 0 && strcmp(node.attribute("langue").value(), language.c_str()) == 0)
 					genre = node.text().get();
 			
@@ -521,6 +547,58 @@ void ScreenScraperRequest::processGame(const pugi::xml_document& xmldoc, std::ve
 
 			if (!genre.empty())
 				result.mdl.set(MetaDataId::Genre, genre);
+
+			if (genreIds.size() > 0)
+			{
+				std::vector<std::string> list;
+				for (auto id : genreIds)
+					list.push_back(id);
+
+				result.mdl.set(MetaDataId::GenreIds, Utils::String::join(list, ","));
+			}
+			else
+				Genres::convertGenreToGenreIds(&result.mdl);
+
+			if (adultGame)
+				result.mdl.set(MetaDataId::KidGame, "false");
+		}
+
+		if (game.child("familles"))
+		{
+			std::string family;
+			for (pugi::xml_node node : game.child("familles").children("famille"))
+			{
+				if (strcmp(node.attribute("principale").value(), "1") == 0 && strcmp(node.attribute("langue").value(), language.c_str()) == 0)
+				{
+					family = node.text().get();
+					break;
+				}
+			}
+
+			if (family.empty())
+			{
+				for (pugi::xml_node node : game.child("familles").children("famille"))
+				{
+					if (strcmp(node.attribute("principale").value(), "1") == 0 && strcmp(node.attribute("langue").value(), "en") == 0)
+					{
+						family = node.text().get();
+						break;
+					}
+				}
+			}
+
+			if (family.empty())
+			{
+				for (pugi::xml_node node : game.child("familles").children("famille"))
+				{
+					family = node.text().get();
+					break;
+				}
+
+			}
+
+			if (!family.empty())
+				result.mdl.set(MetaDataId::Family, family);
 		}
 
 		// Get the date proper. The API returns multiple 'date' children nodes to the 'dates' main child of 'jeu'.

--- a/es-app/src/views/gamelist/BasicGameListView.cpp
+++ b/es-app/src/views/gamelist/BasicGameListView.cpp
@@ -148,6 +148,11 @@ std::shared_ptr<std::vector<FileData*>> recurseFind(FileData* toFind, FolderData
 	return nullptr;
 }
 
+void BasicGameListView::resetLastCursor()
+{
+	mList.resetLastCursor();
+}
+
 void BasicGameListView::setCursor(FileData* cursor)
 {
 	if (cursor && !mList.setCursor(cursor) && !cursor->isPlaceHolder())

--- a/es-app/src/views/gamelist/BasicGameListView.h
+++ b/es-app/src/views/gamelist/BasicGameListView.h
@@ -17,8 +17,9 @@ public:
 
 	virtual FileData* getCursor() override;
 	virtual void setCursor(FileData* file) override;
-	virtual int getCursorIndex() override; // batocera
-	virtual void setCursorIndex(int index) override; // batocera
+	virtual int getCursorIndex() override;
+	virtual void setCursorIndex(int index) override;
+	virtual void resetLastCursor() override;
 
 	virtual const char* getName() const override
 	{

--- a/es-app/src/views/gamelist/CarouselGameListView.cpp
+++ b/es-app/src/views/gamelist/CarouselGameListView.cpp
@@ -133,6 +133,11 @@ FileData* CarouselGameListView::getCursor()
 	return mList.getSelected();
 }
 
+void CarouselGameListView::resetLastCursor()
+{
+	mList.resetLastCursor();
+}
+
 void CarouselGameListView::setCursor(FileData* cursor)
 {
 	if (cursor && !mList.setCursor(cursor) && !cursor->isPlaceHolder())

--- a/es-app/src/views/gamelist/CarouselGameListView.h
+++ b/es-app/src/views/gamelist/CarouselGameListView.h
@@ -20,6 +20,7 @@ public:
 	virtual void setCursor(FileData* file) override;
 	virtual int getCursorIndex() override; // batocera
 	virtual void setCursorIndex(int index) override; // batocera
+	virtual void resetLastCursor() override;
 
 	virtual const char* getName() const override
 	{

--- a/es-app/src/views/gamelist/DetailedContainer.cpp
+++ b/es-app/src/views/gamelist/DetailedContainer.cpp
@@ -547,7 +547,7 @@ void DetailedContainer::updateDetailsForFolder(FolderData* folder)
 		
 		if (mVideo != nullptr && mVideo->showSnapshots())
 		{
-			mVideo->setImage("");
+			mVideo->setImage(":/blank.png");
 			mVideo->setVideo("");
 
 			createFolderGrid(mVideo->getTargetSize(), thumbs);
@@ -582,7 +582,7 @@ void DetailedContainer::updateDetailsForFolder(FolderData* folder)
 		{
 			if (mVideo == nullptr || !mVideo->showSnapshots())
 			{
-				mImage->setImage("");
+				mImage->setImage(":/blank.png");
 
 				createFolderGrid(mImage->getSize(), thumbs);
 				if (mFolderView)

--- a/es-app/src/views/gamelist/GridGameListView.cpp
+++ b/es-app/src/views/gamelist/GridGameListView.cpp
@@ -11,6 +11,7 @@
 #include "SystemConf.h"
 #include "guis/GuiGamelistOptions.h"
 #include "GameNameFormatter.h"
+#include "utils/Randomizer.h"
 
 GridGameListView::GridGameListView(Window* window, FolderData* root, const std::shared_ptr<ThemeData>& theme, std::string themeName, Vector2f gridSize) :
 	ISimpleGameListView(window, root),
@@ -57,6 +58,11 @@ FileData* GridGameListView::getCursor()
 		return nullptr;
 
 	return mGrid.getSelected();
+}
+
+void GridGameListView::resetLastCursor()
+{
+	mGrid.resetLastCursor();
 }
 
 void GridGameListView::setCursor(FileData* cursor)
@@ -322,4 +328,22 @@ void GridGameListView::update(int deltaTime)
 {
 	mDetails.update(deltaTime);
 	ISimpleGameListView::update(deltaTime);
+}
+
+void GridGameListView::moveToRandomGame()
+{
+	auto list = getFileDataEntries();
+
+	unsigned int total = (int)list.size();
+	if (total == 0)
+		return;
+
+	int target = Randomizer::random(total);
+	if (target >= 0 && target < total)
+	{
+		resetLastCursor();
+		setCursor(list.at(target));
+		if (isShowing())
+			onShow();
+	}
 }

--- a/es-app/src/views/gamelist/GridGameListView.h
+++ b/es-app/src/views/gamelist/GridGameListView.h
@@ -22,6 +22,8 @@ public:
 	virtual void setCursor(FileData*) override;
 	virtual int getCursorIndex() override; // batocera
 	virtual void setCursorIndex(int index) override; // batocera
+	virtual void resetLastCursor() override;
+	virtual void moveToRandomGame() override;
 
 	virtual bool input(InputConfig* config, Input input) override;
 

--- a/es-app/src/views/gamelist/ISimpleGameListView.cpp
+++ b/es-app/src/views/gamelist/ISimpleGameListView.cpp
@@ -22,6 +22,7 @@
 #include "guis/GuiSaveState.h"
 #include "guis/GuiGamelistOptions.h"
 #include "BasicGameListView.h"
+#include "utils/Randomizer.h"
 
 ISimpleGameListView::ISimpleGameListView(Window* window, FolderData* root, bool temporary) : IGameListView(window, root),
 	mHeaderText(window), mHeaderImage(window), mBackground(window), mFolderPath(window), mOnExitPopup(nullptr),
@@ -443,7 +444,7 @@ void ISimpleGameListView::moveToRandomGame()
 	if (total == 0)
 		return;
 
-	int target = (int)Math::round((std::rand() / (float)RAND_MAX) * (total - 1));
+	int target = Randomizer::random(total); // (int)Math::round((std::rand() / (float)RAND_MAX) * (total - 1));
 	if (target >= 0 && target < total)
 		setCursor(list.at(target));
 }

--- a/es-app/src/views/gamelist/ISimpleGameListView.h
+++ b/es-app/src/views/gamelist/ISimpleGameListView.h
@@ -28,6 +28,8 @@ public:
 	virtual int getCursorIndex() =0; // batocera
 	virtual void setCursorIndex(int index) =0; // batocera
 
+	virtual void resetLastCursor() = 0;
+
 	virtual void update(int deltaTime) override;
 	virtual bool input(InputConfig* config, Input input) override;
 	virtual void launch(FileData* game) = 0;
@@ -43,7 +45,8 @@ public:
 	void setPopupContext(std::shared_ptr<IGameListView> pThis, std::shared_ptr<GuiComponent> parentView, const std::string label, const std::function<void()>& onExitTemporary);
 	void closePopupContext();
 	
-	void moveToRandomGame();
+	virtual void moveToRandomGame();
+
 	void showQuickSearch();
 	void launchSelectedGame();
 	void showSelectedGameOptions();

--- a/es-core/CMakeLists.txt
+++ b/es-core/CMakeLists.txt
@@ -103,6 +103,7 @@ set(CORE_HEADERS
 	${CMAKE_CURRENT_SOURCE_DIR}/src/utils/ZipFile.h
 	${CMAKE_CURRENT_SOURCE_DIR}/src/utils/md5.h
 	${CMAKE_CURRENT_SOURCE_DIR}/src/utils/Delegate.h
+	${CMAKE_CURRENT_SOURCE_DIR}/src/utils/Randomizer.h
 )
 
 set(CORE_SOURCES
@@ -204,6 +205,7 @@ set(CORE_SOURCES
 	${CMAKE_CURRENT_SOURCE_DIR}/src/utils/ThreadPool.cpp	
 	${CMAKE_CURRENT_SOURCE_DIR}/src/utils/ZipFile.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/utils/md5.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/src/utils/Randomizer.cpp
 )
 
 # Keep Directory structure in Visual Studio

--- a/es-core/src/AudioManager.cpp
+++ b/es-core/src/AudioManager.cpp
@@ -6,6 +6,7 @@
 #include <SDL.h>
 #include "utils/FileSystemUtil.h"
 #include "utils/StringUtil.h"
+#include "utils/Randomizer.h"
 #include "SystemConf.h"
 #include "id3v2lib/include/id3v2lib.h"
 #include "ThemeData.h"
@@ -194,13 +195,7 @@ void AudioManager::playRandomMusic(bool continueIfPlaying)
 	if (musics.empty())
 		return;
 
-#if defined(WIN32)
-	srand(time(NULL) % getpid());
-#else
-	srand(time(NULL) % getpid() + getppid());
-#endif
-
-	int randomIndex = rand() % musics.size();
+	int randomIndex = Randomizer::random(musics.size());
 
 	// continue playing ?
 	if (mCurrentMusic != nullptr && continueIfPlaying)

--- a/es-core/src/HttpReq.cpp
+++ b/es-core/src/HttpReq.cpp
@@ -127,6 +127,9 @@ HttpReq::HttpReq(const std::string& url, const std::string outputFilename)
 		return;
 	}
 
+	// Ignore expired SSL certificates
+	curl_easy_setopt(mHandle, CURLOPT_SSL_VERIFYPEER, 0L);
+
 	//set curl to handle redirects
 	err = curl_easy_setopt(mHandle, CURLOPT_CONNECTTIMEOUT, 10L);
 	if (err != CURLE_OK)

--- a/es-core/src/SystemConf.cpp
+++ b/es-core/src/SystemConf.cpp
@@ -11,7 +11,6 @@
 #include <iostream>
 #include <SDL_timer.h>
 
-
 #if WIN32 & !_DEBUG
 	// NOBATOCERACONF routes all SystemConf to es_settings for Windows Release version
 
@@ -39,7 +38,6 @@ static std::map<std::string, std::string> defaults =
 	{ "kodi.enabled", "1" },
 	{ "kodi.atstartup", "0" },
 	{ "audio.bgmusic", "1" },
-	{ "global.autosave", "3" },
 	{ "wifi.enabled", "0" },
 	{ "system.hostname", "BATOCERA" },
 	{ "global.retroachievements", "0" },

--- a/es-core/src/components/OptionListComponent.h
+++ b/es-core/src/components/OptionListComponent.h
@@ -32,6 +32,7 @@ private:
 
 		T object;
 		bool selected;
+		bool treeChild;
 
 		std::string group;
 	};
@@ -41,6 +42,15 @@ private:
 	private:
 		MenuComponent mMenu;
 		OptionListComponent<T>* mParent;
+		// for select all/none
+
+		struct CheckBoxElement
+		{
+			ImageComponent* checkbox;
+			OptionListData* item;
+		};
+
+		std::vector<CheckBoxElement> mCheckBoxes;
 
 	public:
 		OptionListPopup(Window* window, OptionListComponent<T>* parent, const std::string& title, const std::function<void(T& data, ComponentListRow& row)> callback = nullptr) : GuiComponent(window),
@@ -50,11 +60,11 @@ private:
 			auto font = menuTheme->Text.font;
 			auto color = menuTheme->Text.color;
 
+		//	if (parent->mMultiSelect && parent->mMultiSelectShowNames)
+		//		font = menuTheme->TextSmall.font;
+
 			ComponentListRow row;
-
-			// for select all/none
-			std::vector<ImageComponent*> checkboxes;
-
+					
 			for(auto it = mParent->mEntries.begin(); it != mParent->mEntries.end(); it++)
 			{
 				row.elements.clear();
@@ -69,7 +79,7 @@ private:
 					{
 						row.makeAcceptInputHandler([this, &e]
 						{
-							e.selected = !e.selected;							
+							e.selected = !e.selected;														
 							mParent->onSelectedChanged();
 						});
 					}
@@ -90,7 +100,7 @@ private:
 						row.addElement(std::make_shared<MultiLineMenuEntry>(mWindow, Utils::String::toUpper(it->name), it->description), true);
 					else
 					{
-						auto text = std::make_shared<TextComponent>(mWindow, Utils::String::toUpper(it->name), font, color);
+						auto text = std::make_shared<TextComponent>(mWindow, e.treeChild ? "      " + Utils::String::toUpper(it->name) : Utils::String::toUpper(it->name), font, color);
 						if (EsLocale::isRTL())
 							text->setHorizontalAlignment(Alignment::ALIGN_RIGHT);
 
@@ -114,8 +124,12 @@ private:
 							mParent->onSelectedChanged();
 						});
 
+						CheckBoxElement el;
+						el.checkbox = checkbox.get();
+						el.item = &e;
+
 						// for select all/none
-						checkboxes.push_back(checkbox.get());
+						mCheckBoxes.push_back(el);
 					}
 					else {
 						// input handler for non-multiselect
@@ -140,22 +154,24 @@ private:
 
 			mMenu.addButton(_("BACK"), _("accept"), [this] { delete this; }); // batocera
 
-			if(mParent->mMultiSelect)
+			if (mParent->mMultiSelect)
 			{
-			  mMenu.addButton(_("SELECT ALL"), _("select all"), [this, checkboxes] { // batocera
-					for(unsigned int i = 0; i < mParent->mEntries.size(); i++)
+				mMenu.addButton(_("SELECT ALL"), _("select all"), [this]
+				{
+					for (unsigned int i = 0; i < mParent->mEntries.size(); i++)
 					{
 						mParent->mEntries.at(i).selected = true;
-						checkboxes.at(i)->setImage(CHECKED_PATH);
+						mCheckBoxes.at(i).checkbox->setImage(CHECKED_PATH);
 					}
 					mParent->onSelectedChanged();
 				});
 
-				mMenu.addButton(_("SELECT NONE"), _("select none"), [this, checkboxes] { // batocera
-					for(unsigned int i = 0; i < mParent->mEntries.size(); i++)
+				mMenu.addButton(_("SELECT NONE"), _("select none"), [this]
+				{
+					for (unsigned int i = 0; i < mParent->mEntries.size(); i++)
 					{
 						mParent->mEntries.at(i).selected = false;
-						checkboxes.at(i)->setImage(UNCHECKED_PATH);
+						mCheckBoxes.at(i).checkbox->setImage(UNCHECKED_PATH);
 					}
 					mParent->onSelectedChanged();
 				});
@@ -189,8 +205,8 @@ private:
 	};
 
 public:
-	OptionListComponent(Window* window, const std::string& name, bool multiSelect = false) : GuiComponent(window), mMultiSelect(multiSelect), mName(name),
-		 mText(window), mLeftArrow(window), mRightArrow(window)
+	OptionListComponent(Window* window, const std::string& name, bool multiSelect = false, bool multiSelectShowNames = false) : GuiComponent(window), mMultiSelect(multiSelect), mName(name),
+		 mText(window), mLeftArrow(window), mRightArrow(window), mMultiSelectShowNames(multiSelectShowNames)
 	{
 		auto theme = ThemeData::getMenuTheme();
 
@@ -340,7 +356,7 @@ public:
                 return "";
 	}
         
-	void addEx(const std::string name, const std::string description, const T& obj, bool selected)
+	void addEx(const std::string name, const std::string description, const T& obj, bool selected, bool treeChild = false)
 	{
 		for (auto sysIt = mEntries.cbegin(); sysIt != mEntries.cend(); sysIt++)
 			if (sysIt->name == name)
@@ -351,18 +367,18 @@ public:
 		e.description = description;
 		e.object = obj;
 		e.selected = selected;
-
+		e.treeChild = treeChild;
 		e.group = mGroup;
 		mGroup = "";
 
-		// batocera
 		if (selected)
 			firstSelected = obj;
 
 		mEntries.push_back(e);
 		onSelectedChanged();
 	}
-	void add(const std::string name, const T& obj, bool selected, bool distinct = true)
+
+	void add(const std::string name, const T& obj, bool selected, bool distinct = true, bool treeChild = false)
 	{
 		if (distinct)
 		{
@@ -375,11 +391,10 @@ public:
 		e.name = name;
 		e.object = obj;
 		e.selected = selected;
-
+		e.treeChild = treeChild;
 		e.group = mGroup;
 		mGroup = "";
-
-                // batocera
+                
 		if(selected)
 			firstSelected = obj;
 
@@ -520,11 +535,31 @@ private:
 
 	void onSelectedChanged()
 	{
-		if(mMultiSelect)
+		if (mMultiSelect && mMultiSelectShowNames)
+		{
+			std::string name;
+
+			// display currently selected + l/r cursors
+			for (auto it = mEntries.cbegin(); it != mEntries.cend(); it++)
+			{
+				if (it->selected)
+				{
+					if (name.empty())
+						name = Utils::String::trim(it->name);
+					else
+						name = name + ", " + Utils::String::trim(it->name);
+				}
+			}
+
+			mText.setText(name);
+			mText.setSize(0, mText.getSize().y());
+			setSize(mText.getSize().x() + mLeftArrow.getSize().x() + mRightArrow.getSize().x() + 24, mText.getSize().y());
+			if (mParent) // hack since theres no "on child size changed" callback atm...
+				mParent->onSizeChanged();
+		}
+		else if (mMultiSelect)
 		{
 			// display # selected
-
-                        // batocera
 		  	char strbuf[256];
 			int x = getSelectedObjects().size();
 		  	snprintf(strbuf, 256, ngettext("%i SELECTED", "%i SELECTED", x), x);
@@ -534,7 +569,9 @@ private:
 			setSize(mText.getSize().x() + mRightArrow.getSize().x() + 24, mText.getSize().y());
 			if(mParent) // hack since theres no "on child size changed" callback atm...
 				mParent->onSizeChanged();
-		}else{
+		}
+		else
+		{
 			// display currently selected + l/r cursors
 			for(auto it = mEntries.cbegin(); it != mEntries.cend(); it++)
 			{
@@ -566,6 +603,7 @@ private:
 	}
 
 	bool mMultiSelect;
+	bool mMultiSelectShowNames;
 
 	std::string mName;
 	std::string mGroup;

--- a/es-core/src/resources/ResourceManager.cpp
+++ b/es-core/src/resources/ResourceManager.cpp
@@ -34,7 +34,7 @@ std::vector<std::string> ResourceManager::getResourcePaths() const
 		paths.push_back(themePath);
 
 	// check if default readonly theme overrides default resources
-#ifdef WIN32
+#ifndef WIN32
 	std::string roThemePath = Utils::FileSystem::getSharedConfigPath() + "/themes/" + Settings::getInstance()->getString("ThemeSet") + "/resources";
 	if (Utils::FileSystem::isDirectory(roThemePath))
 		paths.push_back(roThemePath);

--- a/es-core/src/utils/Randomizer.cpp
+++ b/es-core/src/utils/Randomizer.cpp
@@ -1,0 +1,20 @@
+#include "Randomizer.h"
+
+std::random_device Randomizer::RandomDevice;
+Randomizer* Randomizer::Instance = nullptr;
+
+Randomizer::Randomizer() : mMt19937(RandomDevice()) { }
+
+int Randomizer::random(int max)
+{
+	if (max <= 1)
+		return 0;
+
+	if (Instance == nullptr)
+		Instance = new Randomizer();
+
+	std::uniform_int_distribution<int> uniformDistribution(0, max - 1);
+	return uniformDistribution(Instance->mMt19937);
+}
+
+

--- a/es-core/src/utils/Randomizer.h
+++ b/es-core/src/utils/Randomizer.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <random>
+
+class Randomizer
+{
+public:
+	static int random(int max);
+
+private:
+	Randomizer();
+
+	static std::random_device RandomDevice;
+	static Randomizer*	Instance;
+	std::mt19937		mMt19937;
+};

--- a/resources/genres.xml
+++ b/resources/genres.xml
@@ -1,0 +1,1311 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<genres>
+  <genre>
+    <id>10</id>
+    <nom_fr>Action</nom_fr>
+    <nom_de>Action</nom_de>
+    <nom_en>Action</nom_en>
+    <nom_es>Acción</nom_es>
+    <nom_pt>Ação</nom_pt>
+  </genre>
+  <genre>
+    <id>3566</id>
+    <nom_fr>Aventure</nom_fr>
+    <nom_de>Abenteuer</nom_de>
+    <nom_en>Adventure</nom_en>
+    <nom_es>Aventura</nom_es>
+    <nom_pt>Aventura</nom_pt>
+    <parent>10</parent>
+  </genre>
+  <genre>
+    <id>2917</id>
+    <nom_fr>Casse briques</nom_fr>
+    <nom_de>Breakout Spiele</nom_de>
+    <nom_en>Breakout games</nom_en>
+    <nom_es>Juegos de Breakout</nom_es>
+    <nom_pt>Jogos de Breakout</nom_pt>
+    <altname>Action / Breakout</altname>
+    <altname>Ball &amp; Paddle / Breakout</altname>
+    <parent>10</parent>
+  </genre>
+  <genre>
+    <id>2909</id>
+    <nom_fr>Escalade</nom_fr>
+    <nom_de>Klettern</nom_de>
+    <nom_en>Climbing</nom_en>
+    <nom_es>Escalada</nom_es>
+    <nom_pt>Escalada</nom_pt>
+    <parent>10</parent>
+  </genre>
+  <genre>
+    <id>2937</id>
+    <nom_fr>Labyrinthe</nom_fr>
+    <nom_de>Labyrinth</nom_de>
+    <nom_en>Labyrinth</nom_en>
+    <nom_es>Laberinto</nom_es>
+    <nom_pt>Labirinto</nom_pt>
+    <altname>MAZE</altname>
+    <parent>10</parent>
+  </genre>
+  <genre>
+    <id>20688</id>
+    <nom_fr>Action RPG</nom_fr>
+    <nom_en>Action RPG</nom_en>
+    <nom_es>Juego de Rol de Acción</nom_es>
+    <nom_pt>Jogos de RPG</nom_pt>
+    <parent>8</parent>
+  </genre>
+  <genre>
+    <id>413</id>
+    <nom_fr>Adulte</nom_fr>
+    <nom_de>Erwachsene</nom_de>
+    <nom_en>Adult</nom_en>
+    <nom_es>Adulto</nom_es>
+    <nom_pt>Adulto</nom_pt>
+  </genre>
+  <genre>
+    <id>13</id>
+    <nom_fr>Aventure</nom_fr>
+    <nom_de>Abenteuer</nom_de>
+    <nom_en>Adventure</nom_en>
+    <nom_es>Aventura</nom_es>
+    <nom_pt>Aventura</nom_pt>
+  </genre>
+  <genre>
+    <id>20678</id>
+    <nom_fr>3D Temps Réel</nom_fr>
+    <nom_en>RealTime 3D</nom_en>
+    <nom_es>3D en Tiempo Real</nom_es>
+    <nom_pt>3D em Tempo Real</nom_pt>
+    <parent>13</parent>
+  </genre>
+  <genre>
+    <id>20676</id>
+    <nom_fr>Film Interactif</nom_fr>
+    <nom_en>Interactive Movie</nom_en>
+    <nom_es>Película Interactiva</nom_es>
+    <nom_pt>Filme Interativo</nom_pt>
+    <parent>13</parent>
+  </genre>
+  <genre>
+    <id>20672</id>
+    <nom_fr>Graphique</nom_fr>
+    <nom_en>Graphics</nom_en>
+    <nom_es>Gráficos</nom_es>
+    <nom_pt>Gráficos</nom_pt>
+    <parent>13</parent>
+  </genre>
+  <genre>
+    <id>3237</id>
+    <nom_fr>Point and Click</nom_fr>
+    <nom_de>Point und Klick</nom_de>
+    <nom_en>Point and Click</nom_en>
+    <nom_es>Point and Click</nom_es>
+    <parent>13</parent>
+  </genre>
+  <genre>
+    <id>20674</id>
+    <nom_fr>Roman Visuel</nom_fr>
+    <nom_en>Visual Novel</nom_en>
+    <nom_es>Novela Visual</nom_es>
+    <parent>13</parent>
+  </genre>
+  <genre>
+    <id>20680</id>
+    <nom_fr>Survie Horreur</nom_fr>
+    <nom_en>Survival Horror</nom_en>
+    <altname>Horror</altname>
+    <parent>13</parent>
+  </genre>
+  <genre>
+    <id>20670</id>
+    <nom_fr>Texte</nom_fr>
+    <nom_en>Text</nom_en>
+    <nom_es>Texto</nom_es>
+    <nom_pt>Texto</nom_pt>
+    <parent>13</parent>
+  </genre>
+  <genre>
+    <id>1</id>
+    <nom_fr>Beat'em All</nom_fr>
+    <nom_de>Beat'em Up</nom_de>
+    <nom_en>Beat'em Up</nom_en>
+    <nom_es>Beat'em Up</nom_es>
+    <nom_pt>Briga de rua</nom_pt>
+  </genre>
+  <genre>
+    <id>320</id>
+    <nom_fr>Casino</nom_fr>
+    <nom_de>Casino</nom_de>
+    <nom_en>Casino</nom_en>
+    <nom_es>Casino</nom_es>
+    <nom_pt>Cassino</nom_pt>
+  </genre>
+  <genre>
+    <id>2872</id>
+    <nom_fr>Cartes</nom_fr>
+    <nom_de>Karten</nom_de>
+    <nom_en>Cards</nom_en>
+    <nom_es>Cartas</nom_es>
+    <nom_pt>Cartas</nom_pt>
+    <parent>320</parent>
+  </genre>
+  <genre>
+    <id>2950</id>
+    <nom_fr>Course</nom_fr>
+    <nom_de>Rennen</nom_de>
+    <nom_en>Race</nom_en>
+    <nom_es>Carreras</nom_es>
+    <nom_pt>Corrida</nom_pt>
+    <parent>320</parent>
+  </genre>
+  <genre>
+    <id>2932</id>
+    <nom_fr>Loterie</nom_fr>
+    <nom_de>Lotterie</nom_de>
+    <nom_en>Lottery</nom_en>
+    <nom_es>Lotería</nom_es>
+    <nom_pt>Loteria</nom_pt>
+    <parent>320</parent>
+  </genre>
+  <genre>
+    <id>2860</id>
+    <nom_fr>Machine a sous</nom_fr>
+    <nom_de>Slot Machine</nom_de>
+    <nom_en>Slot machine</nom_en>
+    <nom_es>Máquina tragaperras</nom_es>
+    <nom_pt>Caça-níqueis</nom_pt>
+    <parent>320</parent>
+  </genre>
+  <genre>
+    <id>2944</id>
+    <nom_fr>Roulette</nom_fr>
+    <nom_de>Roulette</nom_de>
+    <nom_en>Roulette</nom_en>
+    <nom_es>Ruleta</nom_es>
+    <nom_pt>Roleta</nom_pt>
+    <parent>320</parent>
+  </genre>
+  <genre>
+    <id>171</id>
+    <nom_fr>Casual Game</nom_fr>
+    <nom_de>Gelegenheitsspiel</nom_de>
+    <nom_en>Casual Game</nom_en>
+    <nom_es>Juego Casual</nom_es>
+    <nom_pt>Jogo casual</nom_pt>
+  </genre>
+  <genre>
+    <id>3192</id>
+    <nom_fr>Chasse</nom_fr>
+    <nom_de>Jagen</nom_de>
+    <nom_en>Hunting</nom_en>
+    <nom_es>Caza</nom_es>
+    <nom_pt>Caça</nom_pt>
+    <parent>2648</parent>
+  </genre>
+  <genre>
+    <id>2648</id>
+    <nom_fr>Chasse et Peche</nom_fr>
+    <nom_de>Jagen und Angeln</nom_de>
+    <nom_en>Hunting and Fishing</nom_en>
+    <nom_es>Caza y Pesca</nom_es>
+    <nom_pt>Caça e Pesca</nom_pt>
+  </genre>
+  <genre>
+    <id>14</id>
+    <nom_fr>Combat</nom_fr>
+    <nom_de>Kampf</nom_de>
+    <nom_en>Fight</nom_en>
+    <nom_es>Lucha</nom_es>
+    <nom_pt>Luta</nom_pt>
+    <altname>Fighter</altname>
+  </genre>
+  <genre>
+    <id>2874</id>
+    <nom_fr>2.5D</nom_fr>
+    <nom_de>2.5D</nom_de>
+    <nom_en>2.5D</nom_en>
+    <nom_es>2.5D</nom_es>
+    <nom_pt>2.5D</nom_pt>
+    <parent>14</parent>
+  </genre>
+  <genre>
+    <id>2914</id>
+    <nom_fr>2D</nom_fr>
+    <nom_de>2D</nom_de>
+    <nom_en>2D</nom_en>
+    <nom_es>2D</nom_es>
+    <nom_pt>2D</nom_pt>
+    <parent>14</parent>
+  </genre>
+  <genre>
+    <id>2920</id>
+    <nom_fr>3D</nom_fr>
+    <nom_de>3D</nom_de>
+    <nom_en>3D</nom_en>
+    <nom_es>3D</nom_es>
+    <nom_pt>3D</nom_pt>
+    <parent>14</parent>
+  </genre>
+  <genre>
+    <id>2885</id>
+    <nom_fr>Versus</nom_fr>
+    <nom_de>Versus</nom_de>
+    <nom_en>Versus</nom_en>
+    <nom_es>Versus</nom_es>
+    <nom_pt>Versus</nom_pt>
+    <parent>14</parent>
+  </genre>
+  <genre>
+    <id>2957</id>
+    <nom_fr>Versus Co-op</nom_fr>
+    <nom_de>Versus Ko-Op</nom_de>
+    <nom_en>Versus Co-op</nom_en>
+    <nom_es>Versus Co-op</nom_es>
+    <nom_pt>Versus Co-op</nom_pt>
+	<altname>Fight /  Co-op</altname>
+    <parent>14</parent>
+  </genre>
+  <genre>
+    <id>2922</id>
+    <nom_fr>Vertical</nom_fr>
+    <nom_de>Vertikal</nom_de>
+    <nom_en>Vertical</nom_en>
+    <nom_es>Vertical</nom_es>
+    <nom_pt>Vertical</nom_pt>
+    <parent>14</parent>
+  </genre>
+  <genre>
+    <id>34</id>
+    <nom_fr>Compilation</nom_fr>
+    <nom_de>Sammlung</nom_de>
+    <nom_en>Compilation</nom_en>
+    <nom_es>Compilación</nom_es>
+    <nom_pt>Compilação</nom_pt>
+    <altname>MULTIPLAY / MINI-GAMES</altname>
+    <altname>MINI-GAMES</altname>
+  </genre>
+  <genre>
+    <id>20682</id>
+    <nom_fr>Construction &amp; Management</nom_fr>
+    <nom_en>Build And Management</nom_en>
+    <nom_es>Construcción y Gestión</nom_es>
+    <nom_pt>Construção e Gestão</nom_pt>
+    <parent>40</parent>
+  </genre>
+  <genre>
+    <id>2918</id>
+    <nom_fr>Course de chevaux</nom_fr>
+    <nom_de>Pferderennen</nom_de>
+    <nom_en>Horses race</nom_en>
+    <nom_es>Carreras de caballos</nom_es>
+    <nom_pt>Corrida com Cavalos</nom_pt>
+    <parent>2650</parent>
+  </genre>
+  <genre>
+    <id>2973</id>
+    <nom_fr>Course de Moto vue 1er pers.</nom_fr>
+    <nom_de>Motorradrennen, 1st Pers.</nom_de>
+    <nom_en>Motorcycle Race, 1st Pers.</nom_en>
+    <nom_es>Carreras de moto, 1ª persona</nom_es>
+    <nom_pt>Corrida de moto em 1ª pessoa</nom_pt>
+    <parent>28</parent>
+  </genre>
+  <genre>
+    <id>2871</id>
+    <nom_fr>Course de Moto vue 3eme pers.</nom_fr>
+    <nom_de>Motorradrennen, 3rd Pers.</nom_de>
+    <nom_en>Motorcycle Race, 3rd Pers.</nom_en>
+    <nom_es>Carreras de moto, 3ª persona</nom_es>
+    <nom_pt>Corrida de moto em 3ª pessoa</nom_pt>
+    <parent>28</parent>
+  </genre>
+  <genre>
+    <id>2884</id>
+    <nom_fr>Course vue 1ere pers.</nom_fr>
+    <nom_de>Rennen 1st Pers.</nom_de>
+    <nom_en>Race 1st Pers. view</nom_en>
+    <nom_es>Carreras 1ª persona</nom_es>
+    <nom_pt>Corrida em 1ª pessoa</nom_pt>
+    <altname>DRIVING / RACE 1ST PERSON</altname>
+    <parent>28</parent>
+  </genre>
+  <genre>
+    <id>2888</id>
+    <nom_fr>Course vue 3eme pers.</nom_fr>
+    <nom_de>Rennen 3rd Pers.</nom_de>
+    <nom_en>Race 3rd Pers. view</nom_en>
+    <nom_es>Carreras 3ª persona</nom_es>
+    <nom_pt>Corrida em 3ª pessoa</nom_pt>
+    <parent>28</parent>
+  </genre>
+  <genre>
+    <id>28</id>
+    <nom_fr>Course, Conduite</nom_fr>
+    <nom_de>Rennen, Fahren</nom_de>
+    <nom_en>Race, Driving</nom_en>
+    <nom_es>Carreras, Conducción</nom_es>
+    <nom_pt>Corrida, Pilotagem</nom_pt>
+    <altname>Racing</altname>
+    <altname>Course</altname>
+    <altname>Race</altname>
+    <altname>DRIVING</altname>
+  </genre>
+  <genre>
+    <id>2893</id>
+    <nom_fr>Avion</nom_fr>
+    <nom_de>Flugzeug</nom_de>
+    <nom_en>Plane</nom_en>
+    <nom_es>Avión</nom_es>
+    <nom_pt>Avião</nom_pt>
+    <parent>28</parent>
+  </genre>
+  <genre>
+    <id>2911</id>
+    <nom_fr>Bateau</nom_fr>
+    <nom_de>Boot</nom_de>
+    <nom_en>Boat</nom_en>
+    <nom_es>Bote</nom_es>
+    <nom_pt>Bote</nom_pt>
+    <parent>28</parent>
+  </genre>
+  <genre>
+    <id>2924</id>
+    <nom_fr>Course</nom_fr>
+    <nom_de>Rennen</nom_de>
+    <nom_en>Race</nom_en>
+    <nom_es>Carreras</nom_es>
+    <nom_pt>Corrida</nom_pt>
+    <parent>28</parent>
+  </genre>
+  <genre>
+    <id>2953</id>
+    <nom_fr>Deltaplane</nom_fr>
+    <nom_de>Hang Glider</nom_de>
+    <nom_en>Hang-glider</nom_en>
+    <nom_es>Ala delta</nom_es>
+    <nom_pt>Asa-Delta</nom_pt>
+    <parent>28</parent>
+  </genre>
+  <genre>
+    <id>2943</id>
+    <nom_fr>Moto</nom_fr>
+    <nom_de>Motorrad</nom_de>
+    <nom_en>Motorcycle</nom_en>
+    <nom_es>Motocicleta</nom_es>
+    <nom_pt>Moto</nom_pt>
+    <parent>28</parent>
+  </genre>
+  <genre>
+    <id>2974</id>
+    <nom_fr>Demo</nom_fr>
+    <nom_de>Demo</nom_de>
+    <nom_en>Demo</nom_en>
+    <nom_es>Demo</nom_es>
+    <nom_pt>Demo</nom_pt>
+  </genre>
+  <genre>
+    <id>39</id>
+    <nom_fr>Divers</nom_fr>
+    <nom_de>Verschiedene</nom_de>
+    <nom_en>Various</nom_en>
+    <nom_es>Varios</nom_es>
+    <nom_pt>Variados</nom_pt>
+  </genre>
+  <genre>
+    <id>2890</id>
+    <nom_fr>Electro-mecanique</nom_fr>
+    <nom_de>Elektromechanisch</nom_de>
+    <nom_en>Electro- Mechanical</nom_en>
+    <nom_es>Electromecánico</nom_es>
+    <nom_pt>Eletromecânico</nom_pt>
+    <parent>39</parent>
+  </genre>
+  <genre>
+    <id>2879</id>
+    <nom_fr>Print Club</nom_fr>
+    <nom_de>Print Club</nom_de>
+    <nom_en>Print Club</nom_en>
+    <nom_es>Print Club</nom_es>
+    <nom_pt>Print Club</nom_pt>
+    <parent>39</parent>
+  </genre>
+  <genre>
+    <id>2855</id>
+    <nom_fr>Système</nom_fr>
+    <nom_de>System</nom_de>
+    <nom_en>System</nom_en>
+    <nom_es>Sistema</nom_es>
+    <nom_pt>Sistema</nom_pt>
+    <parent>39</parent>
+  </genre>
+  <genre>
+    <id>2904</id>
+    <nom_fr>Utilitaires</nom_fr>
+    <nom_de>Dienstprogramme</nom_de>
+    <nom_en>Utilities</nom_en>
+    <nom_es>Utilidades</nom_es>
+    <nom_pt>Utilitários</nom_pt>
+    <parent>39</parent>
+  </genre>
+  <genre>
+    <id>20692</id>
+    <nom_fr>Dungeon RPG</nom_fr>
+    <nom_en>Dungeon Crawler RPG</nom_en>
+    <nom_es>Juego de Rol de Calabozo</nom_es>
+    <parent>8</parent>
+  </genre>
+  <genre>
+    <id>31</id>
+    <nom_fr>Flipper</nom_fr>
+    <nom_de>Flipper</nom_de>
+    <nom_en>Pinball</nom_en>
+    <nom_es>Pinball</nom_es>
+    <nom_pt>Pinball</nom_pt>
+  </genre>
+  <genre>
+    <id>2958</id>
+    <nom_fr>Go</nom_fr>
+    <nom_de>Go</nom_de>
+    <nom_en>Go</nom_en>
+    <nom_es>Go</nom_es>
+    <nom_pt>Go</nom_pt>
+    <parent>2647</parent>
+  </genre>
+  <genre>
+    <id>2882</id>
+    <nom_fr>Hanafuda</nom_fr>
+    <nom_de>Hanafuda</nom_de>
+    <nom_en>Hanafuda</nom_en>
+    <nom_es>Hanafuda</nom_es>
+    <nom_pt>Hanafuda</nom_pt>
+    <parent>2647</parent>
+  </genre>
+  <genre>
+    <id>42</id>
+    <nom_fr>Jeu de cartes</nom_fr>
+    <nom_de>Kartenspiele</nom_de>
+    <nom_en>Playing cards</nom_en>
+    <nom_es>Juegos de cartas</nom_es>
+    <nom_pt>Jogo de cartas</nom_pt>
+  </genre>
+  <genre>
+    <id>20696</id>
+    <nom_fr>Jeu de Rôle Japonais</nom_fr>
+    <nom_en>Japanese RPG</nom_en>
+    <nom_es>Juego de Rol Japonés</nom_es>
+    <parent>8</parent>
+  </genre>
+  <genre>
+    <id>20694</id>
+    <nom_fr>Jeu de Rôle Tactique</nom_fr>
+    <nom_en>Tactical RPG</nom_en>
+    <nom_es>Juego de Rol Táctico</nom_es>
+    <parent>8</parent>
+  </genre>
+  <genre>
+    <id>8</id>
+    <nom_fr>Jeu de rôles</nom_fr>
+    <nom_de>Rollenspiele</nom_de>
+    <nom_en>Role playing games</nom_en>
+    <nom_es>Juegos de rol</nom_es>
+    <nom_pt>Jogos de RPG</nom_pt>
+  </genre>
+  <genre>
+    <id>20698</id>
+    <nom_fr>Jeu de rôles en équipe</nom_fr>
+    <nom_en>Team-as-one RPG</nom_en>
+    <nom_es>Juego de Rol en Equipo</nom_es>
+    <parent>8</parent>
+  </genre>
+  <genre>
+    <id>33</id>
+    <nom_fr>Jeu de societe / plateau</nom_fr>
+    <nom_de>Brettspiele</nom_de>
+    <nom_en>Board game</nom_en>
+    <nom_es>Juegos de mesa</nom_es>
+    <nom_pt>Jogo de tabuleiro</nom_pt>
+    <altname>Jeu de societe</altname>
+    <altname>TABLETOP</altname>
+  </genre>
+  <genre>
+    <id>2647</id>
+    <nom_fr>Jeu de societe asiatique</nom_fr>
+    <nom_de>Asiatische Brettspiele</nom_de>
+    <nom_en>Asiatic board game</nom_en>
+    <nom_es>Juegos de mesa asiático</nom_es>
+    <nom_pt>Jogo de tabuleiro Asiático</nom_pt>
+  </genre>
+  <genre>
+    <id>30</id>
+    <nom_fr>Ludo-Educatif</nom_fr>
+    <nom_de>Lernspiel</nom_de>
+    <nom_en>Educational</nom_en>
+    <nom_es>Educacional</nom_es>
+    <nom_pt>Educacional</nom_pt>
+  </genre>
+  <genre>
+    <id>2869</id>
+    <nom_fr>Mahjong</nom_fr>
+    <nom_de>Mahjong</nom_de>
+    <nom_en>Mahjong</nom_en>
+    <nom_es>Mahjong</nom_es>
+    <nom_pt>Mahjong</nom_pt>
+    <parent>2647</parent>
+  </genre>
+  <genre>
+    <id>20690</id>
+    <nom_fr>MMORPG</nom_fr>
+    <nom_en>Massive Multiplayer Online RPG</nom_en>
+    <nom_es>MMORPG</nom_es>
+    <parent>8</parent>
+  </genre>
+  <genre>
+    <id>425</id>
+    <nom_fr>Musique et Danse</nom_fr>
+    <nom_de>Musik und Tanz</nom_de>
+    <nom_en>Music and Dance</nom_en>
+    <nom_es>Música y Baile</nom_es>
+    <nom_pt>Música e dança</nom_pt>
+    <altname>Music</altname>
+  </genre>
+  <!--
+  <genre>
+    <id>323</id>
+    <nom_fr>N/A</nom_fr>
+    <nom_de>N/A</nom_de>
+    <nom_en>N/A</nom_en>
+    <nom_es>N/A</nom_es>
+    <nom_pt>N/A</nom_pt>
+  </genre>-->
+  <genre>
+    <id>2949</id>
+    <nom_fr>Othello</nom_fr>
+    <nom_de>Othello</nom_de>
+    <nom_en>Othello</nom_en>
+    <nom_es>Reversi</nom_es>
+    <nom_pt>Othello</nom_pt>
+    <altname>TABLETOP / OTHELLO - REVERSI</altname>
+    <parent>2647</parent>
+  </genre>
+  <genre>
+    <id>2965</id>
+    <nom_fr>Pachinko</nom_fr>
+    <parent>2857</parent>
+  </genre>
+  <genre>
+    <id>2895</id>
+    <nom_fr>Peche</nom_fr>
+    <nom_de>Angeln</nom_de>
+    <nom_en>Fishing</nom_en>
+    <nom_es>Pesca</nom_es>
+    <nom_pt>Pesca</nom_pt>
+    <parent>2648</parent>
+  </genre>
+  <genre>
+    <id>7</id>
+    <nom_fr>Plateforme</nom_fr>
+    <nom_de>Plattform</nom_de>
+    <nom_en>Platform</nom_en>
+    <nom_es>Plataforma</nom_es>
+    <nom_pt>Plataforma</nom_pt>
+  </genre>
+  <genre>
+    <id>2896</id>
+    <nom_fr>Fighter Scrolling</nom_fr>
+    <nom_de>Kampf Scrolling</nom_de>
+    <nom_en>Fighter Scrolling</nom_en>
+    <nom_es>Combate con desplazamiento</nom_es>
+    <nom_pt>Combate com rolagem</nom_pt>
+    <parent>7</parent>
+  </genre>
+  <genre>
+    <id>2915</id>
+    <nom_fr>Run Jump</nom_fr>
+    <nom_de>Jump'n'Run</nom_de>
+    <nom_en>Run Jump</nom_en>
+    <nom_es>Corre y Salta</nom_es>
+    <nom_pt>Corre e Pula</nom_pt>
+    <parent>7</parent>
+  </genre>
+  <genre>
+    <id>2897</id>
+    <nom_fr>Run Jump Scrolling</nom_fr>
+    <nom_de>Jump'n'Run Scrolling</nom_de>
+    <nom_en>Run Jump Scrolling</nom_en>
+    <nom_es>Corre y Salta con deslizamiento</nom_es>
+    <nom_pt>Corre e Pula com rolagem</nom_pt>
+    <parent>7</parent>
+  </genre>
+  <genre>
+    <id>2887</id>
+    <nom_fr>Shooter Scrolling</nom_fr>
+    <nom_de>Shooter Scrolling</nom_de>
+    <nom_en>Shooter Scrolling</nom_en>
+    <nom_es>Tirador con deslizamiento</nom_es>
+    <nom_pt>Tiro com rolagem</nom_pt>
+    <parent>7</parent>
+  </genre>
+  <genre>
+    <id>26</id>
+    <nom_fr>Puzzle-Game</nom_fr>
+    <nom_de>Puzzle</nom_de>
+    <nom_en>Puzzle-Game</nom_en>
+    <nom_es>Puzzle</nom_es>
+    <nom_pt>Quebra-cabeças</nom_pt>
+  </genre>
+  <genre>
+    <id>2864</id>
+    <nom_fr>Egaler</nom_fr>
+    <nom_de>Partie</nom_de>
+    <nom_en>Equalize</nom_en>
+    <nom_es>Igualar</nom_es>
+    <nom_pt>Igualar</nom_pt>
+    <parent>26</parent>
+  </genre>
+  <genre>
+    <id>2891</id>
+    <nom_fr>Glisser</nom_fr>
+    <nom_de>Gleiten</nom_de>
+    <nom_en>Glide</nom_en>
+    <nom_es>Deslizar</nom_es>
+    <nom_pt>Rolar</nom_pt>
+    <parent>26</parent>
+  </genre>
+  <genre>
+    <id>2923</id>
+    <nom_fr>Lancer</nom_fr>
+    <nom_de>Werfen</nom_de>
+    <nom_en>Throw</nom_en>
+    <nom_es>Lanzar</nom_es>
+    <nom_pt>Lançar</nom_pt>
+    <parent>26</parent>
+  </genre>
+  <genre>
+    <id>2912</id>
+    <nom_fr>Tomber</nom_fr>
+    <nom_de>Fallen</nom_de>
+    <nom_en>Fall</nom_en>
+    <nom_es>Caída</nom_es>
+    <nom_pt>Queda</nom_pt>
+    <parent>26</parent>
+  </genre>
+  <genre>
+    <id>2649</id>
+    <nom_fr>Quiz</nom_fr>
+    <nom_de>Quiz</nom_de>
+    <nom_en>Quiz</nom_en>
+    <nom_es>Quiz</nom_es>
+    <nom_pt>Quiz</nom_pt>
+  </genre>
+  <genre>
+    <id>2954</id>
+    <nom_fr>Allemand</nom_fr>
+    <nom_de>Deutsch</nom_de>
+    <nom_en>German</nom_en>
+    <nom_es>Alemán</nom_es>
+    <nom_pt>Alemão</nom_pt>
+    <parent>2649</parent>
+  </genre>
+  <genre>
+    <id>2931</id>
+    <nom_fr>Anglais</nom_fr>
+    <nom_de>Englisch</nom_de>
+    <nom_en>English</nom_en>
+    <nom_es>Inglés</nom_es>
+    <nom_pt>Inglês</nom_pt>
+    <parent>2649</parent>
+  </genre>
+  <genre>
+    <id>2951</id>
+    <nom_fr>Coréen</nom_fr>
+    <nom_de>Koreanisch</nom_de>
+    <nom_en>Korean</nom_en>
+    <nom_es>Coreano</nom_es>
+    <nom_pt>Coreano</nom_pt>
+    <parent>2649</parent>
+  </genre>
+  <genre>
+    <id>2962</id>
+    <nom_fr>Espagnol</nom_fr>
+    <nom_de>Spanisch</nom_de>
+    <nom_en>Spanish</nom_en>
+    <nom_es>Español</nom_es>
+    <nom_pt>Espanhol</nom_pt>
+    <parent>2649</parent>
+  </genre>
+  <genre>
+    <id>2969</id>
+    <nom_fr>Français</nom_fr>
+    <nom_de>Französisches</nom_de>
+    <nom_en>French</nom_en>
+    <nom_es>Francés</nom_es>
+    <nom_pt>Francês</nom_pt>
+    <parent>2649</parent>
+  </genre>
+  <genre>
+    <id>2952</id>
+    <nom_fr>Italien</nom_fr>
+    <nom_de>Italienisch</nom_de>
+    <nom_en>Italian</nom_en>
+    <nom_es>Italiano</nom_es>
+    <nom_pt>Italiano</nom_pt>
+    <parent>2649</parent>
+  </genre>
+  <genre>
+    <id>2894</id>
+    <nom_fr>Japonais</nom_fr>
+    <nom_de>Japanisch</nom_de>
+    <nom_en>Japanese</nom_en>
+    <nom_es>Japonés</nom_es>
+    <nom_pt>Japonês</nom_pt>
+    <parent>2649</parent>
+  </genre>
+  <genre>
+    <id>2964</id>
+    <nom_fr>Musical Anglais</nom_fr>
+    <nom_de>Englische Musik</nom_de>
+    <nom_en>Music English</nom_en>
+    <nom_es>Música Inglés</nom_es>
+    <nom_pt>Musical Inglês</nom_pt>
+    <parent>2649</parent>
+  </genre>
+  <genre>
+    <id>2967</id>
+    <nom_fr>Musical Japonais</nom_fr>
+    <nom_de>Japanische Musik</nom_de>
+    <nom_en>Music Japanese</nom_en>
+    <nom_es>Música Japonés</nom_es>
+    <nom_pt>Musical Japonês</nom_pt>
+    <parent>2649</parent>
+  </genre>
+  <genre>
+    <id>3511</id>
+    <nom_fr>Réflexion</nom_fr>
+    <nom_de>Überlegung</nom_de>
+    <nom_en>Reflection</nom_en>
+    <nom_es>Reflexión</nom_es>
+    <nom_pt>Reflexão</nom_pt>
+  </genre>
+  <genre>
+    <id>2956</id>
+    <nom_fr>Renju</nom_fr>
+    <nom_de>Renju</nom_de>
+    <nom_en>Renju</nom_en>
+    <nom_es>Renju</nom_es>
+    <nom_pt>Renju</nom_pt>
+    <parent>2647</parent>
+  </genre>
+  <genre>
+    <id>2925</id>
+    <nom_fr>Rythme</nom_fr>
+    <nom_de>Rythmus</nom_de>
+    <nom_en>Rhythm</nom_en>
+    <nom_es>Rítmico</nom_es>
+    <nom_pt>Rítmico</nom_pt>
+    <parent>425</parent>
+  </genre>
+  <genre>
+    <id>79</id>
+    <nom_fr>Shoot'em Up</nom_fr>
+    <nom_de>Shoot'em Up</nom_de>
+    <nom_en>Shoot'em Up</nom_en>
+    <nom_es>Shoot'em Up</nom_es>
+    <nom_pt>Shoot'em Up</nom_pt>
+  </genre>
+  <genre>
+    <id>2955</id>
+    <nom_fr>Diagonal</nom_fr>
+    <nom_de>Diagonal</nom_de>
+    <nom_en>Diagonal</nom_en>
+    <nom_es>Diagonal</nom_es>
+    <nom_pt>Diagonal</nom_pt>
+    <parent>79</parent>
+  </genre>
+  <genre>
+    <id>2870</id>
+    <nom_fr>Horizontal</nom_fr>
+    <nom_de>Horizontal</nom_de>
+    <nom_en>Horizontal</nom_en>
+    <nom_es>Horizontal</nom_es>
+    <nom_pt>Horizontal</nom_pt>
+    <parent>79</parent>
+  </genre>
+  <genre>
+    <id>2851</id>
+    <nom_fr>Vertical</nom_fr>
+    <nom_de>Vertikal</nom_de>
+    <nom_en>Vertical</nom_en>
+    <nom_es>Vertical</nom_es>
+    <nom_pt>Vertical</nom_pt>
+    <parent>79</parent>
+  </genre>
+  <genre>
+    <id>2844</id>
+    <nom_fr>Shooter Small</nom_fr>
+    <parent>2843</parent>
+  </genre>
+  <genre>
+    <id>2961</id>
+    <nom_fr>Shougi</nom_fr>
+    <nom_de>Shougi</nom_de>
+    <nom_en>Shougi</nom_en>
+    <nom_es>Shougi</nom_es>
+    <nom_pt>Shougi</nom_pt>
+    <parent>2647</parent>
+  </genre>
+  <genre>
+    <id>40</id>
+    <nom_fr>Simulation</nom_fr>
+    <nom_de>Simulation</nom_de>
+    <nom_en>Simulation</nom_en>
+    <nom_es>Simulación</nom_es>
+    <nom_pt>Simulação</nom_pt>    
+  </genre>
+  <genre>
+    <id>20702</id>
+    <nom_fr>Science Fiction</nom_fr>
+    <nom_en>SciFi</nom_en>
+    <nom_es>Ciencia Ficción</nom_es>
+    <parent>40</parent>
+  </genre>
+  <genre>
+    <id>20700</id>
+    <nom_fr>Véhicules</nom_fr>
+    <nom_en>Vehicle</nom_en>
+    <nom_es>Vehículos</nom_es>
+    <altname>VEHICLE SIMULATION</altname>
+    <parent>40</parent>
+  </genre>
+  <genre>
+    <id>20684</id>
+    <nom_fr>Vie</nom_fr>
+    <nom_de>Lebenssimulation</nom_de>
+    <nom_en>Life</nom_en>
+    <nom_es>Vida</nom_es>
+    <parent>40</parent>
+  </genre>
+  <genre>
+    <id>685</id>
+    <nom_fr>Sport</nom_fr>
+    <nom_de>Sport</nom_de>
+    <nom_en>Sports</nom_en>
+    <nom_es>Deportes</nom_es>
+    <nom_pt>Esporte</nom_pt>
+  </genre>
+  <genre>
+    <id>2853</id>
+    <nom_fr>Baseball</nom_fr>
+    <nom_de>Baseball</nom_de>
+    <nom_en>Baseball</nom_en>
+    <nom_es>Béisbol</nom_es>
+    <nom_pt>Baseball</nom_pt>
+    <parent>685</parent>
+  </genre>
+  <genre>
+    <id>2852</id>
+    <nom_fr>Basketball</nom_fr>
+    <nom_de>Basketball</nom_de>
+    <nom_en>Basketball</nom_en>
+    <nom_es>Baloncesto</nom_es>
+    <nom_pt>Basquete</nom_pt>
+    <parent>685</parent>
+  </genre>
+  <genre>
+    <id>3028</id>
+    <nom_fr>Billard</nom_fr>
+    <nom_de>Billard</nom_de>
+    <nom_en>Pool</nom_en>
+    <nom_es>Billar</nom_es>
+    <nom_pt>Sinuca</nom_pt>
+    <parent>685</parent>
+  </genre>
+  <genre>
+    <id>2901</id>
+    <nom_fr>Bowling</nom_fr>
+    <nom_de>Bowling</nom_de>
+    <nom_en>Bowling</nom_en>
+    <nom_es>Bowling</nom_es>
+    <nom_pt>Boliche</nom_pt>
+    <parent>685</parent>
+  </genre>
+  <genre>
+    <id>2929</id>
+    <nom_fr>Boxe</nom_fr>
+    <nom_de>Boxen</nom_de>
+    <nom_en>Boxing</nom_en>
+    <nom_es>Boxeo</nom_es>
+    <nom_pt>Boxe</nom_pt>
+    <parent>685</parent>
+  </genre>
+  <genre>
+    <id>2919</id>
+    <nom_fr>Bras de fer</nom_fr>
+    <nom_de>Armdrücken</nom_de>
+    <nom_en>Arm wrestling</nom_en>
+    <nom_es>Pulso</nom_es>
+    <nom_pt>Queda de Braço</nom_pt>
+    <parent>685</parent>
+  </genre>
+  <genre>
+    <id>3034</id>
+    <nom_fr>Combat</nom_fr>
+    <nom_de>Kampfsport</nom_de>
+    <nom_en>Fighting</nom_en>
+    <nom_es>Lucha</nom_es>
+    <nom_pt>Combate</nom_pt>
+    <altname>Fighting</altname>
+    <parent>685</parent>
+  </genre>
+  <genre>
+    <id>2877</id>
+    <nom_fr>Course a pied</nom_fr>
+    <nom_de>Traillauf</nom_de>
+    <nom_en>Running trails</nom_en>
+    <nom_es>Carrera en pista</nom_es>
+    <nom_pt>Pista de Corrida</nom_pt>
+    <parent>685</parent>
+  </genre>
+  <genre>
+    <id>2970</id>
+    <nom_fr>Dodgeball</nom_fr>
+    <nom_de>Völkerball</nom_de>
+    <nom_en>Dodgeball</nom_en>
+    <nom_es>Quemadas</nom_es>
+    <nom_pt>Queimada</nom_pt>
+    <parent>685</parent>
+  </genre>
+  <genre>
+    <id>2906</id>
+    <nom_fr>Flechette</nom_fr>
+    <nom_de>Darts</nom_de>
+    <nom_en>Dart</nom_en>
+    <nom_es>Dardos</nom_es>
+    <nom_pt>Dardos</nom_pt>
+    <altname>Sports / Darts</altname>
+    <parent>685</parent>
+  </genre>
+  <genre>
+    <id>2847</id>
+    <nom_fr>Football</nom_fr>
+    <nom_de>Fußball</nom_de>
+    <nom_en>Soccer</nom_en>
+    <nom_es>Fútbol</nom_es>
+    <nom_pt>Futebol</nom_pt>
+    <parent>685</parent>
+  </genre>
+  <genre>
+    <id>2846</id>
+    <nom_fr>Football Américain</nom_fr>
+    <nom_de>American Football</nom_de>
+    <nom_en>Football</nom_en>
+    <nom_es>Fútbol americano</nom_es>
+    <nom_pt>Futebol americano</nom_pt>
+    <parent>685</parent>
+  </genre>
+  <genre>
+    <id>2913</id>
+    <nom_fr>Golf</nom_fr>
+    <nom_de>Golf</nom_de>
+    <nom_en>Golf</nom_en>
+    <nom_es>Golf</nom_es>
+    <nom_pt>Golfe</nom_pt>
+    <parent>685</parent>
+  </genre>
+  <genre>
+    <id>2960</id>
+    <nom_fr>Handball</nom_fr>
+    <nom_de>Handball</nom_de>
+    <nom_en>Handball</nom_en>
+    <nom_es>Balonmano</nom_es>
+    <nom_pt>Handball</nom_pt>
+    <parent>685</parent>
+  </genre>
+  <genre>
+    <id>2933</id>
+    <nom_fr>Hockey</nom_fr>
+    <nom_de>Eishockey</nom_de>
+    <nom_en>Hockey</nom_en>
+    <nom_es>Hockey</nom_es>
+    <nom_pt>Hóquei</nom_pt>
+    <parent>685</parent>
+  </genre>
+  <genre>
+    <id>2971</id>
+    <nom_fr>Jeu de palet</nom_fr>
+    <nom_de>Shuffleboard</nom_de>
+    <nom_en>Shuffleboard</nom_en>
+    <nom_es>Juego de Tejo</nom_es>
+    <nom_pt>Futebol de botão</nom_pt>
+    <parent>685</parent>
+  </genre>
+  <genre>
+    <id>2861</id>
+    <nom_fr>Lutte</nom_fr>
+    <nom_de>Wrestling</nom_de>
+    <nom_en>Wrestling</nom_en>
+    <nom_es>Lucha libre</nom_es>
+    <nom_pt>Luta Livre</nom_pt>
+    <parent>685</parent>
+  </genre>
+  <genre>
+    <id>2878</id>
+    <nom_fr>Natation</nom_fr>
+    <nom_de>Schwimmen</nom_de>
+    <nom_en>Swimming</nom_en>
+    <nom_es>Natación</nom_es>
+    <nom_pt>Natação</nom_pt>
+    <parent>685</parent>
+  </genre>
+  <genre>
+    <id>2968</id>
+    <nom_fr>Parachutisme</nom_fr>
+    <nom_de>Fallschirmspringen</nom_de>
+    <nom_en>Skydiving</nom_en>
+    <nom_es>Paracaidismo</nom_es>
+    <nom_pt>Paraquedismo</nom_pt>
+    <parent>685</parent>
+  </genre>
+  <genre>
+    <id>2966</id>
+    <nom_fr>Ping pong</nom_fr>
+    <nom_de>Tischtennis</nom_de>
+    <nom_en>Table tennis</nom_en>
+    <nom_es>Ping-pong</nom_es>
+    <nom_pt>Ping-pong</nom_pt>
+    <parent>685</parent>
+  </genre>
+  <genre>
+    <id>2948</id>
+    <nom_fr>Rugby</nom_fr>
+    <nom_de>Rugby</nom_de>
+    <nom_en>Rugby</nom_en>
+    <nom_es>Rugby</nom_es>
+    <nom_pt>Rugby</nom_pt>
+    <parent>685</parent>
+  </genre>
+  <genre>
+    <id>2875</id>
+    <nom_fr>Skateboard</nom_fr>
+    <nom_de>Skateboard</nom_de>
+    <nom_en>Skateboard</nom_en>
+    <nom_es>Skate</nom_es>
+    <nom_pt>Skate</nom_pt>
+    <parent>685</parent>
+    <altname>Sports / Skateboarding</altname>
+  </genre>
+  <genre>
+    <id>2902</id>
+    <nom_fr>Ski</nom_fr>
+    <nom_de>Ski</nom_de>
+    <nom_en>Skiing</nom_en>
+    <nom_es>Esquí</nom_es>
+    <nom_pt>Esqui</nom_pt>
+    <parent>685</parent>
+  </genre>
+  <genre>
+    <id>2947</id>
+    <nom_fr>Sumo</nom_fr>
+    <nom_de>Sumo</nom_de>
+    <nom_en>Sumo</nom_en>
+    <nom_es>Sumo</nom_es>
+    <nom_pt>Sumô</nom_pt>
+    <parent>685</parent>
+  </genre>
+  <genre>
+    <id>2867</id>
+    <nom_fr>Tennis</nom_fr>
+    <nom_de>Tennis</nom_de>
+    <nom_en>Tennis</nom_en>
+    <nom_es>Tenis</nom_es>
+    <nom_pt>Tênis</nom_pt>
+    <parent>685</parent>
+  </genre>
+  <genre>
+    <id>2883</id>
+    <nom_fr>Volleyball</nom_fr>
+    <nom_de>Volleyball</nom_de>
+    <nom_en>Volleyball</nom_en>
+    <nom_es>Voleibol</nom_es>
+    <nom_pt>Voleibol</nom_pt>
+    <parent>685</parent>
+  </genre>
+  <genre>
+    <id>2650</id>
+    <nom_fr>Sport avec animaux</nom_fr>
+    <nom_de>Sport mit Tieren</nom_de>
+    <nom_en>Sports with Animals</nom_en>
+    <nom_es>Deportes con animales</nom_es>
+    <nom_pt>Esporte com animais</nom_pt>
+  </genre>
+  <genre>
+    <id>27</id>
+    <nom_fr>Stratégie</nom_fr>
+    <nom_de>Strategie</nom_de>
+    <nom_en>Strategy</nom_en>
+    <nom_es>Estrategia</nom_es>
+    <nom_pt>Estratégia</nom_pt>
+  </genre>
+  <genre>
+    <id>2646</id>
+    <nom_fr>Tir</nom_fr>
+    <nom_de>Shooter</nom_de>
+    <nom_en>Shooter</nom_en>
+    <nom_es>Shooter</nom_es>
+    <nom_pt>Tiro</nom_pt>
+  </genre>
+  <genre>
+    <id>3024</id>
+    <nom_fr>1ere Personne</nom_fr>
+    <nom_de>1st Pers.</nom_de>
+    <nom_en>1st person</nom_en>
+    <nom_es>1ª persona</nom_es>
+    <nom_pt>Tiro em 1ª pessoa</nom_pt>
+    <parent>2646</parent>
+  </genre>
+  <genre>
+    <id>2899</id>
+    <nom_fr>3eme Personne</nom_fr>
+    <nom_de>3rd Pers.</nom_de>
+    <nom_en>3rd person</nom_en>
+    <nom_es>3ª persona</nom_es>
+    <nom_pt>Tiro em 3ª pessoa</nom_pt>
+    <parent>2646</parent>
+  </genre>
+  <genre>
+    <id>2903</id>
+    <nom_fr>A pied</nom_fr>
+    <nom_de>Run and Shoot</nom_de>
+    <nom_en>Run and Shoot</nom_en>
+    <nom_es>Corre y Dispara</nom_es>
+    <nom_pt>Corra e Atire</nom_pt>
+    <parent>2646</parent>
+  </genre>
+  <genre>
+    <id>2928</id>
+    <nom_fr>Avion</nom_fr>
+    <nom_de>Flugzeug</nom_de>
+    <nom_en>Plane</nom_en>
+    <nom_es>Avión</nom_es>
+    <nom_pt>Avião</nom_pt>
+    <parent>2646</parent>
+  </genre>
+  <genre>
+    <id>2892</id>
+    <nom_fr>Avion, 1ere personne</nom_fr>
+    <nom_de>Flugzeug, 1st Pers.</nom_de>
+    <nom_en>Plane, 1st person</nom_en>
+    <nom_es>Avión, 1ª persona</nom_es>
+    <nom_pt>Avião em 1ª pessoa</nom_pt>
+    <parent>2646</parent>
+  </genre>
+  <genre>
+    <id>2881</id>
+    <nom_fr>Avion, 3eme personne</nom_fr>
+    <nom_de>Flugzeug, 3rd Pers.</nom_de>
+    <nom_en>Plane, 3rd person</nom_en>
+    <nom_es>Avión, 3ª persona</nom_es>
+    <nom_pt>Avião em 3ª pessoa</nom_pt>
+    <altname>FLIGHT SIMULATOR</altname>
+    <parent>2646</parent>
+  </genre>
+  <genre>
+    <id>2876</id>
+    <nom_fr>Horizontal</nom_fr>
+    <nom_de>Horizontal</nom_de>
+    <nom_en>Horizontal</nom_en>
+    <nom_es>Horizontal</nom_es>
+    <nom_pt>Horizontal</nom_pt>
+    <parent>2646</parent>
+  </genre>
+  <genre>
+    <id>2945</id>
+    <nom_fr>Missile Command Like</nom_fr>
+    <nom_de>Wie Missile Command</nom_de>
+    <nom_en>Missile Command Like</nom_en>
+    <nom_es>Estilo Missile Command</nom_es>
+    <nom_pt>Estilo Missile Command</nom_pt>
+    <parent>2646</parent>
+  </genre>
+  <genre>
+    <id>3026</id>
+    <nom_fr>Run and Gun</nom_fr>
+    <nom_de>Run and Gun</nom_de>
+    <nom_en>Run and Gun</nom_en>
+    <nom_es>Run and Gun</nom_es>
+    <nom_pt>Run and Gun</nom_pt>
+    <parent>2646</parent>
+  </genre>
+  <genre>
+    <id>2900</id>
+    <nom_fr>Space Invaders Like</nom_fr>
+    <nom_de>Wie Space Invaders</nom_de>
+    <nom_en>Space Invaders Like</nom_en>
+    <nom_es>Estilo Space Invader</nom_es>
+    <nom_pt>Estilo Space Invader</nom_pt>
+    <parent>2646</parent>
+  </genre>
+  <genre>
+    <id>2940</id>
+    <nom_fr>Véhicule, 1ere personne</nom_fr>
+    <nom_de>Fahrzeug, 1st Pers.</nom_de>
+    <nom_en>Vehicle, 1st person</nom_en>
+    <nom_es>Vehículo 1ª persona</nom_es>
+    <nom_pt>Carro 1ª Pessoa</nom_pt>
+    <parent>2646</parent>
+  </genre>
+  <genre>
+    <id>2910</id>
+    <nom_fr>Vehicule, 3eme personne</nom_fr>
+    <nom_de>Fahrzeug, 3rd. Pers.</nom_de>
+    <nom_en>Vehicle, 3rd person</nom_en>
+    <nom_es>Vehículo, 3ª persona</nom_es>
+    <nom_pt>Carro 3ª Pessoa</nom_pt>
+    <parent>2646</parent>
+  </genre>
+  <genre>
+    <id>2934</id>
+    <nom_fr>Véhicule, Diagonal</nom_fr>
+    <nom_de>Fahrzeug, Diagonal</nom_de>
+    <nom_en>Vehicle, Diagonal</nom_en>
+    <nom_es>Vehículo, Diagonal</nom_es>
+    <nom_pt>Carro, Diagonal</nom_pt>
+    <parent>2646</parent>
+  </genre>
+  <genre>
+    <id>2938</id>
+    <nom_fr>Véhicule, Horizontal</nom_fr>
+    <nom_de>Fahrzeug, Horizontal</nom_de>
+    <nom_en>Vehicle, Horizontal</nom_en>
+    <nom_es>Vehículo, Horizontal</nom_es>
+    <nom_pt>Carro, Horizontal</nom_pt>
+    <parent>2646</parent>
+  </genre>
+  <genre>
+    <id>2921</id>
+    <nom_fr>Véhicule, Vertical</nom_fr>
+    <nom_de>Fahrzeug, Vertikal</nom_de>
+    <nom_en>Vehicle, Vertical</nom_en>
+    <nom_es>Vehículo, Vertical</nom_es>
+    <nom_pt>Carro, Vertical</nom_pt>
+    <parent>2646</parent>
+  </genre>
+  <genre>
+    <id>2889</id>
+    <nom_fr>Vertical</nom_fr>
+    <nom_de>Vertikal</nom_de>
+    <nom_en>Vertical</nom_en>
+    <nom_es>Vertical</nom_es>
+    <nom_pt>Vertical</nom_pt>
+    <altname>Shooter / Flying Vertical</altname>
+    <parent>2646</parent>
+  </genre>
+  <genre>
+    <id>32</id>
+    <nom_fr>Tir avec accessoire</nom_fr>
+    <nom_de>Lightgun Shooter</nom_de>
+    <nom_en>Lightgun Shooter</nom_en>
+    <nom_es>Lightgun Shooter</nom_es>
+    <nom_pt>Tiro com acessórios</nom_pt>
+  </genre>
+</genres>


### PR DESCRIPTION
Note : Bump the theme before the next RC, please

- Fix crash when adding collections to 'custom-collections'
- Add & scrape 'Family' Metadata
- Rationalize Genres using xml file based on screenscraper genres.
- Add 'per genre' auto collections
- Allow auto collections without theme to be grouped in 'custom-collections'
- Fix : Delete game visible in Kid/Kiosk mode.
- Fix : Magazines can't be read if there is no manual.
- Fix : image.default still visible when 'DetailsForFolder' is active
- Add better Randomizer for random operations
