### PR TITLE
Do not group systems for PER SYSTEM ADVANCED CONFIGURATION

### DIFF
--- a/es-app/src/FileData.cpp
+++ b/es-app/src/FileData.cpp
@@ -776,7 +776,7 @@ const std::vector<FileData*> FolderData::getChildrenListToDisplay()
 	auto sys = CollectionSystemManager::get()->getSystemToView(mSystem);
 
 	std::vector<std::string> hiddenExts;
-	if (!mSystem->isGroupSystem() && !mSystem->isCollection())
+	if (mSystem->isGameSystem() && !mSystem->isCollection())
 		for (auto ext : Utils::String::split(Settings::getInstance()->getString(mSystem->getName() + ".HiddenExt"), ';'))	
 			hiddenExts.push_back("." + Utils::String::toLower(ext));
 	
@@ -979,7 +979,7 @@ std::vector<FileData*> FolderData::getFilesRecursive(unsigned int typeMask, bool
 	SystemData* pSystem = (system != nullptr ? system : mSystem);
 
 	std::vector<std::string> hiddenExts;
-	if (!pSystem->isGroupSystem() && !pSystem->isCollection())
+	if (pSystem->isGameSystem() && !pSystem->isCollection())
 		for (auto ext : Utils::String::split(Settings::getInstance()->getString(pSystem->getName() + ".HiddenExt"), ';'))
 			hiddenExts.push_back("." + Utils::String::toLower(ext));
 

--- a/es-app/src/FileFilterIndex.cpp
+++ b/es-app/src/FileFilterIndex.cpp
@@ -912,7 +912,7 @@ bool CollectionFilter::createFromSystem(const std::string name, SystemData* syst
 
 	mSystemFilter.clear();
 
-	if (system != nullptr && !system->isCollection() && !system->isGroupSystem() && system->getName() != "all")
+	if (system != nullptr && !system->isCollection() && system->isGameSystem() && system->getName() != "all")
 		mSystemFilter.insert(system->getName());
 
 	resetIndex();

--- a/es-app/src/SystemData.cpp
+++ b/es-app/src/SystemData.cpp
@@ -54,7 +54,7 @@ SystemData::SystemData(const SystemMetadata& meta, SystemEnvironmentData* envDat
 	loadFeatures();
 
 	// if it's an actual system, initialize it, if not, just create the data structure
-	if (!mIsCollectionSystem && !mIsGroupSystem)
+	if (!mIsCollectionSystem && mIsGameSystem)
 	{
 		mRootFolder = new FolderData(mEnvData->mStartPath, this);
 		mRootFolder->getMetadata().set(MetaDataId::Name, mMetadata.fullName);
@@ -1787,7 +1787,7 @@ bool SystemData::isNetplaySupported()
 			if (core.netplay)
 				return true;
 
-	if (isGroupSystem())
+	if (!isGameSystem())
 		return false;
 
 	if (!SystemData::es_features_loaded)

--- a/es-app/src/guis/GuiGameOptions.cpp
+++ b/es-app/src/guis/GuiGameOptions.cpp
@@ -359,7 +359,7 @@ GuiGameOptions::GuiGameOptions(Window* window, FileData* game) : GuiComponent(wi
 		if (ApiSystem::getInstance()->isScriptingSupported(ApiSystem::GAMESETTINGS))
 		{
 			auto srcSystem = game->getSourceFileData()->getSystem();
-			auto sysOptions = mSystem->isGroupSystem() ? srcSystem : mSystem;
+			auto sysOptions = !mSystem->isGameSystem() ? srcSystem : mSystem;
 
 			if (game->getType() != FOLDER)
 			{

--- a/es-app/src/guis/GuiGamelistFilter.cpp
+++ b/es-app/src/guis/GuiGamelistFilter.cpp
@@ -207,7 +207,7 @@ void GuiGamelistFilter::addSystemFilterToMenu()
 	mSystemFilter = std::make_shared<OptionListComponent<SystemData*>>(mWindow, _("SYSTEMS"), true);
 	
 	for (auto system : SystemData::sSystemVector)
-		if (!system->isCollection() && !system->isGroupSystem())
+		if (!system->isCollection() && system->isGameSystem())
 			mSystemFilter->add(system->getFullName(), system, cf->isSystemSelected(system->getName()));
 
 	mMenu.addWithLabel(_("SYSTEMS"), mSystemFilter);
@@ -234,7 +234,7 @@ void GuiGamelistFilter::applyFilters()
 		{
 			for (auto system : SystemData::sSystemVector)
 			{
-				if (system->isCollection() || system->isGroupSystem())
+				if (system->isCollection() || !system->isGameSystem())
 					continue;
 
 				bool sel = std::find(sys.cbegin(), sys.cend(), system) != sys.cend();

--- a/es-app/src/guis/GuiGamelistOptions.cpp
+++ b/es-app/src/guis/GuiGamelistOptions.cpp
@@ -296,7 +296,7 @@ GuiGamelistOptions::GuiGamelistOptions(Window* window, IGameListView* gamelist, 
 		if (!fromPlaceholder)
 		{
 			auto srcSystem = file->getSourceFileData()->getSystem();
-			auto sysOptions = mSystem->isGroupSystem() ? srcSystem : mSystem;
+			auto sysOptions = !mSystem->isGameSystem() ? srcSystem : mSystem;
 
 			bool showSystemOptions = ApiSystem::getInstance()->isScriptingSupported(ApiSystem::GAMESETTINGS) && (sysOptions->hasFeatures() || sysOptions->hasEmulatorSelection());
 			/*

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -871,7 +871,7 @@ void GuiMenu::openDeveloperSettings()
 		{
 			for (auto system : SystemData::sSystemVector)
 			{
-				if (system->isCollection() || system->isGroupSystem())
+				if (system->isCollection() || !system->isGameSystem())
 					continue;
 
 				for (auto game : system->getRootFolder()->getFilesRecursive(GAME))
@@ -2155,7 +2155,7 @@ void GuiMenu::openGamesSettings_batocera()
 		std::vector<SystemData *> systems = SystemData::sSystemVector;
 		for (auto system : systems)
 		{
-			if (system->isCollection() || system->isGroupSystem())
+			if (system->isCollection() || !system->isGameSystem())
 				continue;
 
 			if (system->hasPlatformId(PlatformIds::PLATFORM_IGNORE))
@@ -2919,7 +2919,7 @@ void GuiMenu::openThemeConfiguration(Window* mWindow, GuiComponent* s, std::shar
 		
 
 		// File extensions
-		if (!system->isCollection() && !system->isGroupSystem())
+		if (!system->isCollection() && system->isGameSystem())
 		{
 			auto hiddenExts = Utils::String::split(Settings::getInstance()->getString(system->getName() + ".HiddenExt"), ';');
 

--- a/es-app/src/guis/GuiScraperStart.cpp
+++ b/es-app/src/guis/GuiScraperStart.cpp
@@ -40,7 +40,7 @@ GuiScraperStart::GuiScraperStart(Window* window) : GuiComponent(window),
 	mSystems = std::make_shared< OptionListComponent<SystemData*> >(mWindow, _("SCRAPE THESE SYSTEMS"), true); // batocera
 	for (auto it = SystemData::sSystemVector.cbegin(); it != SystemData::sSystemVector.cend(); it++)
 	{
-		if ((*it)->isGroupSystem())
+		if (!(*it)->isGameSystem())
 			continue;
 
 		if ((*it)->hasPlatformId(PlatformIds::PLATFORM_IGNORE))

--- a/es-app/src/services/HttpServerThread.cpp
+++ b/es-app/src/services/HttpServerThread.cpp
@@ -502,7 +502,7 @@ void HttpServerThread::run()
 
 		for (auto system : SystemData::sSystemVector)
 		{
-			if (system->isCollection() || system->isGroupSystem())
+			if (system->isCollection() || !system->isGameSystem())
 				continue;
 
 			for (auto file : system->getRootFolder()->getFilesRecursive(GAME))

--- a/es-app/src/views/gamelist/BasicGameListView.cpp
+++ b/es-app/src/views/gamelist/BasicGameListView.cpp
@@ -52,7 +52,7 @@ void BasicGameListView::onFileChanged(FileData* file, FileChangeType change)
 
 void BasicGameListView::populateList(const std::vector<FileData*>& files)
 {
-	SystemData* system = mCursorStack.size() && mRoot->getSystem()->isGroupSystem() ? mCursorStack.top()->getSystem() : mRoot->getSystem();
+	SystemData* system = mCursorStack.size() && !mRoot->getSystem()->isGameSystem() ? mCursorStack.top()->getSystem() : mRoot->getSystem();
 
 	auto groupTheme = system->getTheme();
 	if (groupTheme && mHeaderImage.hasImage())

--- a/es-app/src/views/gamelist/CarouselGameListView.cpp
+++ b/es-app/src/views/gamelist/CarouselGameListView.cpp
@@ -65,7 +65,7 @@ void CarouselGameListView::onFileChanged(FileData* file, FileChangeType change)
 
 void CarouselGameListView::populateList(const std::vector<FileData*>& files)
 {
-	SystemData* system = mCursorStack.size() && mRoot->getSystem()->isGroupSystem() ? mCursorStack.top()->getSystem() : mRoot->getSystem();
+	SystemData* system = mCursorStack.size() && !mRoot->getSystem()->isGameSystem() ? mCursorStack.top()->getSystem() : mRoot->getSystem();
 
 	auto groupTheme = system->getTheme();
 	if (groupTheme && mHeaderImage.hasImage())

--- a/es-app/src/views/gamelist/DetailedContainer.cpp
+++ b/es-app/src/views/gamelist/DetailedContainer.cpp
@@ -761,7 +761,7 @@ void DetailedContainer::updateControls(FileData* file, bool isClearing, int move
 			SystemConf::getInstance()->getBool("global.retroachievements") && (
 			file->getSourceFileData()->getSystem()->isCheevosSupported() || 
 			file->getSystem()->isCollection() || 
-			file->getSystem()->isGroupSystem()); // Fake cheevos supported if the game is in a collection cuz there are lot of games from different systems
+			!file->getSystem()->isGameSystem()); // Fake cheevos supported if the game is in a collection cuz there are lot of games from different systems
 
 		// Cheevos
 		if (mCheevos != nullptr)

--- a/es-app/src/views/gamelist/GameNameFormatter.cpp
+++ b/es-app/src/views/gamelist/GameNameFormatter.cpp
@@ -87,9 +87,9 @@ GameNameFormatter::GameNameFormatter(SystemData* system)
 		mSortId == FileSorts::RELEASEDATE_SYSTEM_ASCENDING ||
 		mSortId == FileSorts::RELEASEDATE_SYSTEM_DESCENDING;
 
-	mShowSystemName = (system->isGroupSystem() || system->isCollection()) && Settings::getInstance()->getBool("CollectionShowSystemInfo");
+	mShowSystemName = (!system->isGameSystem() || system->isCollection()) && Settings::getInstance()->getBool("CollectionShowSystemInfo");
 
-	if (mShowSystemName && system->isGroupSystem() && system->getFolderViewMode() != "never")
+	if (mShowSystemName && !system->isGameSystem() && system->getFolderViewMode() != "never")
 		mShowSystemName = false;
 }
 
@@ -110,7 +110,7 @@ std::string GameNameFormatter::getDisplayName(FileData* fd, bool showFolderIcon)
 	{
 		if (fd->getSystem()->isGroupChildSystem())
 			showSystemNameByFile = fd->getSystem()->getRootFolder()->getChildren().size() > 1;
-		else if (fd->getSystem()->isGroupSystem())
+		else if (!fd->getSystem()->isGameSystem())
 			showSystemNameByFile = false;
 	}
 

--- a/es-app/src/views/gamelist/GridGameListView.cpp
+++ b/es-app/src/views/gamelist/GridGameListView.cpp
@@ -144,7 +144,7 @@ const bool GridGameListView::isVirtualFolder(FileData* file)
 
 void GridGameListView::populateList(const std::vector<FileData*>& files)
 {
-	SystemData* system = mCursorStack.size() && mRoot->getSystem()->isGroupSystem() ? mCursorStack.top()->getSystem() : mRoot->getSystem();
+	SystemData* system = mCursorStack.size() && !mRoot->getSystem()->isGameSystem() ? mCursorStack.top()->getSystem() : mRoot->getSystem();
 
 	auto groupTheme = system->getTheme();
 	if (groupTheme && mHeaderImage.hasImage())


### PR DESCRIPTION
Fixes Nintendo Entertainment System and Sega Megadrive not being shown in "GAMES SETTINGS" - "PER SYSTEM ADVANCED CONFIGURATION" menu.

Nintendo Entertainment System has the same group as Famicom Disk System and was hidden in "PER SYSTEM ADVANCED CONFIGURATION" menu. Settings for Famicom Disk System had no impact on Nintendo Entertainment System games because different setting prefixes in batocera.conf