### PR TITLE
Scaper : Add bezel option to screenscraper + Gameinfo : Provide full paths

### DIFF
--- a/es-app/src/FileData.cpp
+++ b/es-app/src/FileData.cpp
@@ -490,12 +490,12 @@ std::string FileData::getlaunchCommand(LaunchGameOptions& options, bool includeC
 
 	// Export Game info XML is requested
 #ifdef WIN32
-	std::string fileInfo = Utils::FileSystem::combine(Utils::FileSystem::getTempPath(), "gameinfo.xml");
+	std::string fileInfo = Utils::FileSystem::combine(Utils::FileSystem::getTempPath(), "game.xml");
 #else
-	std::string fileInfo = "/tmp/gameinfo.xml";
+	std::string fileInfo = "/tmp/game.xml";
 #endif
 
-	if (command.find("%GAMEINFOXML%") != std::string::npos && saveToXml(gameToUpdate, fileInfo))
+	if (command.find("%GAMEINFOXML%") != std::string::npos && saveToXml(gameToUpdate, fileInfo, true))
 		command = Utils::String::replace(command, "%GAMEINFOXML%", Utils::FileSystem::getEscapedPath(fileInfo));
 	else
 	{

--- a/es-app/src/Gamelist.h
+++ b/es-app/src/Gamelist.h
@@ -19,7 +19,7 @@ void cleanupGamelist(SystemData* system);
 bool saveToGamelistRecovery(FileData* file);
 bool removeFromGamelistRecovery(FileData* file);
 
-bool saveToXml(FileData* file, const std::string& fileName);
+bool saveToXml(FileData* file, const std::string& fileName, bool fullPaths = false);
 
 bool hasDirtyFile(SystemData* system);
 

--- a/es-app/src/MetaData.cpp
+++ b/es-app/src/MetaData.cpp
@@ -45,6 +45,7 @@ void MetaDataList::initMetadata()
 		{ Manual,			"manual",	   MD_PATH,                "",                 false,      _("Manual"),               _("enter path to manual"),     true },
 		{ Magazine,			"magazine",	   MD_PATH,                "",                 false,      _("Magazine"),             _("enter path to magazine"),     true },
 		{ Map,			    "map",	       MD_PATH,                "",                 false,      _("Map"),                  _("enter path to map"),		 true },
+		{ Bezel,            "bezel",       MD_PATH,                "",                 false,      _("Bezel (16:9)"),         _("enter path to bezel (16:9)"),	 true },
 
 		// Non scrappable /editable medias
 		{ Cartridge,        "cartridge",   MD_PATH,                "",                 true,       _("Cartridge"),            _("enter path to cartridge"),  true },
@@ -244,7 +245,7 @@ void MetaDataList::migrate(FileData* file, pugi::xml_node& node)
 	}
 }
 
-void MetaDataList::appendToXML(pugi::xml_node& parent, bool ignoreDefaults, const std::string& relativeTo) const
+void MetaDataList::appendToXML(pugi::xml_node& parent, bool ignoreDefaults, const std::string& relativeTo, bool fullPaths) const
 {
 	const std::vector<MetaDataDecl>& mdd = getMDD();
 
@@ -271,9 +272,13 @@ void MetaDataList::appendToXML(pugi::xml_node& parent, bool ignoreDefaults, cons
 			// try and make paths relative if we can
 			std::string value = mapIter->second;
 			if (mddIter->type == MD_PATH)
-				value = Utils::FileSystem::createRelativePath(value, relativeTo, true);
-
-			
+			{
+				if (fullPaths && mRelativeTo != nullptr)
+					value = Utils::FileSystem::resolveRelativePath(value, mRelativeTo->getStartPath(), true);
+				else
+					value = Utils::FileSystem::createRelativePath(value, relativeTo, true);
+			}
+						
 			if (mddIter->isAttribute)
 				parent.append_attribute(mddIter->key.c_str()).set_value(value.c_str());
 			else

--- a/es-app/src/MetaData.h
+++ b/es-app/src/MetaData.h
@@ -71,7 +71,8 @@ enum MetaDataId
 	BoxBack = 37,
 	Magazine = 38,
 	GenreIds = 39,
-	Family = 40
+	Family = 40,
+	Bezel = 41
 };
 
 namespace MetaDataImportType
@@ -131,7 +132,7 @@ public:
 	static void initMetadata();
 
 	static MetaDataList createFromXML(MetaDataListType type, pugi::xml_node& node, SystemData* system);
-	void appendToXML(pugi::xml_node& parent, bool ignoreDefaults, const std::string& relativeTo) const;
+	void appendToXML(pugi::xml_node& parent, bool ignoreDefaults, const std::string& relativeTo, bool fullPaths = false) const;
 
 	void migrate(FileData* file, pugi::xml_node& node);
 

--- a/es-app/src/SaveStateRepository.cpp
+++ b/es-app/src/SaveStateRepository.cpp
@@ -84,7 +84,7 @@ void SaveStateRepository::refresh()
 		state->fileName = file.path;
 
 #if WIN32
-		state->creationDate.setTime(file.creationTime);
+		state->creationDate.setTime(file.lastWriteTime);
 #else
 		state->creationDate = Utils::FileSystem::getFileModificationDate(state->fileName);
 #endif

--- a/es-app/src/components/ScraperSearchComponent.cpp
+++ b/es-app/src/components/ScraperSearchComponent.cpp
@@ -15,6 +15,7 @@
 #include "Log.h"
 #include "Window.h"
 #include "LocaleES.h"
+#include "components/MultiLineMenuEntry.h"
 
 ScraperSearchComponent::ScraperSearchComponent(Window* window, SearchType type) : GuiComponent(window),
 	mGrid(window, Vector2i(5, 5)), mBusyAnim(window),
@@ -341,9 +342,16 @@ void ScraperSearchComponent::onSearchDone()
 				if (result.urls.find(MetaDataId::Manual) != result.urls.cend())
 					icons += _U(" \uF02D");
 
+				if (result.urls.find(MetaDataId::Map) != result.urls.cend())
+					icons += _U(" \uF0AC");
+
+				if (result.urls.find(MetaDataId::Bezel) != result.urls.cend())
+					icons += _U(" \uF07E");
+
 				row.elements.clear();
-				row.addElement(std::make_shared<TextComponent>(mWindow, Utils::String::toUpper(result.mdl.get(MetaDataId::Name)) + " " + icons, font, color), true);
+				row.addElement(std::make_shared<TextComponent>(mWindow, Utils::String::toUpper(result.mdl.get(MetaDataId::Name)) + " " + icons, font, color), true);					
 				row.makeAcceptInputHandler([this, result] { returnResult(result); });
+
 				mResultList->addRow(row, false, true, std::to_string(i));
 
 				i++;

--- a/es-app/src/guis/GuiCollectionSystemsOptions.cpp
+++ b/es-app/src/guis/GuiCollectionSystemsOptions.cpp
@@ -34,7 +34,7 @@ void GuiCollectionSystemsOptions::initializeMenu()
 		std::string man;
 		for (auto system : SystemData::sSystemVector)
 		{
-			if (system->isCollection() || system->isGroupChildSystem())
+			if (system->isCollection()/* || system->isGroupChildSystem()*/)
 				continue;
 
 			if (man != system->getSystemMetadata().manufacturer)
@@ -49,7 +49,7 @@ void GuiCollectionSystemsOptions::initializeMenu()
 	else
 	{
 		for (auto system : SystemData::sSystemVector)
-			if (!system->isCollection() && !system->isGroupChildSystem())
+			if (!system->isCollection()/* && !system->isGroupChildSystem()*/)
 				displayedSystems->add(system->getFullName(), system, std::find(hiddenSystems.cbegin(), hiddenSystems.cend(), system->getName()) == hiddenSystems.cend());
 	}
 
@@ -62,7 +62,7 @@ void GuiCollectionSystemsOptions::initializeMenu()
 
 		for (auto system : SystemData::sSystemVector)
 		{
-			if (system->isCollection() || system->isGroupChildSystem())
+			if (system->isCollection()/* || system->isGroupChildSystem()*/)
 				continue;
 
 			if (std::find(sys.cbegin(), sys.cend(), system) == sys.cend())
@@ -133,7 +133,7 @@ void GuiCollectionSystemsOptions::initializeMenu()
 
 			for (auto groupName : groupNames)
 			{
-				if (std::find(checkedItems.cbegin(), checkedItems.cend(), groupName) == checkedItems.cend())
+				if (std::find(checkedItems.cbegin(), checkedItems.cend(), groupName) == checkedItems.cend() && Settings::getInstance()->getBool(groupName + ".ungroup"))
 					Settings::getInstance()->setBool(groupName + ".ungroup", false);
 
 				for (auto systemName : SystemData::getGroupChildSystemNames(groupName))
@@ -141,9 +141,13 @@ void GuiCollectionSystemsOptions::initializeMenu()
 					if (systemName == groupName)
 						continue;
 
-					bool isGroupActive = std::find(checkedItems.cbegin(), checkedItems.cend(), systemName) != checkedItems.cend();
-					if (Settings::getInstance()->setBool(systemName + ".ungroup", !isGroupActive))
-						setVariable("reloadSystems", true);
+					bool unGrouped = std::find(checkedItems.cbegin(), checkedItems.cend(), systemName) == checkedItems.cend();
+
+					if (Settings::getInstance()->getBool(systemName + ".ungroup") == unGrouped)
+						continue;
+
+					Settings::getInstance()->setBool(systemName + ".ungroup", unGrouped);
+					setVariable("reloadSystems", true);
 				}
 			}
 		});

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -376,6 +376,9 @@ void GuiMenu::openScraperSettings()
 		if (scrap->isMediaSupported(Scraper::ScraperMediaSource::FanArt))
 			addSwitchComponent(_("SCRAPE FANART"), "ScrapeFanart");
 
+		if (scrap->isMediaSupported(Scraper::ScraperMediaSource::Bezel_16_9))
+			addSwitchComponent(_("SCRAPE BEZEL (16:9)"), "ScrapeBezel");
+
 		if (scrap->isMediaSupported(Scraper::ScraperMediaSource::BoxBack))
 			addSwitchComponent(_("SCRAPE BOX BACKSIDE"), "ScrapeBoxBack");
 

--- a/es-app/src/scrapers/Scraper.cpp
+++ b/es-app/src/scrapers/Scraper.cpp
@@ -95,6 +95,11 @@ bool Scraper::hasMissingMedia(FileData* file)
 		if (Settings::getInstance()->getBool("ScrapeCartridge") && (file->getMetadata(MetaDataId::Cartridge).empty() || !Utils::FileSystem::exists(file->getMetadata(MetaDataId::Cartridge))))
 			return true;
 
+	if (isMediaSupported(ScraperMediaSource::Bezel_16_9))
+		if (Settings::getInstance()->getBool("ScrapeBezel") && (file->getMetadata(MetaDataId::Bezel).empty() || !Utils::FileSystem::exists(file->getMetadata(MetaDataId::Bezel))))
+			return true;
+	
+
 	return false;
 }
 
@@ -294,6 +299,7 @@ MDResolveHandle::MDResolveHandle(const ScraperSearchResult& result, const Scrape
 		case MetaDataId::Magazine: suffix = "magazine"; resize = false;  break;
 		case MetaDataId::Map: suffix = "map"; resize = false; break;
 		case MetaDataId::Cartridge: suffix = "cartridge"; break;
+		case MetaDataId::Bezel: suffix = "bezel"; resize = false; break;
 		}
 
 		auto ext = url.second.format;
@@ -519,7 +525,7 @@ void ImageDownloadHandle::update()
 		}
 
 		// It's an image ?
-		if (mSavePath.find("-fanart") == std::string::npos && mSavePath.find("-map") == std::string::npos && (ext == ".jpg" || ext == ".jpeg" || ext == ".png" || ext == ".bmp" || ext == ".gif"))
+		if (mSavePath.find("-fanart") == std::string::npos && mSavePath.find("-bezel") == std::string::npos && mSavePath.find("-map") == std::string::npos && (ext == ".jpg" || ext == ".jpeg" || ext == ".png" || ext == ".bmp" || ext == ".gif"))
 		{
 			try { resizeImage(mSavePath, mMaxWidth, mMaxHeight); }
 			catch(...) { }
@@ -622,6 +628,7 @@ std::string Scraper::getSaveAsPath(FileData* game, const MetaDataId metadataId, 
 	case MetaDataId::Magazine: suffix = "magazine"; folder = "magazines"; break;
 	case MetaDataId::Map: suffix = "map"; break;
 	case MetaDataId::Cartridge: suffix = "cartridge"; break;
+	case MetaDataId::Bezel: suffix = "bezel"; break;
 	}
 
 	auto system = game->getSourceFileData()->getSystem();

--- a/es-app/src/scrapers/Scraper.h
+++ b/es-app/src/scrapers/Scraper.h
@@ -218,7 +218,8 @@ public:
 		BoxBack = 13,
 		Magazine = 14,
 		PadToKey = 15,
-		Ratings = 16
+		Ratings = 16,
+		Bezel_16_9 = 17
 	};
 
 	static std::vector<std::pair<std::string, Scraper*>> scrapers;

--- a/es-app/src/scrapers/ScreenScraper.cpp
+++ b/es-app/src/scrapers/ScreenScraper.cpp
@@ -194,7 +194,8 @@ const std::set<Scraper::ScraperMediaSource>& ScreenScraperScraper::getSupportedM
 		ScraperMediaSource::Mix,
 		ScraperMediaSource::Manual,
 		ScraperMediaSource::Ratings,
-		ScraperMediaSource::PadToKey
+		ScraperMediaSource::PadToKey,
+		ScraperMediaSource::Bezel_16_9
 	};
 
 	return mdds;
@@ -699,7 +700,7 @@ void ScreenScraperRequest::processGame(const pugi::xml_document& xmldoc, std::ve
 					if (art)
 						result.urls[MetaDataId::Marquee] = ScraperSearchItem(ensureUrl(art.text().get()), art.attribute("format") ? "." + std::string(art.attribute("format").value()) : "");
 					else
-						LOG(LogDebug) << "Failed to find media XML node for video";
+						LOG(LogDebug) << "Failed to find media XML node for logo";
 				}
 			}
 
@@ -725,7 +726,7 @@ void ScreenScraperRequest::processGame(const pugi::xml_document& xmldoc, std::ve
 					if (art)
 						result.urls[MetaDataId::FanArt] = ScraperSearchItem(ensureUrl(art.text().get()), art.attribute("format") ? "." + std::string(art.attribute("format").value()) : "");
 					else
-						LOG(LogDebug) << "Failed to find media XML node for video";
+						LOG(LogDebug) << "Failed to find media XML node for fanart";
 				}
 			}
 			
@@ -738,7 +739,7 @@ void ScreenScraperRequest::processGame(const pugi::xml_document& xmldoc, std::ve
 					if (art)
 						result.urls[MetaDataId::BoxBack] = ScraperSearchItem(ensureUrl(art.text().get()), art.attribute("format") ? "." + std::string(art.attribute("format").value()) : "");
 					else
-						LOG(LogDebug) << "Failed to find media XML node for video";
+						LOG(LogDebug) << "Failed to find media XML node for box back";
 				}
 			}
 
@@ -752,7 +753,7 @@ void ScreenScraperRequest::processGame(const pugi::xml_document& xmldoc, std::ve
 					if (art)
 						result.urls[MetaDataId::Manual] = ScraperSearchItem(ensureUrl(art.text().get()), art.attribute("format") ? "." + std::string(art.attribute("format").value()) : "");
 					else
-						LOG(LogDebug) << "Failed to find media XML node for video";
+						LOG(LogDebug) << "Failed to find media XML node for manual";
 				}
 			}
 
@@ -765,7 +766,7 @@ void ScreenScraperRequest::processGame(const pugi::xml_document& xmldoc, std::ve
 					if (art)
 						result.urls[MetaDataId::Map] = ScraperSearchItem(ensureUrl(art.text().get()), art.attribute("format") ? "." + std::string(art.attribute("format").value()) : "");
 					else
-						LOG(LogDebug) << "Failed to find media XML node for video";
+						LOG(LogDebug) << "Failed to find media XML node for map";
 				}
 			}
 
@@ -778,9 +779,22 @@ void ScreenScraperRequest::processGame(const pugi::xml_document& xmldoc, std::ve
 					if (art)
 						result.urls[MetaDataId::TitleShot] = ScraperSearchItem(ensureUrl(art.text().get()), art.attribute("format") ? "." + std::string(art.attribute("format").value()) : "");
 					else
-						LOG(LogDebug) << "Failed to find media XML node for video";
+						LOG(LogDebug) << "Failed to find media XML node for titleshot";
 				}
 			}		
+			
+			if (Settings::getInstance()->getBool("ScrapeBezel"))
+			{
+				ripList = getRipList("bezel-16-9");
+				if (!ripList.empty())
+				{
+					pugi::xml_node art = findMedia(media_list, ripList, romlang, region);
+					if (art)
+						result.urls[MetaDataId::Bezel] = ScraperSearchItem(ensureUrl(art.text().get()), art.attribute("format") ? "." + std::string(art.attribute("format").value()) : "");
+					else
+						LOG(LogDebug) << "Failed to find media XML node for bezel";
+				}
+			}
 		}
 
 		out_results.push_back(result);

--- a/es-app/src/views/gamelist/BasicGameListView.cpp
+++ b/es-app/src/views/gamelist/BasicGameListView.cpp
@@ -57,17 +57,7 @@ void BasicGameListView::onFileChanged(FileData* file, FileChangeType change)
 
 void BasicGameListView::populateList(const std::vector<FileData*>& files)
 {
-	SystemData* system = mCursorStack.size() && !mRoot->getSystem()->isGameSystem() ? mCursorStack.top()->getSystem() : mRoot->getSystem();
-
-	auto groupTheme = system->getTheme();
-	if (groupTheme && mHeaderImage.hasImage())
-	{
-		const ThemeData::ThemeElement* logoElem = groupTheme->getElement(getName(), "logo", "image");
-		if (logoElem && logoElem->has("path") && Utils::FileSystem::exists(logoElem->get<std::string>("path")))
-			mHeaderImage.setImage(logoElem->get<std::string>("path"), false, mHeaderImage.getMaxSizeInfo());
-	}
-
-	mHeaderText.setText(system->getFullName());
+	updateHeaderLogoAndText();
 
 	mList.clear();
 

--- a/es-app/src/views/gamelist/CarouselGameListView.cpp
+++ b/es-app/src/views/gamelist/CarouselGameListView.cpp
@@ -65,17 +65,7 @@ void CarouselGameListView::onFileChanged(FileData* file, FileChangeType change)
 
 void CarouselGameListView::populateList(const std::vector<FileData*>& files)
 {
-	SystemData* system = mCursorStack.size() && !mRoot->getSystem()->isGameSystem() ? mCursorStack.top()->getSystem() : mRoot->getSystem();
-
-	auto groupTheme = system->getTheme();
-	if (groupTheme && mHeaderImage.hasImage())
-	{
-		const ThemeData::ThemeElement* logoElem = groupTheme->getElement(getName(), "logo", "image");
-		if (logoElem && logoElem->has("path") && Utils::FileSystem::exists(logoElem->get<std::string>("path")))
-			mHeaderImage.setImage(logoElem->get<std::string>("path"), false, mHeaderImage.getMaxSizeInfo());
-	}
-
-	mHeaderText.setText(system->getFullName());
+	updateHeaderLogoAndText();
 
 	mList.clear();
 

--- a/es-app/src/views/gamelist/GridGameListView.cpp
+++ b/es-app/src/views/gamelist/GridGameListView.cpp
@@ -144,17 +144,7 @@ const bool GridGameListView::isVirtualFolder(FileData* file)
 
 void GridGameListView::populateList(const std::vector<FileData*>& files)
 {
-	SystemData* system = mCursorStack.size() && !mRoot->getSystem()->isGameSystem() ? mCursorStack.top()->getSystem() : mRoot->getSystem();
-
-	auto groupTheme = system->getTheme();
-	if (groupTheme && mHeaderImage.hasImage())
-	{
-		const ThemeData::ThemeElement* logoElem = groupTheme->getElement(getName(), "logo", "image");
-		if (logoElem && logoElem->has("path") && Utils::FileSystem::exists(logoElem->get<std::string>("path")))
-			mHeaderImage.setImage(logoElem->get<std::string>("path"), false, mHeaderImage.getMaxSizeInfo());
-	}
-
-	mHeaderText.setText(system->getFullName());
+	updateHeaderLogoAndText();
 
 	mGrid.resetLastCursor();
 	mGrid.clear(); 

--- a/es-app/src/views/gamelist/ISimpleGameListView.cpp
+++ b/es-app/src/views/gamelist/ISimpleGameListView.cpp
@@ -54,6 +54,7 @@ ISimpleGameListView::ISimpleGameListView(Window* window, FolderData* root, bool 
 
 }
 
+
 ISimpleGameListView::~ISimpleGameListView()
 {
 	for (auto extra : mThemeExtras)
@@ -464,6 +465,21 @@ std::vector<std::string> ISimpleGameListView::getEntriesLetters()
 
 	std::sort(letters.begin(), letters.end());
 	return letters;
+}
+
+void ISimpleGameListView::updateHeaderLogoAndText()
+{
+	SystemData* system = mCursorStack.size() && (!mRoot->getSystem()->isGameSystem() || mRoot->getSystem()->isGroupSystem()) ? mCursorStack.top()->getSystem() : mRoot->getSystem();
+
+	auto groupTheme = system->getTheme();
+	if (groupTheme && mHeaderImage.hasImage())
+	{
+		const ThemeData::ThemeElement* logoElem = groupTheme->getElement(getName(), "logo", "image");
+		if (logoElem && logoElem->has("path") && Utils::FileSystem::exists(logoElem->get<std::string>("path")))
+			mHeaderImage.setImage(logoElem->get<std::string>("path"), false, mHeaderImage.getMaxSizeInfo());
+	}
+
+	mHeaderText.setText(system->getFullName());
 }
 
 void ISimpleGameListView::updateFolderPath()

--- a/es-app/src/views/gamelist/ISimpleGameListView.h
+++ b/es-app/src/views/gamelist/ISimpleGameListView.h
@@ -57,6 +57,7 @@ public:
 
 protected:	
 	void	  updateFolderPath();
+	void      updateHeaderLogoAndText();
 
 	virtual std::string getQuickSystemSelectRightButton() = 0;
 	virtual std::string getQuickSystemSelectLeftButton() = 0;

--- a/es-core/src/utils/FileSystemUtil.cpp
+++ b/es-core/src/utils/FileSystemUtil.cpp
@@ -393,7 +393,7 @@ namespace Utils
 						fi.path = path + "/" + name;
 						fi.hidden = (findData.dwFileAttributes & FILE_ATTRIBUTE_HIDDEN) == FILE_ATTRIBUTE_HIDDEN;
 						fi.directory = (findData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) == FILE_ATTRIBUTE_DIRECTORY;
-						fi.creationTime = to_time_t(findData.ftCreationTime);
+						fi.lastWriteTime = to_time_t(findData.ftLastWriteTime);
 
 						contentList.push_back(fi);
 

--- a/es-core/src/utils/FileSystemUtil.h
+++ b/es-core/src/utils/FileSystemUtil.h
@@ -54,7 +54,7 @@ namespace Utils
 			bool hidden;
 			bool directory;
 #if WIN32
-			time_t creationTime;
+			time_t lastWriteTime;
 #endif
 		};
 


### PR DESCRIPTION
+ Scaper : Add bezel option to screenscraper
+ Gameinfo : Provide full paths
 Win32/SaveStates : use modification date instead of creation time 
+ Grouped systems : Fix - unable to hide a system when it's grouped into another one + Fix group child system logo when showing folders