### PR TITLE
Add game-selected and system-selected events

### DIFF
--- a/es-app/src/FileData.cpp
+++ b/es-app/src/FileData.cpp
@@ -1646,11 +1646,15 @@ std::string FileData::getCurrentGameSetting(const std::string& settingName)
 	return SystemConf::getInstance()->get("global." + settingName);
 }
 
-void FileData::speak()
+void FileData::setSelectedGame()
 {
 	TextToSpeech::getInstance()->say(getName(), false);
+
+	Scripting::fireEvent("game-selected", getSourceFileData()->getSystem()->getName(), getPath(), getName());
 
 	std::string desc = getMetadata(MetaDataId::Desc);
 	if (!desc.empty())
 		TextToSpeech::getInstance()->say(desc, true);
+
+	
 }

--- a/es-app/src/FileData.h
+++ b/es-app/src/FileData.h
@@ -152,7 +152,7 @@ public:
 	bool hasContentFiles();
 	std::set<std::string> getContentFiles();
 
-	void speak();
+	void setSelectedGame();
 
 private:
 	std::string getKeyboardMappingFilePath();

--- a/es-app/src/SystemScreenSaver.cpp
+++ b/es-app/src/SystemScreenSaver.cpp
@@ -11,6 +11,7 @@
 #include "FileFilterIndex.h"
 #include "Log.h"
 #include "PowerSaver.h"
+#include "Scripting.h"
 #include "Sound.h"
 #include "SystemData.h"
 #include "components/ImageComponent.h"
@@ -122,6 +123,7 @@ void SystemScreenSaver::startScreenSaver()
 			mVideoScreensaver->setGame(mCurrentGame);
 			mVideoScreensaver->setVideo(path);
 
+			Scripting::fireEvent("game-selected", mCurrentGame->getSystem()->getName(), mCurrentGame->getPath(), mCurrentGame->getName());
 			PowerSaver::runningScreenSaver(true);
 			mTimer = 0;
 			return;
@@ -163,6 +165,7 @@ void SystemScreenSaver::startScreenSaver()
 			mImageScreensaver->setGame(mCurrentGame);
 			mImageScreensaver->setImage(path);
 
+			Scripting::fireEvent("game-selected", mCurrentGame->getSystem()->getName(), mCurrentGame->getPath(), mCurrentGame->getName());
 			PowerSaver::runningScreenSaver(true);
 			mTimer = 0;
 			return;

--- a/es-app/src/views/SystemView.cpp
+++ b/es-app/src/views/SystemView.cpp
@@ -5,6 +5,7 @@
 #include "views/UIModeController.h"
 #include "views/ViewController.h"
 #include "Log.h"
+#include "Scripting.h"
 #include "Settings.h"
 #include "SystemData.h"
 #include "Window.h"
@@ -832,7 +833,10 @@ void SystemView::onCursorChanged(const CursorState& state)
 
 	// tts
 	if(state == CURSOR_STOPPED)
+	{
 	  TextToSpeech::getInstance()->say(getSelected()->getFullName());
+	  Scripting::fireEvent("system-selected", getSelected()->getName());
+	}
 
 	if (!mCarousel.scrollSound.empty())
 		Sound::get(mCarousel.scrollSound)->play();

--- a/es-app/src/views/ViewController.cpp
+++ b/es-app/src/views/ViewController.cpp
@@ -14,6 +14,7 @@
 #include "views/UIModeController.h"
 #include "FileFilterIndex.h"
 #include "Log.h"
+#include "Scripting.h"
 #include "Settings.h"
 #include "SystemData.h"
 #include "Window.h"
@@ -190,6 +191,8 @@ void ViewController::goToSystemView(SystemData* system, bool forceImmediate)
 
 	mState.viewing = SYSTEM_SELECT;
 	mState.system = dest;
+
+	Scripting::fireEvent("system-selected", dest->getName());
 
 	systemList->goToSystem(dest, false);
 

--- a/es-app/src/views/gamelist/BasicGameListView.cpp
+++ b/es-app/src/views/gamelist/BasicGameListView.cpp
@@ -23,7 +23,7 @@ BasicGameListView::BasicGameListView(Window* window, FolderData* root)
 		{
 		  FileData* file = (mList.size() == 0 || mList.isScrolling()) ? NULL : mList.getSelected();
 		  if (file != nullptr)
-		    file->speak();
+		    file->setSelectedGame();
 		  
 			if (mRoot->getSystem()->isCollection())
 				updateHelpPrompts();

--- a/es-app/src/views/gamelist/DetailedContainer.cpp
+++ b/es-app/src/views/gamelist/DetailedContainer.cpp
@@ -1140,7 +1140,7 @@ void DetailedContainerHost::updateControls(FileData* file, bool isClearing, int 
 	if (!mContainer->anyComponentHasStoryBoard() || file == nullptr || isClearing || moveBy == 0)
 	{
 		if (file != nullptr && !isClearing)
-			file->speak();
+			file->setSelectedGame();
 
 		mContainer->updateControls(file, isClearing, moveBy);
 		return;
@@ -1156,7 +1156,7 @@ void DetailedContainerHost::updateControls(FileData* file, bool isClearing, int 
 	}
 
 	mActiveFile = file;
-	mActiveFile->speak();
+	mActiveFile->setSelectedGame();
 	bool clear = isClearing;
 	int by = moveBy;
 

--- a/es-core/src/Scripting.cpp
+++ b/es-core/src/Scripting.cpp
@@ -5,9 +5,9 @@
 
 namespace Scripting
 {
-	void fireEvent(const std::string& eventName, const std::string& arg1, const std::string& arg2)
+	void fireEvent(const std::string& eventName, const std::string& arg1, const std::string& arg2, const std::string& arg3)
 	{
-		LOG(LogDebug) << "fireEvent: " << eventName << " " << arg1 << " " << arg2;
+		LOG(LogDebug) << "fireEvent: " << eventName << " " << arg1 << " " << arg2 << " " << arg3;
 
         std::list<std::string> scriptDirList;
         std::string test;
@@ -25,8 +25,15 @@ namespace Scripting
         for(std::list<std::string>::const_iterator dirIt = scriptDirList.cbegin(); dirIt != scriptDirList.cend(); ++dirIt) {
             std::list<std::string> scripts = Utils::FileSystem::getDirContent(*dirIt);
             for (std::list<std::string>::const_iterator it = scripts.cbegin(); it != scripts.cend(); ++it) {
-                // append folder to path
-                std::string script = *it + " \"" + arg1 + "\" \"" + arg2 + "\"";
+                std::string script = *it;
+
+                for (auto arg : { arg1, arg2, arg3 })
+                {
+                    if (arg.empty())
+                        break;
+
+                    script += " \"" + arg + "\"";
+                }
                 LOG(LogDebug) << "  executing: " << script;
                 runSystemCommand(script, "", nullptr);
             }

--- a/es-core/src/Scripting.h
+++ b/es-core/src/Scripting.h
@@ -6,7 +6,7 @@
 
 namespace Scripting
 {
-	void fireEvent(const std::string& eventName, const std::string& arg1="", const std::string& arg2="");
+	void fireEvent(const std::string& eventName, const std::string& arg1="", const std::string& arg2="", const std::string& arg3="");
 } // Scripting::
 
 #endif //ES_CORE_SCRIPTING_H


### PR DESCRIPTION
This PR adds 2 new scripting events:

game-selected: fired when the cursor is on a game and when the screensaver selects a random game
system-selected: fired when the cursor is on a system

game-selected passes the system name, path to rom, and game name to fireEvent
system-selected passes the system name to fireEvent

Additionally, fireEvent was updated to accept an optional third argument. Arguments are also checked for empty strings and are dropped if empty.