### PR TITLE
Add ui setting to ignore leading articles when sorting

### DIFF
--- a/es-app/src/FileSorts.h
+++ b/es-app/src/FileSorts.h
@@ -81,5 +81,7 @@ namespace FileSorts
 
 	bool compareSystemReleaseYear(const FileData* file1, const FileData* file2);
 	bool compareReleaseYearSystem(const FileData* file1, const FileData* file2);
+
+	std::string stripLeadingArticle(const std::string &string, const std::vector<std::string> &articles);
 };
 #endif // ES_APP_FILE_SORTS_H

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -3403,6 +3403,16 @@ void GuiMenu::openUISettings()
 		}
 	});
 	
+	auto ignoreArticles = std::make_shared<SwitchComponent>(mWindow);
+	ignoreArticles->setState(Settings::getInstance()->getBool("IgnoreLeadingArticles"));
+	s->addWithLabel(_("IGNORE LEADING ARTICLES WHEN SORTING"), ignoreArticles);
+	s->addSaveFunc([s, ignoreArticles]
+	{
+		if (Settings::getInstance()->setBool("IgnoreLeadingArticles", ignoreArticles->getState()))
+		{
+			s->setVariable("reloadAll", true);
+		}
+	});
 
 	s->onFinalize([s, pthis, window]
 	{

--- a/es-core/src/Settings.cpp
+++ b/es-core/src/Settings.cpp
@@ -7,6 +7,7 @@
 #include <pugixml/src/pugixml.hpp>
 #include <algorithm>
 #include <vector>
+#include "utils/StringUtil.h"
 
 bool Settings::DebugText = false;
 bool Settings::DebugImage = false;
@@ -64,6 +65,7 @@ void Settings::setDefaults()
 	mBoolMap["ParseGamelistOnly"] = false;
 	mBoolMap["ShowHiddenFiles"] = false;
 	mBoolMap["ShowParentFolder"] = true;
+	mBoolMap["IgnoreLeadingArticles"] = false;
 	mBoolMap["DrawFramerate"] = false;
 	mBoolMap["ShowExit"] = true;
 	mBoolMap["ExitOnRebootRequired"] = false;

--- a/es-core/src/Settings.h
+++ b/es-core/src/Settings.h
@@ -4,6 +4,7 @@
 
 #include <map>
 #include <string>
+#include <vector>
 
 #define DEFINE_BOOL_SETTING(name) static bool name() { return Settings::getInstance()->getBool(#name); }
 #define DEFINE_STRING_SETTING(name) static std::string name() { return Settings::getInstance()->getString(#name); }

--- a/es-core/src/utils/StringUtil.cpp
+++ b/es-core/src/utils/StringUtil.cpp
@@ -487,6 +487,11 @@ namespace Utils
 
 		} // vectorToCommaString
 
+		stringVector commaStringToVector(const std::string& _string)
+		{
+			return Utils::String::split(_string, ',', false);
+		}
+
 		std::string format(const char* _format, ...)
 		{
 			va_list	args;

--- a/es-core/src/utils/StringUtil.h
+++ b/es-core/src/utils/StringUtil.h
@@ -24,6 +24,7 @@ namespace Utils
 		bool         endsWith           (const std::string& _string, const std::string& _end);
 		std::string  removeParenthesis  (const std::string& _string);		
 		std::string  vectorToCommaString(stringVector _vector);
+		stringVector commaStringToVector(const std::string& _string);
 		std::string  format             (const char* _string, ...);      
 		std::string  scramble           (const std::string& _input, const std::string& key);
 


### PR DESCRIPTION
* This PR adds a new UI Setting option for ignoring leading articles when sorting.
* "The Legend of Zelda" is now sorted like "Legend of Zelda", "A Boy and His Blob" -> "Boy and His Blob", etc.
* I set the default value to `false` to maintain existing behavior.
* ~~The articles default to "a,an,the", but can be adjusted in `batocera.conf` if the user wishes.~~
* The articles can be defined per language

Thanks!