### PR TITLE
Themes : Add support for ifArch/ifNotArch attributes -> Allow filtering elements/subsets by board to optimize slow boards

### DIFF
--- a/es-app/src/Win32ApiSystem.h
+++ b/es-app/src/Win32ApiSystem.h
@@ -54,6 +54,7 @@ protected:
 
 private:
 	void updateEmulatorLauncher(const std::function<void(const std::string)>& func);
+	void installEmulationStationZip(const std::string& zipFile);
 };
 
 

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -79,10 +79,10 @@
 #define fake_gettext_flatten_glow	_("FLATTEN-GLOW")
 #define fake_gettext_rgascaling		_("RGA SCALING")
 
-#define fake_gettext_glvendor		_("GL VENDOR")
-#define fake_gettext_glvrenderer	_("GL RENDERER")
-#define fake_gettext_glversion		_("GL VERSION")
-#define fake_gettext_glslversion	_("GLSL VERSION")
+#define fake_gettext_glvendor		_("VENDOR")
+#define fake_gettext_glvrenderer	_("RENDERER")
+#define fake_gettext_glversion		_("VERSION")
+#define fake_gettext_glslversion	_("SHADERS")
 
 GuiMenu::GuiMenu(Window *window, bool animate) : GuiComponent(window), mMenu(window, _("MAIN MENU").c_str()), mVersion(window)
 {
@@ -613,6 +613,8 @@ void GuiMenu::openSystemInformations_batocera()
 	bool isFullUI = UIModeController::getInstance()->isUIModeFull();
 	GuiSettings *informationsGui = new GuiSettings(window, _("INFORMATION").c_str());
 
+	informationsGui->addGroup(_("INFORMATIONS"));
+
 	auto version = std::make_shared<TextComponent>(window, ApiSystem::getInstance()->getVersion(), font, color);
 	informationsGui->addWithLabel(_("VERSION"), version);
 
@@ -629,11 +631,7 @@ void GuiMenu::openSystemInformations_batocera()
 		color);
 	informationsGui->addWithLabel(_("SYSTEM DISK USAGE"), systemspace);
 	
-	for (auto info : Renderer::getDriverInformation())
-	{
-		auto glversion = std::make_shared<TextComponent>(window, info.second, font, color);
-		informationsGui->addWithLabel(_(info.first.c_str()), glversion);
-	}
+	informationsGui->addGroup(_("SYSTEM"));
 
 	// various informations
 	std::vector<std::string> infos = ApiSystem::getInstance()->getSystemInformations();
@@ -656,6 +654,13 @@ void GuiMenu::openSystemInformations_batocera()
 		}
 	}
 	
+	informationsGui->addGroup(_("VIDEO DRIVER"));
+	for (auto info : Renderer::getDriverInformation())
+	{
+		auto glversion = std::make_shared<TextComponent>(window, info.second, font, color);
+		informationsGui->addWithLabel(_(info.first.c_str()), glversion);
+	}
+
 	window->pushGui(informationsGui);
 }
 

--- a/es-core/src/Splash.cpp
+++ b/es-core/src/Splash.cpp
@@ -36,7 +36,10 @@ Splash::Splash(Window* window, const std::string image, bool fullScreenBackGroun
 	if (Utils::FileSystem::exists(themeFilePath))
 	{
 		std::map<std::string, std::string> sysData;
-		theme->loadFile("splash", sysData, themeFilePath);
+
+		try { theme->loadFile("splash", sysData, themeFilePath); }
+		catch(...) { }
+		
 		useOldSplashLayout = false;
 	}
 

--- a/es-core/src/ThemeData.cpp
+++ b/es-core/src/ThemeData.cpp
@@ -1022,6 +1022,39 @@ bool ThemeData::parseFilterAttributes(const pugi::xml_node& node)
 			return false;
 	}
 
+	if (node.attribute("ifArch"))
+	{
+		std::string arch = getArchString();
+		if (!arch.empty())
+		{
+			const std::string ifBoard = Utils::String::toLower(node.attribute("ifArch").as_string());
+
+			bool hasValue = false;
+			auto values = Utils::String::splitAny(Utils::String::trim(ifBoard), ",|", true);
+			for (auto value : values)
+				if (arch == value)
+					hasValue = true;
+
+			if (!hasValue)
+				return false;
+		}
+	}
+
+	if (node.attribute("ifNotArch"))
+	{
+		std::string arch = getArchString();
+		if (!arch.empty())
+		{
+			const std::string ifBoard = Utils::String::toLower(node.attribute("ifNotArch").as_string());
+
+			auto values = Utils::String::splitAny(Utils::String::trim(ifBoard), "|,", true);
+			for (auto value : values)
+				if (arch == value)
+					return false;
+		}
+	}
+
+
 	if (node.attribute("ifSubset"))
 	{
 		const std::string ifSubset = node.attribute("ifSubset").as_string();

--- a/es-core/src/platform.cpp
+++ b/es-core/src/platform.cpp
@@ -367,3 +367,97 @@ BatteryInformation queryBatteryInformation()
 
 	return ret;
 }
+
+
+std::string getArchString()
+{
+#if WIN32
+	return "windows";
+#endif
+
+#if X86
+	return "x86";
+#endif
+
+#if X86_64
+	return "x86_64";
+#endif
+
+#if RPI1
+	return "rpi1";
+#endif
+
+#if RPI2
+	return "rpi2";
+#endif
+
+#if RPI3
+	return "rpi3";
+#endif
+
+#if RPI4
+	return "rpi4";
+#endif
+
+#if ODROIDGOA
+	return "odroidgoa";
+#endif
+
+#if ODROIDXU4
+	return "odroidxu4";
+#endif
+
+#if ODROIDC2
+	return "odroidc2";
+#endif
+
+#if ODROIDC4
+	return "odroidc4";
+#endif
+
+#if TINKERBOARD
+	return "tinkerboard";
+#endif
+
+#if RK3399
+	return "rk3399";
+#endif
+
+#if MIQI
+	return "miqi";
+#endif
+
+#if LIBRETECH_H5
+	return "libretech_h5";
+#endif
+
+#if ORANGEPI_ZERO2
+	return "orangepi_zero2";
+#endif
+
+#if ORANGEPI_PC
+	return "orangepi_pc";
+#endif
+
+#if S812
+	return "s812";
+#endif
+
+#if S922X
+	return "s922x";
+#endif
+
+#if S905
+	return "s905";
+#endif
+
+#if S905GEN3
+	return "s905gen3";
+#endif
+
+#if S912
+	return "s912";
+#endif
+
+	return "";
+}

--- a/es-core/src/platform.h
+++ b/es-core/src/platform.h
@@ -45,4 +45,6 @@ struct BatteryInformation
 BatteryInformation queryBatteryInformation();
 std::string queryIPAdress();
 
+std::string getArchString();
+
 #endif // ES_CORE_PLATFORM_H

--- a/es-core/src/renderers/Renderer_GL21.cpp
+++ b/es-core/src/renderers/Renderer_GL21.cpp
@@ -84,17 +84,19 @@ namespace Renderer
 	{
 		std::vector<std::pair<std::string, std::string>> info;
 
+		info.push_back(std::pair<std::string, std::string>("GRAPHICS API", "DESKTOP OPENGL 2.1"));
+
 		const std::string vendor = glGetString(GL_VENDOR) ? (const char*)glGetString(GL_VENDOR) : "";
 		if (!vendor.empty())
-			info.push_back(std::pair<std::string, std::string>("GL VENDOR", vendor));
+			info.push_back(std::pair<std::string, std::string>("VENDOR", vendor));
 
 		const std::string renderer = glGetString(GL_RENDERER) ? (const char*)glGetString(GL_RENDERER) : "";
 		if (!renderer.empty())
-			info.push_back(std::pair<std::string, std::string>("GL RENDERER", renderer));
+			info.push_back(std::pair<std::string, std::string>("RENDERER", renderer));
 
 		const std::string version = glGetString(GL_VERSION) ? (const char*)glGetString(GL_VERSION) : "";
 		if (!version.empty())
-			info.push_back(std::pair<std::string, std::string>("GL VERSION", version));
+			info.push_back(std::pair<std::string, std::string>("VERSION", version));
 
 		return info;
 	}

--- a/es-core/src/renderers/Renderer_GLES10.cpp
+++ b/es-core/src/renderers/Renderer_GLES10.cpp
@@ -80,17 +80,19 @@ namespace Renderer
 	{
 		std::vector<std::pair<std::string, std::string>> info;
 
+		info.push_back(std::pair<std::string, std::string>("GRAPHICS API", "OPENGL ES 1.0"));
+
 		const std::string vendor = glGetString(GL_VENDOR) ? (const char*)glGetString(GL_VENDOR) : "";
 		if (!vendor.empty())
-			info.push_back(std::pair<std::string, std::string>("GL VENDOR", vendor));
+			info.push_back(std::pair<std::string, std::string>("VENDOR", vendor));
 
 		const std::string renderer = glGetString(GL_RENDERER) ? (const char*)glGetString(GL_RENDERER) : "";
 		if (!renderer.empty())
-			info.push_back(std::pair<std::string, std::string>("GL RENDERER", renderer));
+			info.push_back(std::pair<std::string, std::string>("RENDERER", renderer));
 
 		const std::string version = glGetString(GL_VERSION) ? (const char*)glGetString(GL_VERSION) : "";
 		if (!version.empty())
-			info.push_back(std::pair<std::string, std::string>("GL VERSION", version));
+			info.push_back(std::pair<std::string, std::string>("VERSION", version));
 
 		return info;
 	}

--- a/es-core/src/resources/TextureData.cpp
+++ b/es-core/src/resources/TextureData.cpp
@@ -334,13 +334,13 @@ bool TextureData::uploadAndBind()
 
 		// Upload texture
 		mTextureID = Renderer::createTexture(Renderer::Texture::RGBA, mLinear, mTile, mWidth, mHeight, mDataRGBA);
-		if (mTextureID)
-		{
-			if (mDataRGBA != nullptr && !mIsExternalDataRGBA)
-				delete[] mDataRGBA;
+		if (mTextureID == 0)
+			return false;
 
-			mDataRGBA = nullptr;
-		}
+		if (mDataRGBA != nullptr && !mIsExternalDataRGBA)
+			delete[] mDataRGBA;
+
+		mDataRGBA = nullptr;
 	}
 
 	return true;


### PR DESCRIPTION
NOTE : Please bump the theme, I added ifArch/ifNotArch attributes to deactivate some things for slow boards.

+ Add ES Video renderer information 
+ better organisation of information screen
+ Splash : Fix crash when gamesplash.xml is invalid 
+ Win32 only / Retrobat : if es-update script last line is a zip file, uncompress it using internal ES installer

