### PR TITLE
Add "full" ratio as option

### DIFF
--- a/es-app/src/LibretroRatio.cpp
+++ b/es-app/src/LibretroRatio.cpp
@@ -36,7 +36,8 @@ LibretroRatio::LibretroRatio() {
                     {"Config",        "config"},
                     {"Square pixel",  "squarepixel"},
                     {"Core provided",  "core"},
-                    {"Custom",        "custom"}
+                    {"Custom",        "custom"},
+                    {"Full",          "full"}
             };
 }
 


### PR DESCRIPTION
Collaborates with https://github.com/batocera-linux/batocera.linux/pull/4743 to add the "full" ratio as an option in EmulationStation. "Full" stretches the image to fill the screen.