### PR TITLE
exit on reboot required

### DIFF
--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -734,8 +734,12 @@ void GuiMenu::openDeveloperSettings()
 	s->addWithDescription(_("ENABLE PUBLIC WEB ACCESS"), Utils::String::format(_("Allow public web access API using %s").c_str(), std::string("http://" + hostName + ":1234").c_str()), webAccess);
 	s->addSaveFunc([webAccess, window]
 	{ 
-		if (Settings::getInstance()->setBool("PublicWebAccess", webAccess->getState()))
-			window->displayNotificationMessage(_U("\uF011  ") + _("A REBOOT OF THE SYSTEM IS REQUIRED TO APPLY THE NEW CONFIGURATION"));
+	  if (Settings::getInstance()->setBool("PublicWebAccess", webAccess->getState())) {
+	    window->displayNotificationMessage(_U("\uF011  ") + _("A REBOOT OF THE SYSTEM IS REQUIRED TO APPLY THE NEW CONFIGURATION"));
+	    if (Settings::getInstance()->getBool("ExitOnRebootRequired")) {
+	      quitES(QuitMode::QUIT);
+	    }
+	  }
 	});
 
 
@@ -1353,6 +1357,9 @@ void GuiMenu::openSystemSettings_batocera()
 			SystemConf::getInstance()->set("global.videooutput", optionsVideo->getSelected());
 			SystemConf::getInstance()->saveSystemConf();
 			mWindow->displayNotificationMessage(_U("\uF011  ") + _("A REBOOT OF THE SYSTEM IS REQUIRED TO APPLY THE NEW CONFIGURATION"));
+			if (Settings::getInstance()->getBool("ExitOnRebootRequired")) {
+			  quitES(QuitMode::QUIT);
+			}
 		}
 	});
 
@@ -1596,8 +1603,9 @@ void GuiMenu::openSystemSettings_batocera()
 				reboot = true;
 			}
 
-			if (reboot)
-				window->displayNotificationMessage(_U("\uF011  ") + _("A REBOOT OF THE SYSTEM IS REQUIRED TO APPLY THE NEW CONFIGURATION"));
+			if (reboot) {
+			  window->displayNotificationMessage(_U("\uF011  ") + _("A REBOOT OF THE SYSTEM IS REQUIRED TO APPLY THE NEW CONFIGURATION"));
+			}
 		});
 		mWindow->pushGui(securityGui);
 	});
@@ -1609,6 +1617,7 @@ void GuiMenu::openSystemSettings_batocera()
 	s->addSaveFunc([overclock_choice, window, language_choice, language, optionsStorage, selectedStorage, s] 
 	{
 		bool reboot = false;
+		bool rebootForLanguage = false;
 		if (optionsStorage->changed()) 
 		{
 			ApiSystem::getInstance()->setStorage(optionsStorage->getSelected());
@@ -1631,12 +1640,20 @@ void GuiMenu::openSystemSettings_batocera()
 				s->setVariable("reloadGuiMenu", true);
 #ifdef HAVE_INTL
 				reboot = true;
+				rebootForLanguage = true;
 #endif
 			}			
 		}
 
-		if (reboot)
-			window->displayNotificationMessage(_U("\uF011  ") + _("A REBOOT OF THE SYSTEM IS REQUIRED TO APPLY THE NEW CONFIGURATION"));
+		if (reboot) {
+		  window->displayNotificationMessage(_U("\uF011  ") + _("A REBOOT OF THE SYSTEM IS REQUIRED TO APPLY THE NEW CONFIGURATION"));
+
+		  if(rebootForLanguage) {
+		    if (Settings::getInstance()->getBool("ExitOnRebootRequired")) {
+		      quitES(QuitMode::QUIT);
+		    }
+		  }
+		}
 
 	});
 

--- a/es-app/src/main.cpp
+++ b/es-app/src/main.cpp
@@ -156,6 +156,9 @@ bool parseArgs(int argc, char* argv[])
 		}else if(strcmp(argv[i], "--no-exit") == 0)
 		{
 			Settings::getInstance()->setBool("ShowExit", false);
+		}else if(strcmp(argv[i], "--exit-on-reboot-required") == 0)
+		{
+			Settings::getInstance()->setBool("ExitOnRebootRequired", true);
 		}else if(strcmp(argv[i], "--no-splash") == 0)
 		{
 			Settings::getInstance()->setBool("SplashScreen", false);

--- a/es-core/src/Settings.cpp
+++ b/es-core/src/Settings.cpp
@@ -24,6 +24,7 @@ std::vector<const char*> settings_dont_save {
 	{ "IgnoreGamelist" },
 	{ "HideConsole" },
 	{ "ShowExit" },
+	{ "ExitOnRebootRequired" },
 	{ "SplashScreen" },
 	{ "SplashScreenProgress" },
 	// { "VSync" },
@@ -65,6 +66,7 @@ void Settings::setDefaults()
 	mBoolMap["ShowParentFolder"] = true;
 	mBoolMap["DrawFramerate"] = false;
 	mBoolMap["ShowExit"] = true;
+	mBoolMap["ExitOnRebootRequired"] = false;
 	mBoolMap["Windowed"] = false;
 	mBoolMap["SplashScreen"] = true;
 	mBoolMap["SplashScreenProgress"] = true;


### PR DESCRIPTION
on batocera side, i'll add a script to restart es in case of crash
to avoid the incidence of the black screen,
+ for some options, like language, video output, we can just restart es
so that it is taken immediatly. unfortunnatly, it is not perfectly consistent :
for example, i don't do it on the secure option or overclocking options while
a real reboot is required for them.

Signed-off-by: Nicolas Adenis-Lamarre <nicolas.adenis.lamarre@gmail.com>