### PR TITLE
FIX: bootgame was cleared by mistake

### DIFF
--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4379,8 +4379,10 @@ void GuiMenu::popSpecificConfigurationGui(Window* mWindow, std::string title, st
 		systemConfiguration->addWithLabel(_("LAUNCH THIS GAME AT STARTUP"), bootgame);
 		systemConfiguration->addSaveFunc([bootgame, fileData, gamePath]
 		{ 
+        if (bootgame->changed()) {
 			SystemConf::getInstance()->set("global.bootgame.path", bootgame->getState() ? gamePath : "");
 			SystemConf::getInstance()->set("global.bootgame.cmd", bootgame->getState() ? fileData->getlaunchCommand(LaunchGameOptions(), false) : "");
+        }
 		});
 	}
 


### PR DESCRIPTION
Bug:
1.- Set any game to be "Launched at startup" and save
2.- global.bootgame.cmd and global.bootgame.path are set
3.- Open another game advance options, do nothing, return to menu
4.- global.bootgame.cmd and global.bootgame.path are cleared

This PR fixes it by only running the save function if the value has changed.
