### PR TITLE
Integrate PixelArcade support

### DIFF
--- a/es-app/src/SystemScreenSaver.cpp
+++ b/es-app/src/SystemScreenSaver.cpp
@@ -22,6 +22,7 @@
 #include "SystemConf.h"
 #include "ImageIO.h"
 #include "utils/Randomizer.h"
+#include "HttpReq.h"
 
 #define FADE_TIME 			500
 
@@ -124,6 +125,13 @@ void SystemScreenSaver::startScreenSaver()
 
 			PowerSaver::runningScreenSaver(true);
 			mTimer = 0;
+
+			if (mCurrentGame != NULL) {
+				HttpReq req("http://127.0.0.1:8080/arcade/stream/" + HttpReq::urlEncode(mCurrentGame->getSystem()->getName()) + "/" + HttpReq::urlEncode(mCurrentGame->getFileName()) + "?t=" + HttpReq::urlEncode(mCurrentGame->getName()));
+				if(req.status() != 200){
+         			//std::cout "http://127.0.0.1:8080/arcade/stream/" << mCurrentGame->getSystem()->getName() << "/" << mCurrentGame->getFileName() << "failed.";
+           		}
+			}
 			return;
 		}
 	}
@@ -154,6 +162,19 @@ void SystemScreenSaver::startScreenSaver()
 		}
 		else
 			path = pickRandomGameListImage();
+
+		if (mCurrentGame != NULL) {
+			HttpReq req("http://127.0.0.1:8080/arcade/stream/" + HttpReq::urlEncode(mCurrentGame->getSystem()->getName()) + "/" + HttpReq::urlEncode(mCurrentGame->getFileName()) + "?t=" + HttpReq::urlEncode(mCurrentGame->getName()));
+			if(req.status() != 200){
+				//std::cout "http://127.0.0.1:8080/arcade/stream/" << mCurrentGame->getSystem()->getName() << "/" << mCurrentGame->getFileName() << "failed.";
+			}
+		}
+
+		// No videos. Just use a standard random screensaver.
+		HttpReq req("http://127.0.0.1:8080/animations?r");
+		if(req.status() != 200) {
+			//std::cout "http://127.0.0.1:8080/arcade/stream/" << mCurrentGame->getSystem()->getName() << "/" << mCurrentGame->getFileName() << "failed.";
+		}
 
 		if (!path.empty() && Utils::FileSystem::exists(path))
 		{

--- a/es-app/src/views/SystemView.cpp
+++ b/es-app/src/views/SystemView.cpp
@@ -22,6 +22,7 @@
 #include "guis/GuiTextEditPopup.h"
 #include "guis/GuiTextEditPopupKeyboard.h"
 #include "TextToSpeech.h"
+#include "HttpReq.h"
 
 // buffer values for scrolling velocity (left, stopped, right)
 const int logoBuffersLeft[] = { -5, -2, -1 };
@@ -559,6 +560,11 @@ bool SystemView::input(InputConfig* config, Input input)
 			config->isMappedLike("l2", input) ||
 			config->isMappedLike("r2", input))
 			listInput(0);
+		std::string system = this->IList::getSelected()->getName();
+        //if (system != NULL) {
+			HttpReq req("http://127.0.0.1:8080/console/stream/" + HttpReq::urlEncode(system));
+			if(req.status() != 200 ){}
+		//}
 		/*
 #ifdef WIN32
 		// batocera

--- a/es-app/src/views/ViewController.cpp
+++ b/es-app/src/views/ViewController.cpp
@@ -28,6 +28,7 @@
 #include "utils/ThreadPool.h"
 #include <SDL_timer.h>
 #include "TextToSpeech.h"
+#include "HttpReq.h"
 
 ViewController* ViewController::sInstance = nullptr;
 
@@ -102,6 +103,16 @@ void ViewController::goToStart(bool forceImmediate)
 
 	if("" != requestedSystem && "retropie" != requestedSystem)
 	{
+		for(auto it = SystemData::sSystemVector.cbegin(); it != SystemData::sSystemVector.cend(); it++){
+			if ((*it)->getName() == requestedSystem)
+			{       
+			  goToGameList(*it);
+			  //if (requestedSystem != NULL) {
+				  HttpReq req("http://127.0.0.1:8080/console/stream/" + HttpReq::urlEncode(requestedSystem) + "?t=" + HttpReq::urlEncode(requestedSystem));
+				  if(req.status() != 200){}
+			  //}
+			}
+		}
 		auto system = SystemData::getSystem(requestedSystem);
 		if (system != nullptr && !system->isGroupChildSystem())
 		{
@@ -262,6 +273,18 @@ void ViewController::goToGameList(SystemData* system, bool forceImmediate)
 		sysList->setPosition(view->getPosition().x(), sysList->getPosition().y());
 		offX = sysList->getPosition().x() - offX;
 		mCamera.translation().x() -= offX;
+        if (system != NULL) {
+			HttpReq req("http://127..0.1:8080/console/stream/" + HttpReq::urlEncode(system->getName()));
+			if(req.status() != 200){}
+		}
+		//std::cout <<  "http://127.0.0.1:8080/arcade/stream/" << HttpReq::urlEncode(system->getName()) << "failed.";
+				
+		/*httplib::Client cli("localhost", 8080);
+                          std::string url = "/arcade/stream/" + system->getName();
+                          auto res = cli.Get( &url[0]);
+                          if (res && res->status == 200) {
+                             std::cout << res->body << std::endl;
+                           }*/
 	}	
 	else if (mState.viewing == GAME_LIST && mState.system != nullptr)
 	{

--- a/es-app/src/views/gamelist/ISimpleGameListView.cpp
+++ b/es-app/src/views/gamelist/ISimpleGameListView.cpp
@@ -23,6 +23,7 @@
 #include "guis/GuiGamelistOptions.h"
 #include "BasicGameListView.h"
 #include "utils/Randomizer.h"
+#include "HttpReq.h"
 
 ISimpleGameListView::ISimpleGameListView(Window* window, FolderData* root, bool temporary) : IGameListView(window, root),
 	mHeaderText(window), mHeaderImage(window), mBackground(window), mFolderPath(window), mOnExitPopup(nullptr),
@@ -310,6 +311,21 @@ bool ISimpleGameListView::input(InputConfig* config, Input input)
 
 		return true;
 	}
+
+	FileData* cursor = getCursor();
+    SystemData* system = this->mRoot->getSystem();
+    if (system != NULL) { 
+		  HttpReq req("http://127.0.0.1:8080/arcade/stream/" + HttpReq::urlEncode(system->getName()) + "/" + HttpReq::urlEncode(cursor->getFileName()) + "?t=" + HttpReq::urlEncode( cursor->getName()));
+		  if(req.status() != 200){}
+	}
+	 //std::cout << "http://127.0.0.1:8080/arcade/stream/" << system->getName() << "/" << cursor->getFileName() << "callfailed.";
+	 //}
+	/*httplib::Client cli("localhost", 8080);
+                          std::string url = "/arcade/stream/" + system->getName() + "/" + cursor->getFileName();
+                          auto res = cli.Get( &url[0]);
+                          if (res && res->status == 200) {
+                             std::cout << res->body << std::endl;
+                           }*/ 
 
 	return IGameListView::input(config, input);
 }


### PR DESCRIPTION
User needs to separately install all the necessary dependencies and make sure everything else is configured correctly in Batocera itself.

This change just makes it so that they can use batocera-emulationstation with it as well as the custom fork of emulationstation PixelArcade has. One fork that natively supports PixelArcade: https://github.com/alinke/PIXEL/tree/wip/EmulationStation-kai

Would like to have another dev look over this first before I switch this off of draft.

To help with organising my thoughts I made notes in draft copies containing just the code that was needed to be used and where it should go:
[modified.zip](https://github.com/batocera-linux/batocera-emulationstation/files/7612702/modified.zip) 