### PR TITLE
quit from thread should not call exit

### DIFF
--- a/es-core/src/VolumeControl.cpp
+++ b/es-core/src/VolumeControl.cpp
@@ -105,8 +105,7 @@ public:
 private:
 	static void quit(void* userdata, int code)
 	{
-		PulseAudioControl* pThis = (PulseAudioControl*)userdata;		
-		pThis->exit();
+		PulseAudioControl* pThis = (PulseAudioControl*)userdata;
 	}
 
 	static void simple_callback(pa_context *c, int success, void *userdata) 


### PR DESCRIPTION
otherwise... when restarting pw, it crashes

Signed-off-by: Nicolas Adenis-Lamarre <nicolas.adenis.lamarre@gmail.com>