### PR TITLE
Fix an issue with non-scraped games on Linux

### DIFF
--- a/es-app/src/FileData.cpp
+++ b/es-app/src/FileData.cpp
@@ -501,8 +501,13 @@ std::string FileData::getlaunchCommand(LaunchGameOptions& options, bool includeC
 		command = Utils::String::replace(command, "%GAMEINFOXML%", Utils::FileSystem::getEscapedPath(fileInfo));
 	else
 	{
+#ifdef WIN32
 		command = Utils::String::replace(command, "%GAMEINFOXML%", "");
 		Utils::FileSystem::removeFile(fileInfo);
+#else
+		// Linux emulatorlauncher.py (Batocera) always requires a /tmp/game.xml (even if non existent file)
+		command = Utils::String::replace(command, "%GAMEINFOXML%", Utils::FileSystem::getEscapedPath(fileInfo));
+#endif
 	}
 	
 	if (includeControllers)


### PR DESCRIPTION
emulatorlauncher.py on Batocera always requires an argument for ` -gameinfoxml` (even if the file doesn't exist).