### PR TITLE
- Add 'Incremental SaveState' option

### DIFF
--- a/es-app/src/FileData.cpp
+++ b/es-app/src/FileData.cpp
@@ -396,7 +396,7 @@ FileData* FileData::getSourceFileData()
 	return this;
 }
 
-std::string FileData::getlaunchCommand(LaunchGameOptions options, bool includeControllers)
+std::string FileData::getlaunchCommand(LaunchGameOptions& options, bool includeControllers)
 {
 	FileData* gameToUpdate = getSourceFileData();
 	if (gameToUpdate == nullptr)
@@ -560,7 +560,7 @@ bool FileData::launchGame(Window* window, LaunchGameOptions options)
 
 	if (SaveStateRepository::isEnabled(this))
 	{
-		options.saveStateInfo.onGameEnded();
+		options.saveStateInfo.onGameEnded(this);
 		getSourceFileData()->getSystem()->getSaveStateRepository()->refresh();
 	}
 

--- a/es-app/src/FileData.h
+++ b/es-app/src/FileData.h
@@ -115,7 +115,7 @@ public:
 	// As above, but also remove parenthesis
 	std::string getCleanName();
 
-	std::string getlaunchCommand(LaunchGameOptions options = LaunchGameOptions(), bool includeControllers = true);
+	std::string getlaunchCommand(LaunchGameOptions& options = LaunchGameOptions(), bool includeControllers = true);
 	bool		launchGame(Window* window, LaunchGameOptions options = LaunchGameOptions());
 
 	static void resetSettings();

--- a/es-app/src/SaveState.h
+++ b/es-app/src/SaveState.h
@@ -24,11 +24,16 @@ struct SaveState
 	std::string getScreenShot() const;
 	int slot;
 
+	void remove() const;
+	bool copyToSlot(int slot, bool move = false) const;
+
 	Utils::Time::DateTime creationDate;
 
 public:
+	virtual std::string makeStateFilename(int slot, bool fullPath = true) const;
+
 	std::string setupSaveState(FileData* game, const std::string& command);
-	void onGameEnded();
+	void onGameEnded(FileData* game);
 
 private:
 	std::string mAutoFileBackup;

--- a/es-app/src/SaveStateRepository.h
+++ b/es-app/src/SaveStateRepository.h
@@ -17,9 +17,7 @@ public:
 
 	static bool isEnabled(FileData* game);
 	static int	getNextFreeSlot(FileData* game);
-	
-	bool copyToSlot(const SaveState& state, int slot);
-	void deleteSaveState(const SaveState& state) const;
+	static void renumberSlots(FileData* game);
 
 	bool hasSaveStates(FileData* game);
 

--- a/es-app/src/SystemData.cpp
+++ b/es-app/src/SystemData.cpp
@@ -529,6 +529,9 @@ std::vector<CustomFeature>  SystemData::loadCustomFeatures(pugi::xml_node node)
 		if (featureNode.attribute("description"))
 			feat.description = featureNode.attribute("description").value();
 
+		if (featureNode.attribute("submenu"))
+			feat.submenu = featureNode.attribute("submenu").value();
+
 		if (featureNode.attribute("value"))
 			feat.value = featureNode.attribute("value").value();
 		else 

--- a/es-app/src/SystemData.h
+++ b/es-app/src/SystemData.h
@@ -33,6 +33,7 @@ struct CustomFeature
 	std::string name;
 	std::string value;
 	std::string description;
+	std::string submenu;
 	std::vector<CustomFeatureChoice> choices;
 };
 

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -1995,6 +1995,19 @@ void GuiMenu::openRetroachievementsSettings()
 	mWindow->pushGui(retroachievements);
 }
 
+template <typename StructType, typename FieldSelectorUnaryFn>
+static auto groupBy(const std::vector<StructType>& instances, const FieldSelectorUnaryFn& fieldChooser)
+{
+	StructType _;
+	using FieldType = decltype(fieldChooser(_));
+	std::map<FieldType, std::vector<StructType>> instancesByField;
+	for (auto& instance : instances)
+	{
+		instancesByField[fieldChooser(instance)].push_back(instance);
+	}
+	return instancesByField;
+}
+
 void GuiMenu::openNetplaySettings()
 {
 	GuiSettings* settings = new GuiSettings(mWindow, _("NETPLAY SETTINGS").c_str());
@@ -2061,6 +2074,30 @@ void GuiMenu::openNetplaySettings()
 	
 	mWindow->pushGui(settings);
 }
+
+void GuiMenu::addDecorationSetOptionListComponent(Window* window, GuiSettings* parentWindow, const std::vector<DecorationSetInfo>& sets, const std::string& configName)
+{
+	auto decorations = std::make_shared<OptionListComponent<std::string> >(window, _("DECORATION SET"), false);
+	decorations->setRowTemplate([window, sets](std::string data, ComponentListRow& row) { createDecorationItemTemplate(window, sets, data, row); });
+
+	std::vector<std::string> items = { _("AUTO"), _("NONE") };
+	for (auto set : sets)
+		items.push_back(set.name);
+
+	std::string bezel = SystemConf::getInstance()->get(configName + ".bezel");
+
+	for (auto item : items)
+		decorations->add(item, item, (bezel == item) || (bezel == "none" && item == _("NONE")) || (bezel == "" && item == _("AUTO")));
+
+	if (!decorations->hasSelection())
+		decorations->selectFirstItem();
+
+	parentWindow->addWithLabel(_("DECORATION SET"), decorations);
+	parentWindow->addSaveFunc([decorations, configName]
+	{
+		SystemConf::getInstance()->set(configName + ".bezel", decorations->getSelected() == _("NONE") ? "none" : decorations->getSelected() == _("AUTO") ? "" : decorations->getSelected());
+	});
+};
 
 void GuiMenu::openGamesSettings_batocera() 
 {
@@ -2129,11 +2166,14 @@ void GuiMenu::openGamesSettings_batocera()
 	auto autosave_enabled = std::make_shared<OptionListComponent<std::string>>(mWindow, _("AUTO SAVE/LOAD ON GAME LAUNCH"));
 	autosave_enabled->addRange({ { _("OFF"), "auto" },{ _("ON") , "1" },{ _("SHOW SAVE STATES") , "2" },{ _("SHOW SAVE STATES IF NOT EMPTY") , "3" } }, SystemConf::getInstance()->get("global.autosave"));
 	s->addWithLabel(_("AUTO SAVE/LOAD ON GAME LAUNCH"), autosave_enabled);
-	s->addSaveFunc([autosave_enabled] 
-	{ 
-		SystemConf::getInstance()->set("global.autosave", autosave_enabled->getSelected()); 
-	});
+	s->addSaveFunc([autosave_enabled] { SystemConf::getInstance()->set("global.autosave", autosave_enabled->getSelected()); });
 	
+	// Incremental savestates
+	auto incrementalSaveStates = std::make_shared<SwitchComponent>(mWindow);
+	incrementalSaveStates->setState(SystemConf::getInstance()->get("global.incrementalsavestates") != "0");
+	s->addWithLabel(_("INCREMENTAL SAVESTATES"), incrementalSaveStates);
+	s->addSaveFunc([incrementalSaveStates] { SystemConf::getInstance()->set("global.incrementalsavestates", incrementalSaveStates->getState() ? "" : "0"); });
+
 	// Shaders preset
 	if (ApiSystem::getInstance()->isScriptingSupported(ApiSystem::SHADERS))
 	{
@@ -2160,37 +2200,18 @@ void GuiMenu::openGamesSettings_batocera()
 	// decorations
 	if (ApiSystem::getInstance()->isScriptingSupported(ApiSystem::DECORATIONS))
 	{		
-		s->addEntry(_("DECORATIONS"), true, [this]
+		auto sets = GuiMenu::getDecorationsSets(ViewController::get()->getState().getSystem());
+		if (sets.size() > 0)
 		{
-			GuiSettings *decorations_window = new GuiSettings(mWindow, _("DECORATIONS").c_str());
-			Window* window = mWindow;
-			auto sets = GuiMenu::getDecorationsSets(ViewController::get()->getState().getSystem());
-			if (sets.size() > 0)
+#if defined(WIN32) || defined(_DEBUG)
+			addDecorationSetOptionListComponent(mWindow, s, sets);
+#else
+			s->addEntry(_("DECORATIONS"), true, [this, sets]
 			{
-				auto decorations = std::make_shared<OptionListComponent<std::string> >(mWindow, _("DECORATION SET"), false);
-				decorations->setRowTemplate([window, sets](std::string data, ComponentListRow& row)
-				{
-					createDecorationItemTemplate(window, sets, data, row);
-				});
+				GuiSettings *decorations_window = new GuiSettings(mWindow, _("DECORATIONS").c_str());
 
-				std::vector<std::string> decorations_item;
-				decorations_item.push_back(_("AUTO"));
-				decorations_item.push_back(_("NONE"));
-				for (auto set : sets)
-					decorations_item.push_back(set.name);
+				addDecorationSetOptionListComponent(mWindow, decorations_window, sets);
 
-				for (auto it = decorations_item.begin(); it != decorations_item.end(); it++)
-					decorations->add(*it, *it,
-					(SystemConf::getInstance()->get("global.bezel") == *it) ||
-						(SystemConf::getInstance()->get("global.bezel") == "none" && *it == _("NONE")) ||
-						(SystemConf::getInstance()->get("global.bezel") == "" && *it == _("AUTO")));
-
-				decorations_window->addWithLabel(_("DECORATION SET"), decorations);
-				decorations_window->addSaveFunc([decorations]
-				{
-					SystemConf::getInstance()->set("global.bezel", decorations->getSelected() == _("NONE") ? "none" : decorations->getSelected() == _("AUTO") ? "" : decorations->getSelected());
-				});
-#if !defined(WIN32) || defined(_DEBUG)
 				// stretch bezels
 				auto bezel_stretch_enabled = std::make_shared<OptionListComponent<std::string>>(mWindow, _("STRETCH BEZELS (4K & ULTRAWIDE)"));
 				bezel_stretch_enabled->add(_("AUTO"), "auto", SystemConf::getInstance()->get("global.bezel_stretch") != "0" && SystemConf::getInstance()->get("global.bezel_stretch") != "1");
@@ -2203,6 +2224,7 @@ void GuiMenu::openGamesSettings_batocera()
 						SystemConf::getInstance()->saveSystemConf();
 						}
 						});
+
 				// tattoo and controller overlays
 				auto bezel_tattoo = std::make_shared<OptionListComponent<std::string>>(mWindow, _("SHOW CONTROLLER OVERLAYS"));
 				bezel_tattoo->add(_("AUTO"), "auto", SystemConf::getInstance()->get("global.bezel.tattoo") != "0"
@@ -2218,6 +2240,7 @@ void GuiMenu::openGamesSettings_batocera()
 						SystemConf::getInstance()->saveSystemConf();
 						}
 						});
+
 				auto bezel_tattoo_corner = std::make_shared<OptionListComponent<std::string>>(mWindow, _("OVERLAY CORNER"));
 				bezel_tattoo_corner->add(_("AUTO"), "auto", SystemConf::getInstance()->get("global.bezel.tattoo_corner") != "NW"
 						&& SystemConf::getInstance()->get("global.bezel.tattoo_corner") != "NE"
@@ -2235,10 +2258,11 @@ void GuiMenu::openGamesSettings_batocera()
 						}
 						});
 				decorations_window->addInputTextRow(_("CUSTOM .PNG IMAGE PATH"), "global.bezel.tattoo_file", false);
+
+				mWindow->pushGui(decorations_window);
+			});			
 #endif
-			}
-			mWindow->pushGui(decorations_window);
-		});
+		}
 	}
 	
 	// latency reduction
@@ -2309,31 +2333,71 @@ void GuiMenu::openGamesSettings_batocera()
 
 		mWindow->pushGui(ai_service);
 	});
-	
-	// Load global custom features
-	for (auto feat : SystemData::mGlobalFeatures)
+		
+	auto groups = groupBy(SystemData::mGlobalFeatures, [](const CustomFeature& item) { return item.submenu; });
+	for (auto group : groups)
 	{
-		std::string storageName = "global." + feat.value;
-		std::string storedValue = SystemConf::getInstance()->get(storageName);
+		if (!group.first.empty())
+		{				
+			s->addEntry(group.first, true, [this, group]
+			{
+				GuiSettings* groupSettings = new GuiSettings(mWindow, _(group.first.c_str()));
 
-		auto cf = std::make_shared<OptionListComponent<std::string>>(mWindow, _(feat.name.c_str()));
-		cf->add(_("AUTO"), "", storedValue.empty() || storedValue == "auto");
+				for (auto feat : group.second)
+				{
+					std::string storageName = "global." + feat.value;
+					std::string storedValue = SystemConf::getInstance()->get(storageName);
 
-		for (auto fval : feat.choices)
-			cf->add(_(fval.name.c_str()), fval.value, storedValue == fval.value);
+					auto cf = std::make_shared<OptionListComponent<std::string>>(mWindow, _(feat.name.c_str()));
+					cf->add(_("AUTO"), "", storedValue.empty() || storedValue == "auto");
 
-		if (!cf->hasSelection())
-			cf->selectFirstItem();
+					for (auto fval : feat.choices)
+						cf->add(_(fval.name.c_str()), fval.value, storedValue == fval.value);
 
-		if (!feat.description.empty())
-			s->addWithDescription(_(feat.name.c_str()), _(feat.description.c_str()), cf);
+					if (!cf->hasSelection())
+						cf->selectFirstItem();
+
+					if (!feat.description.empty())
+						groupSettings->addWithDescription(_(feat.name.c_str()), _(feat.description.c_str()), cf);
+					else
+						groupSettings->addWithLabel(_(feat.name.c_str()), cf);
+
+					groupSettings->addSaveFunc([cf, storageName] { SystemConf::getInstance()->set(storageName, cf->getSelected()); });
+				}
+
+				mWindow->pushGui(groupSettings);
+			});
+		}
 		else
-			s->addWithLabel(_(feat.name.c_str()), cf);
+		{
+			// Load global custom features
+			for (auto feat : group.second)
+			{
+				std::string storageName = "global." + feat.value;
+				std::string storedValue = SystemConf::getInstance()->get(storageName);
 
-		s->addSaveFunc([cf, storageName] { SystemConf::getInstance()->set(storageName, cf->getSelected()); });
+				auto cf = std::make_shared<OptionListComponent<std::string>>(mWindow, _(feat.name.c_str()));
+				cf->add(_("AUTO"), "", storedValue.empty() || storedValue == "auto");
+
+				for (auto fval : feat.choices)
+					cf->add(_(fval.name.c_str()), fval.value, storedValue == fval.value);
+
+				if (!cf->hasSelection())
+					cf->selectFirstItem();
+
+				if (!feat.description.empty())
+					s->addWithDescription(_(feat.name.c_str()), _(feat.description.c_str()), cf);
+				else
+					s->addWithLabel(_(feat.name.c_str()), cf);
+
+				s->addSaveFunc([cf, storageName] { SystemConf::getInstance()->set(storageName, cf->getSelected()); });
+			}
+		}
 	}
 
 	// Custom config for systems
+	s->addGroup(_("SETTINGS"));
+
 	s->addEntry(_("PER SYSTEM ADVANCED CONFIGURATION"), true, [this, s, window]
 	{
 		s->save();
@@ -4085,40 +4149,20 @@ void GuiMenu::popSpecificConfigurationGui(Window* mWindow, std::string title, st
 	}
 
 	// decorations
-	if (ApiSystem::getInstance()->isScriptingSupported(ApiSystem::DECORATIONS))
-	if (systemData->isFeatureSupported(currentEmulator, currentCore, EmulatorFeatures::decoration))
+	if (ApiSystem::getInstance()->isScriptingSupported(ApiSystem::DECORATIONS) && systemData->isFeatureSupported(currentEmulator, currentCore, EmulatorFeatures::decoration))
 	{
-		systemConfiguration->addEntry(_("DECORATIONS"), true, [mWindow, configName, systemData]
+		auto sets = GuiMenu::getDecorationsSets(systemData);
+		if (sets.size() > 0)
 		{
-			GuiSettings *decorations_window = new GuiSettings(mWindow, _("DECORATIONS").c_str());
-			Window* window = mWindow;
-			auto sets = GuiMenu::getDecorationsSets(systemData);
-			if (sets.size() > 0)
+#if defined(WIN32) || defined(_DEBUG)
+			addDecorationSetOptionListComponent(mWindow, systemConfiguration, sets, configName);
+#else
+			systemConfiguration->addEntry(_("DECORATIONS"), true, [mWindow, configName, systemData, sets]
 			{
-				auto decorations = std::make_shared<OptionListComponent<std::string> >(mWindow, _("DECORATION SET"), false);
-				decorations->setRowTemplate([window, sets](std::string data, ComponentListRow& row)
-				{
-					createDecorationItemTemplate(window, sets, data, row);
-				});
+				GuiSettings* decorations_window = new GuiSettings(mWindow, _("DECORATIONS").c_str());
 
-				std::vector<std::string> decorations_item;
-				decorations_item.push_back(_("AUTO"));
-				decorations_item.push_back(_("NONE"));
-				for (auto set : sets)
-					decorations_item.push_back(set.name);
-
-				for (auto it = decorations_item.begin(); it != decorations_item.end(); it++)
-					decorations->add(*it, *it,
-					(SystemConf::getInstance()->get(configName + ".bezel") == *it) ||
-						(SystemConf::getInstance()->get(configName + ".bezel") == "none" && *it == _("NONE")) ||
-						(SystemConf::getInstance()->get(configName + ".bezel") == "" && *it == _("AUTO")));
-
-				decorations_window->addWithLabel(_("DECORATION SET"), decorations);
-				decorations_window->addSaveFunc([decorations, configName]
-				{
-					SystemConf::getInstance()->set(configName + ".bezel", decorations->getSelected() == _("NONE") ? "none" : decorations->getSelected() == _("AUTO") ? "" : decorations->getSelected());
-				});
-#if !defined(WIN32) || defined(_DEBUG)
+				addDecorationSetOptionListComponent(mWindow, decorations_window, sets, configName);
+				
 				// stretch bezels
 				auto bezel_stretch_enabled = std::make_shared<OptionListComponent<std::string>>(mWindow, _("STRETCH BEZELS (4K & ULTRAWIDE)"));
 				bezel_stretch_enabled->add(_("AUTO"), "auto", SystemConf::getInstance()->get(configName + ".bezel_stretch") != "0" && SystemConf::getInstance()->get(configName + ".bezel_stretch") != "1");
@@ -4126,50 +4170,54 @@ void GuiMenu::popSpecificConfigurationGui(Window* mWindow, std::string title, st
 				bezel_stretch_enabled->add(_("OFF"), "0", SystemConf::getInstance()->get(configName + ".bezel_stretch") == "0");
 				decorations_window->addWithLabel(_("STRETCH BEZELS (4K & ULTRAWIDE)"), bezel_stretch_enabled);
 				decorations_window->addSaveFunc([bezel_stretch_enabled, configName] {
-						if (bezel_stretch_enabled->changed()) {
+					if (bezel_stretch_enabled->changed()) {
 						SystemConf::getInstance()->set(configName + ".bezel_stretch", bezel_stretch_enabled->getSelected());
 						SystemConf::getInstance()->saveSystemConf();
-						}
-						});
+					}
+				});
+
 				// tattoo and controller overlays
 				auto bezel_tattoo = std::make_shared<OptionListComponent<std::string>>(mWindow, _("SHOW CONTROLLER OVERLAYS"));
 				bezel_tattoo->add(_("AUTO"), "auto", SystemConf::getInstance()->get(configName + ".bezel.tattoo") != "0"
-						&& SystemConf::getInstance()->get(configName + ".bezel.tattoo") != "system"
-						&& SystemConf::getInstance()->get(configName + ".bezel.tattoo") != "custom");
+					&& SystemConf::getInstance()->get(configName + ".bezel.tattoo") != "system"
+					&& SystemConf::getInstance()->get(configName + ".bezel.tattoo") != "custom");
 				bezel_tattoo->add(_("NO"), "0", SystemConf::getInstance()->get(configName + ".bezel.tattoo") == "0");
 				bezel_tattoo->add(_("SYSTEM CONTROLLERS"), "system", SystemConf::getInstance()->get(configName + ".bezel.tattoo") == "system");
 				bezel_tattoo->add(_("CUSTOM .PNG IMAGE"), "custom", SystemConf::getInstance()->get(configName + ".bezel.tattoo") == "custom");
 				decorations_window->addWithLabel(_("SHOW CONTROLLER OVERLAYS"), bezel_tattoo);
 				decorations_window->addSaveFunc([bezel_tattoo, configName] {
-						if (bezel_tattoo->changed()) {
+					if (bezel_tattoo->changed()) {
 						SystemConf::getInstance()->set(configName + ".bezel.tattoo", bezel_tattoo->getSelected());
 						SystemConf::getInstance()->saveSystemConf();
-						}
-						});
+					}
+				});
+
 				auto bezel_tattoo_corner = std::make_shared<OptionListComponent<std::string>>(mWindow, _("OVERLAY CORNER"));
 				bezel_tattoo_corner->add(_("AUTO"), "auto", SystemConf::getInstance()->get(configName + ".bezel.tattoo_corner") != "NW"
-						&& SystemConf::getInstance()->get(configName + ".bezel.tattoo_corner") != "NE"
-						&& SystemConf::getInstance()->get(configName + ".bezel.tattoo_corner") != "SE"
-						&& SystemConf::getInstance()->get(configName + ".bezel.tattoo_corner") != "SW");
+					&& SystemConf::getInstance()->get(configName + ".bezel.tattoo_corner") != "NE"
+					&& SystemConf::getInstance()->get(configName + ".bezel.tattoo_corner") != "SE"
+					&& SystemConf::getInstance()->get(configName + ".bezel.tattoo_corner") != "SW");
 				bezel_tattoo_corner->add(_("NORTH WEST"), "NW", SystemConf::getInstance()->get(configName + ".bezel.tattoo_corner") == "NW");
 				bezel_tattoo_corner->add(_("NORTH EAST"), "NE", SystemConf::getInstance()->get(configName + ".bezel.tattoo_corner") == "NE");
 				bezel_tattoo_corner->add(_("SOUTH EAST"), "SE", SystemConf::getInstance()->get(configName + ".bezel.tattoo_corner") == "SE");
 				bezel_tattoo_corner->add(_("SOUTH WEST"), "SW", SystemConf::getInstance()->get(configName + ".bezel.tattoo_corner") == "SW");
 				decorations_window->addWithLabel(_("OVERLAY CORNER"), bezel_tattoo_corner);
 				decorations_window->addSaveFunc([bezel_tattoo_corner, configName] {
-						if (bezel_tattoo_corner->changed()) {
+					if (bezel_tattoo_corner->changed()) {
 						SystemConf::getInstance()->set(configName + ".bezel.tattoo_corner", bezel_tattoo_corner->getSelected());
 						SystemConf::getInstance()->saveSystemConf();
-						}
-						});
+					}
+				});
+
 				std::string tatpath = configName + ".bezel.tattoo_file";
 				const char *bezelpath = const_cast<char*>(tatpath.data());
 				decorations_window->addInputTextRow(_("CUSTOM .PNG IMAGE PATH"), bezelpath, false);
-#endif
-			}
-			mWindow->pushGui(decorations_window);
-		});
-	}
+
+				mWindow->pushGui(decorations_window);
+			});
+#endif		
+		}
+	}	
 
 	if (systemData->isFeatureSupported(currentEmulator, currentCore, EmulatorFeatures::latency_reduction))	
 		systemConfiguration->addEntry(_("LATENCY REDUCTION"), true, [mWindow, configName] { openLatencyReductionConfiguration(mWindow, configName); });
@@ -4387,29 +4435,71 @@ void GuiMenu::popSpecificConfigurationGui(Window* mWindow, std::string title, st
 
 	// Load per-game / per-emulator / per-system custom features
 	std::vector<CustomFeature> customFeatures = systemData->getCustomFeatures(currentEmulator, currentCore);
-	for (auto feat : customFeatures)
+
+	auto groups = groupBy(customFeatures, [](const CustomFeature& item) { return item.submenu; });
+	for (auto group : groups)
 	{
-		std::string storageName = configName + "." + feat.value;
-		std::string storedValue = SystemConf::getInstance()->get(storageName);
+		if (!group.first.empty())
+		{
+			systemConfiguration->addEntry(group.first, true, [configName, mWindow, group]
+			{
+				GuiSettings* groupSettings = new GuiSettings(mWindow, _(group.first.c_str()));
 
-		auto cf = std::make_shared<OptionListComponent<std::string>>(mWindow, _(feat.name.c_str()));
-		cf->add(_("AUTO"), "", storedValue.empty() || storedValue == "auto");
+				for (auto feat : group.second)
+				{
+					std::string storageName = configName + "." + feat.value;
+					std::string storedValue = SystemConf::getInstance()->get(storageName);
 
-		for(auto fval : feat.choices)
-			cf->add(_(fval.name.c_str()), fval.value, storedValue == fval.value);
+					auto cf = std::make_shared<OptionListComponent<std::string>>(mWindow, _(feat.name.c_str()));
+					cf->add(_("AUTO"), "", storedValue.empty() || storedValue == "auto");
 
-		if (!cf->hasSelection())
-			cf->selectFirstItem();
+					for (auto fval : feat.choices)
+						cf->add(_(fval.name.c_str()), fval.value, storedValue == fval.value);
 
-		if (!feat.description.empty())
-			systemConfiguration->addWithDescription(_(feat.name.c_str()), _(feat.description.c_str()), cf);
+					if (!cf->hasSelection())
+						cf->selectFirstItem();
+
+					if (!feat.description.empty())
+						groupSettings->addWithDescription(_(feat.name.c_str()), _(feat.description.c_str()), cf);
+					else
+						groupSettings->addWithLabel(_(feat.name.c_str()), cf);
+
+					groupSettings->addSaveFunc([cf, storageName]
+					{
+						SystemConf::getInstance()->set(storageName, cf->getSelected());
+					});
+				}
+
+				mWindow->pushGui(groupSettings);
+			});
+		}
 		else
-			systemConfiguration->addWithLabel(_(feat.name.c_str()), cf);
+		{
+			for (auto feat : group.second)
+			{
+				std::string storageName = configName + "." + feat.value;
+				std::string storedValue = SystemConf::getInstance()->get(storageName);
 
-		systemConfiguration->addSaveFunc([cf, storageName] 
-		{			
-			SystemConf::getInstance()->set(storageName, cf->getSelected());
-		});
+				auto cf = std::make_shared<OptionListComponent<std::string>>(mWindow, _(feat.name.c_str()));
+				cf->add(_("AUTO"), "", storedValue.empty() || storedValue == "auto");
+
+				for (auto fval : feat.choices)
+					cf->add(_(fval.name.c_str()), fval.value, storedValue == fval.value);
+
+				if (!cf->hasSelection())
+					cf->selectFirstItem();
+
+				if (!feat.description.empty())
+					systemConfiguration->addWithDescription(_(feat.name.c_str()), _(feat.description.c_str()), cf);
+				else
+					systemConfiguration->addWithLabel(_(feat.name.c_str()), cf);
+
+				systemConfiguration->addSaveFunc([cf, storageName]
+				{
+					SystemConf::getInstance()->set(storageName, cf->getSelected());
+				});
+			}
+		}
 	}
 
 	// automatic controller configuration

--- a/es-app/src/guis/GuiMenu.h
+++ b/es-app/src/guis/GuiMenu.h
@@ -95,6 +95,8 @@ private:
 
 	std::vector<StrInputConfig*> mLoadedInput; // used to keep information about loaded devices in case there are unpluged between device window load and save
 	void clearLoadedInput();
+
+	static void addDecorationSetOptionListComponent(Window* window, GuiSettings* parentWindow, const std::vector<DecorationSetInfo>& sets, const std::string& configName = "global");
 	static void createDecorationItemTemplate(Window* window, std::vector<DecorationSetInfo> sets, std::string data, ComponentListRow& row);
 
 	bool checkNetwork();

--- a/es-app/src/guis/GuiSaveState.cpp
+++ b/es-app/src/guis/GuiSaveState.cpp
@@ -100,12 +100,18 @@ GuiSaveState::GuiSaveState(Window* window, FileData* game, const std::function<v
 
 void GuiSaveState::loadGrid()
 {
-	mGrid->clear();
-		
-	auto states = mRepository->getSaveStates(mGame);
-	std::sort(states.begin(), states.end(), [](const SaveState* file1, const SaveState* file2) { return file1->creationDate >= file2->creationDate; });
+	bool incrementalSaveStates = (SystemConf::getInstance()->get("global.incrementalsavestates") != "0");
 
-	int slot = SaveStateRepository::getNextFreeSlot(mGame);
+	mGrid->clear();
+	mGrid->onSizeChanged(); // To Rebuild tiles
+
+	auto states = mRepository->getSaveStates(mGame);
+
+	if (incrementalSaveStates)
+		std::sort(states.begin(), states.end(), [](const SaveState* file1, const SaveState* file2) { return file1->creationDate >= file2->creationDate; });
+	else
+		std::sort(states.begin(), states.end(), [](const SaveState* file1, const SaveState* file2) { return file1->slot < file2->slot; });
+
 	mGrid->add(_("START NEW GAME"), ":/freeslot.svg", "", "", false, false, false, false, SaveState(-2));
 
 	std::string autoSaveMode = mGame->getCurrentGameSetting("autosave");
@@ -116,12 +122,15 @@ void GuiSaveState::loadGrid()
 			mGrid->add(_("START AUTO SAVE"), ":/freeslot.svg", "", "", false, false, false, false, SaveState(-1));
 	}
 
+
 	for (auto item : states)
 	{
 		if (item->slot == -1)
 			mGrid->add(item->creationDate.toLocalTimeString() + std::string("\r\n") + _("AUTO SAVE"), item->getScreenShot(), "", "", false, false, false, false, *item);
-		else
-			mGrid->add(item->creationDate.toLocalTimeString() + std::string("\r\n") + _("SLOT") + std::string(" ") + std::to_string(item->slot), item->getScreenShot(), "", "", false, false, false, false, *item);
+		else if (incrementalSaveStates)
+			mGrid->add(item->creationDate.toLocalTimeString(), item->getScreenShot(), "", "", false, false, false, false, *item);
+		else 
+			mGrid->add(_("SLOT") + std::string(" ") + std::to_string(item->slot) + std::string("\r\n") + item->creationDate.toLocalTimeString() , item->getScreenShot(), "", "", false, false, false, false, *item);
 	}
 
 }
@@ -200,8 +209,9 @@ bool GuiSaveState::input(InputConfig* config, Input input)
 				[this]
 				{
 					const SaveState& toDelete = mGrid->getSelected();
+					toDelete.remove();
 
-					mRepository->deleteSaveState(toDelete);
+					SaveStateRepository::renumberSlots(mGame);
 					mRepository->refresh();
 
 					loadGrid();
@@ -220,11 +230,11 @@ bool GuiSaveState::input(InputConfig* config, Input input)
 			if (slot >= 0)
 			{
 				const SaveState& toCopy = mGrid->getSelected();
-
-				mRepository->copyToSlot(toCopy, slot);
-				mRepository->refresh();
-
-				loadGrid();
+				if (toCopy.copyToSlot(slot))
+				{
+					mRepository->refresh();
+					loadGrid();
+				}
 			}
 		}
 

--- a/es-core/src/utils/FileSystemUtil.cpp
+++ b/es-core/src/utils/FileSystemUtil.cpp
@@ -322,6 +322,17 @@ namespace Utils
 
 		} // getDirContent
 
+#if WIN32
+		static time_t to_time_t(FILETIME& ft)
+		{
+			ULARGE_INTEGER ull;
+			ull.LowPart = ft.dwLowDateTime;
+			ull.HighPart = ft.dwHighDateTime;
+			time_t ret = (ull.QuadPart / 10000000ULL - 11644473600ULL);
+			return ret;
+		}
+#endif
+
 		fileList getDirectoryFiles(const std::string& _path)
 		{
 			std::string path = getGenericPath(_path);
@@ -382,6 +393,8 @@ namespace Utils
 						fi.path = path + "/" + name;
 						fi.hidden = (findData.dwFileAttributes & FILE_ATTRIBUTE_HIDDEN) == FILE_ATTRIBUTE_HIDDEN;
 						fi.directory = (findData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) == FILE_ATTRIBUTE_DIRECTORY;
+						fi.creationTime = to_time_t(findData.ftCreationTime);
+
 						contentList.push_back(fi);
 
 						FileCache::add(fi.path, FileCache((DWORD)findData.dwFileAttributes));

--- a/es-core/src/utils/FileSystemUtil.h
+++ b/es-core/src/utils/FileSystemUtil.h
@@ -47,13 +47,15 @@ namespace Utils
 		std::string getEsConfigPath();
 		std::string getSharedConfigPath();
 
-		// FCA
 		struct FileInfo
 		{
 		public:
 			std::string path;
 			bool hidden;
 			bool directory;
+#if WIN32
+			time_t creationTime;
+#endif
 		};
 
 		typedef std::list<FileInfo> fileList;


### PR DESCRIPTION
- Add 'Incremental SaveState' option ( active by default ).
These lines need to be added in libretroConfig.py (near Autosave option) for optimal use -> 
```
if system.isOptSet('incrementalsavestates') and not system.getOptBoolean('incrementalsavestates'):
      retroarchConfig['savestate_auto_index'] = 'false'
      retroarchConfig['savestate_max_keep'] = '50'
else:
      retroarchConfig['savestate_auto_index'] = 'true'
      retroarchConfig['savestate_max_keep'] = '0'
```

- Es_features : add 'submenu' management
```<feature submenu="RETROARCH"  ...```
 
- Fix : Decorations are in a submenu with only one item on Windows.