### PR TITLE
es_features : Add shared features support ( reusability of features )

### DIFF
--- a/es-app/src/SystemData.cpp
+++ b/es-app/src/SystemData.cpp
@@ -530,9 +530,17 @@ std::vector<CustomFeature>  SystemData::loadCustomFeatures(pugi::xml_node node)
 		{
 			std::string featureName = featureNode.attribute("name").value();
 
-			auto it = std::find_if(mSharedFeatures.cbegin(), mSharedFeatures.cend(), [featureName](const CustomFeature& x) { return x.value == featureName; });
+			auto it = std::find_if(mSharedFeatures.cbegin(), mSharedFeatures.cend(), [featureName](const CustomFeature& x) { return x.name == featureName; });
 			if (it != mSharedFeatures.cend())
 				ret.push_back(*it);
+			else if (featureNode.attribute("value"))
+			{
+				std::string featureValue = featureNode.attribute("value").value();
+
+				it = std::find_if(mSharedFeatures.cbegin(), mSharedFeatures.cend(), [featureValue](const CustomFeature& x) { return x.value == featureValue; });
+				if (it != mSharedFeatures.cend())
+					ret.push_back(*it);
+			}
 
 			continue;
 		}		

--- a/es-app/src/SystemData.cpp
+++ b/es-app/src/SystemData.cpp
@@ -31,6 +31,7 @@ using namespace Utils;
 
 std::vector<SystemData*> SystemData::sSystemVector;
 std::vector<CustomFeature> SystemData::mGlobalFeatures;
+std::vector<CustomFeature> SystemData::mSharedFeatures;
 
 SystemData::SystemData(const SystemMetadata& meta, SystemEnvironmentData* envData, std::vector<EmulatorData>* pEmulators, bool CollectionSystem, bool groupedSystem, bool withTheme, bool loadThemeOnlyIfElements) : // batocera
 	mMetadata(meta), mEnvData(envData), mIsCollectionSystem(CollectionSystem), mIsGameSystem(true)
@@ -518,9 +519,24 @@ std::vector<CustomFeature>  SystemData::loadCustomFeatures(pugi::xml_node node)
 	if (customFeatures == nullptr)
 		customFeatures = node;
 
-	for (pugi::xml_node featureNode = customFeatures.child("feature"); featureNode; featureNode = featureNode.next_sibling("feature"))
+	//	for (pugi::xml_node featureNode = customFeatures.child("feature"); featureNode; featureNode = featureNode.next_sibling("feature"))
+	for (pugi::xml_node featureNode = customFeatures.first_child(); featureNode; featureNode = featureNode.next_sibling())
 	{
 		if (!featureNode.attribute("name"))
+			continue;
+
+		std::string name = featureNode.name();		
+		if (name == "sharedFeature")
+		{
+			std::string featureName = featureNode.attribute("name").value();
+
+			auto it = std::find_if(mSharedFeatures.cbegin(), mSharedFeatures.cend(), [featureName](const CustomFeature& x) { return x.value == featureName; });
+			if (it != mSharedFeatures.cend())
+				ret.push_back(*it);
+
+			continue;
+		}		
+		else if (name != "feature")
 			continue;
 
 		CustomFeature feat;
@@ -565,6 +581,7 @@ bool SystemData::loadEsFeaturesFile()
 	es_features.clear();
 	es_features_loaded = false;
 	mGlobalFeatures.clear();
+	mSharedFeatures.clear();
 
 	std::string path = Utils::FileSystem::getEsConfigPath() + "/es_features.cfg";
 	if (!Utils::FileSystem::exists(path))
@@ -590,7 +607,11 @@ bool SystemData::loadEsFeaturesFile()
 		LOG(LogError) << "es_features.cfg is missing the <features> tag!";
 		return false;
 	}
-	
+
+	pugi::xml_node sharedFeatures = systemList.child("sharedFeatures");
+	if (sharedFeatures)
+		mSharedFeatures = loadCustomFeatures(sharedFeatures);
+
 	pugi::xml_node globalFeatures = systemList.child("globalFeatures");
 	if (globalFeatures)
 		mGlobalFeatures = loadCustomFeatures(globalFeatures);

--- a/es-app/src/SystemData.h
+++ b/es-app/src/SystemData.h
@@ -300,6 +300,7 @@ public:
 
 	bool shouldExtractHashesFromArchives();
 
+	static std::vector<CustomFeature> mSharedFeatures;
 	static std::vector<CustomFeature> mGlobalFeatures;
 
 	bool getShowFilenames();


### PR DESCRIPTION
Allow features to be reused elsewhere without duplicating them multiple times.
Here's a sample of what can be achieved :

```
<features>
  <sharedFeatures>
    <feature name="INPUT DRIVER" value="input_driver" >
      <choice name="SDL2" value="sdl2"/>
      [...]
    </feature>
  </sharedFeatures>
  <globalFeatures>
    <sharedFeature value="input_driver" />
  </globalFeatures>
  <emulator name="libretro">
    <sharedFeature name="input_driver"/>
  [...]
  <emulator name="pcsx2">
    <sharedFeature value="input_driver"/>
  [...]
```