### PR TITLE
update padtokey label so it fits and support file generation location

### DIFF
--- a/es-app/src/guis/GuiGameOptions.cpp
+++ b/es-app/src/guis/GuiGameOptions.cpp
@@ -362,7 +362,7 @@ GuiGameOptions::GuiGameOptions(Window* window, FileData* game) : GuiComponent(wi
 		{
 			if (game->hasKeyboardMapping())
 			{
-				mMenu.addEntry(_("EDIT PAD TO KEYBOARD CONFIGURATION"), false, [this, game]
+				mMenu.addEntry(_("EDIT PADTOKEY PROFILE"), false, [this, game]
 				{ 
 					GuiMenu::editKeyboardMappings(mWindow, game, true); 
 					close();
@@ -370,7 +370,7 @@ GuiGameOptions::GuiGameOptions(Window* window, FileData* game) : GuiComponent(wi
 			}
 			else if (game->isFeatureSupported(EmulatorFeatures::Features::padTokeyboard))
 			{
-				mMenu.addEntry(_("CREATE PAD TO KEYBOARD CONFIGURATION"), false, [this, game]
+				mMenu.addEntry(_("CREATE PADTOKEY PROFILE"), false, [this, game]
 				{ 
 					GuiMenu::editKeyboardMappings(mWindow, game, true);
 					close();

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -802,10 +802,10 @@ void GuiMenu::openDeveloperSettings()
 		window->pushGui(new GuiMsgBox(window, _("CREATE A SUPPORT FILE?"), _("YES"),
 			[window] {
 			if (ApiSystem::getInstance()->generateSupportFile()) {
-				window->pushGui(new GuiMsgBox(window, _("SUPPORT FILE GENERATED SUCCESSFULLY"), _("OK")));
+				window->pushGui(new GuiMsgBox(window, _("SUPPORT FILE CREATED IN SAVES FOLDER"), _("OK")));
 			}
 			else {
-				window->pushGui(new GuiMsgBox(window, _("SUPPORT FILE GENERATION FAILED"), _("OK")));
+				window->pushGui(new GuiMsgBox(window, _("SUPPORT FILE CREATION FAILED"), _("OK")));
 			}
 		}, _("NO"), nullptr));
 	});
@@ -4390,9 +4390,9 @@ void GuiMenu::popSpecificConfigurationGui(Window* mWindow, std::string title, st
 	if (fileData == nullptr && ApiSystem::getInstance()->isScriptingSupported(ApiSystem::ScriptId::EVMAPY) && systemData->isCurrentFeatureSupported(EmulatorFeatures::Features::padTokeyboard))
 	{
 		if (systemData->hasKeyboardMapping())
-			systemConfiguration->addEntry(_("EDIT PAD TO KEYBOARD CONFIGURATION"), true, [mWindow, systemData] { editKeyboardMappings(mWindow, systemData, true); });
+			systemConfiguration->addEntry(_("EDIT PADTOKEY PROFILE"), true, [mWindow, systemData] { editKeyboardMappings(mWindow, systemData, true); });
 		else
-			systemConfiguration->addEntry(_("CREATE PAD TO KEYBOARD CONFIGURATION"), true, [mWindow, systemData] { editKeyboardMappings(mWindow, systemData, true); });
+			systemConfiguration->addEntry(_("CREATE PADTOKEY PROFILE"), true, [mWindow, systemData] { editKeyboardMappings(mWindow, systemData, true); });
 	}
 	
 	// Set as boot game 


### PR DESCRIPTION
The string "EDIT PAD TO KEYBOARD CONFIGURATION" was too long to fit in the menu and was cut off. Changed to "EDIT PADTOKEY PROFILE" to properly fit. Same thing with "CREATE PADTOKEY PROFILE".

![screenshot-2021 10 26-18h09 32](https://user-images.githubusercontent.com/67527064/140606311-78e75f9d-7565-4ea2-a933-28aef5c6703d.png)

Made support file creation pop use consistent terminology, opted to use "create" verb. It also now mentions _where_ the file is created, reducing confusion.