### PR TITLE
SaveStates : Split "AUTO SAVE/LOAD" option in two options 

### DIFF
--- a/es-app/src/SaveState.cpp
+++ b/es-app/src/SaveState.cpp
@@ -7,8 +7,6 @@
 #include "SaveStateRepository.h"
 #include "SystemConf.h"
 
-#define incrementalSaveStates (SystemConf::getInstance()->get("global.incrementalsavestates") != "0")
-
 std::string SaveState::makeStateFilename(int slot, bool fullPath) const
 {
 	std::string ret = this->rom + ".state" + (slot < 0 ? ".auto" : (slot == 0 ? "" : std::to_string(slot)));
@@ -36,7 +34,7 @@ std::string SaveState::setupSaveState(FileData* game, const std::string& command
 
 	if (!isSlotValid())
 	{
-		if (nextSlot > 0)
+		if (nextSlot > 0 && !SystemConf::getIncrementalSaveStatesUseCurrentSlot())
 		{
 			// We start a game normally but there are saved games : Start game on next free slot to avoid loosing a saved game
 			return command + " -state_slot " + std::to_string(nextSlot);
@@ -44,6 +42,8 @@ std::string SaveState::setupSaveState(FileData* game, const std::string& command
 
 		return command;
 	}
+
+	bool incrementalSaveStates = SystemConf::getIncrementalSaveStates();
 	
 	std::string path = Utils::FileSystem::getParent(fileName);
 
@@ -135,7 +135,7 @@ void SaveState::onGameEnded(FileData* game)
 		Utils::FileSystem::renameFile(mAutoImageBackup + ".bak", mAutoImageBackup);
 	}
 
-	if (incrementalSaveStates)
+	if (SystemConf::getIncrementalSaveStates())
 		SaveStateRepository::renumberSlots(game);
 }
 

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -2031,6 +2031,7 @@ void GuiMenu::addDecorationSetOptionListComponent(Window* window, GuiSettings* p
 
 void GuiMenu::openGamesSettings_batocera() 
 {
+
 	Window* window = mWindow;
 
 	auto s = new GuiSettings(mWindow, _("GAME SETTINGS").c_str());
@@ -2091,18 +2092,6 @@ void GuiMenu::openGamesSettings_batocera()
 	integerscale_enabled->addRange({ { _("AUTO"), "auto" },{ _("ON") , "1" },{ _("OFF") , "0" } }, SystemConf::getInstance()->get("global.integerscale"));
 	s->addWithLabel(_("INTEGER SCALING (PIXEL PERFECT)"), integerscale_enabled);
 	s->addSaveFunc([integerscale_enabled] { SystemConf::getInstance()->set("global.integerscale", integerscale_enabled->getSelected()); });
-
-	// autosave/load
-	auto autosave_enabled = std::make_shared<OptionListComponent<std::string>>(mWindow, _("AUTO SAVE/LOAD ON GAME LAUNCH"));
-	autosave_enabled->addRange({ { _("OFF"), "auto" },{ _("ON") , "1" },{ _("SHOW SAVE STATES") , "2" },{ _("SHOW SAVE STATES IF NOT EMPTY") , "3" } }, SystemConf::getInstance()->get("global.autosave"));
-	s->addWithLabel(_("AUTO SAVE/LOAD ON GAME LAUNCH"), autosave_enabled);
-	s->addSaveFunc([autosave_enabled] { SystemConf::getInstance()->set("global.autosave", autosave_enabled->getSelected()); });
-	
-	// Incremental savestates
-	auto incrementalSaveStates = std::make_shared<SwitchComponent>(mWindow);
-	incrementalSaveStates->setState(SystemConf::getInstance()->get("global.incrementalsavestates") != "0");
-	s->addWithLabel(_("INCREMENTAL SAVESTATES"), incrementalSaveStates);
-	s->addSaveFunc([incrementalSaveStates] { SystemConf::getInstance()->set("global.incrementalsavestates", incrementalSaveStates->getState() ? "" : "0"); });
 
 	// Shaders preset
 	if (ApiSystem::getInstance()->isScriptingSupported(ApiSystem::SHADERS))
@@ -2339,6 +2328,32 @@ void GuiMenu::openGamesSettings_batocera()
 			}
 		}
 	}
+	// Custom config for systems
+	s->addGroup(_("SAVESTATES"));
+
+	// AUTO SAVE/LOAD
+	auto autosave_enabled = std::make_shared<SwitchComponent>(mWindow);
+	autosave_enabled->setState(SystemConf::getInstance()->get("global.autosave") == "1");
+	s->addWithLabel(_("AUTO SAVE/LOAD"), autosave_enabled);
+	s->addSaveFunc([autosave_enabled] { SystemConf::getInstance()->set("global.autosave", autosave_enabled->getState() ? "1" : ""); });
+
+	// INCREMENTAL SAVESTATES
+	auto incrementalSaveStates = std::make_shared<OptionListComponent<std::string>>(mWindow, _("INCREMENTAL SAVESTATES"));
+	incrementalSaveStates->addRange({ 
+		{ _("YES"), "", "" }, // Don't use 1 -> 1 is YES, auto too
+		{ _("NO") , _("NEW GAME CREATES NEW SLOT"), "0" },
+		{ _("DISABLED"), _("NEW GAME OVERWRITES CURRENT SLOT"), "2" } },
+		SystemConf::getInstance()->get("global.incrementalsavestates"));
+
+	s->addWithLabel(_("INCREMENTAL SAVESTATES"), incrementalSaveStates);
+	s->addSaveFunc([incrementalSaveStates] { SystemConf::getInstance()->set("global.incrementalsavestates", incrementalSaveStates->getSelected()); });
+	
+	// SHOW SAVE STATES
+	auto showSaveStates = std::make_shared<OptionListComponent<std::string>>(mWindow, _("DISPLAY SAVE STATE MANAGER"));
+	showSaveStates->addRange({ { _("NO"), "auto" },{ _("ALWAYS") , "1" },{ _("IF NOT EMPTY") , "2" } }, SystemConf::getInstance()->get("global.savestates"));
+	s->addWithDescription(_("SHOW SAVE STATE MANAGER"), _("DISPLAY SAVE STATE MANAGER BEFORE LAUNCHING A GAME"), showSaveStates);
+	s->addSaveFunc([showSaveStates] { SystemConf::getInstance()->set("global.savestates", showSaveStates->getSelected()); });
+
 
 	// Custom config for systems
 	s->addGroup(_("SETTINGS"));
@@ -4051,15 +4066,24 @@ void GuiMenu::popSpecificConfigurationGui(Window* mWindow, std::string title, st
 		systemConfiguration->addSaveFunc([configName, rewind_enabled] { SystemConf::getInstance()->set(configName + ".rewind", rewind_enabled->getSelected()); });
 	}
 
-	// autosave
+	// AUTO SAVE/LOAD
 	if (systemData->isFeatureSupported(currentEmulator, currentCore, EmulatorFeatures::autosave))
 	{
-		auto autosave_enabled = std::make_shared<OptionListComponent<std::string>>(mWindow, _("AUTO SAVE/LOAD ON GAME LAUNCH"));
-		autosave_enabled->addRange({ { _("AUTO"), "auto" }, { _("ON") , "1" }, { _("OFF"), "0" }, { _("SHOW SAVE STATES") , "2" }, { _("SHOW SAVE STATES IF NOT EMPTY") , "3" } }, SystemConf::getInstance()->get(configName + ".autosave"));
+		auto autosave_enabled = std::make_shared<OptionListComponent<std::string>>(mWindow, _("AUTO SAVE/LOAD"));
+		autosave_enabled->addRange({ { _("AUTO"), "auto" }, { _("ON") , "1" }, { _("OFF"), "0" } }, SystemConf::getInstance()->get(configName + ".autosave"));
 		systemConfiguration->addWithLabel(_("AUTO SAVE/LOAD ON GAME LAUNCH"), autosave_enabled);
 		systemConfiguration->addSaveFunc([configName, autosave_enabled] { SystemConf::getInstance()->set(configName + ".autosave", autosave_enabled->getSelected()); });
 	}
-
+	/*
+	// SHOW SAVE STATES
+	if (systemData->isFeatureSupported(currentEmulator, currentCore, EmulatorFeatures::autosave))
+	{
+		auto showSaveStates = std::make_shared<OptionListComponent<std::string>>(mWindow, _("SHOW SAVE STATE MANAGER"));
+		showSaveStates->addRange({ { _("OFF"), "auto" },{ _("ALWAYS") , "1" },{ _("IF NOT EMPTY") , "2" } }, SystemConf::getInstance()->get(configName + ".savestates"));
+		systemConfiguration->addWithLabel(_("SHOW SAVE STATE MANAGER"), showSaveStates);
+		systemConfiguration->addSaveFunc([configName, showSaveStates] { SystemConf::getInstance()->set(configName + ".savestates", showSaveStates->getSelected()); });
+	}
+	*/
 	// Shaders preset
 	if (ApiSystem::getInstance()->isScriptingSupported(ApiSystem::SHADERS) &&
 		systemData->isFeatureSupported(currentEmulator, currentCore, EmulatorFeatures::shaders))

--- a/es-app/src/guis/GuiSaveState.cpp
+++ b/es-app/src/guis/GuiSaveState.cpp
@@ -100,7 +100,7 @@ GuiSaveState::GuiSaveState(Window* window, FileData* game, const std::function<v
 
 void GuiSaveState::loadGrid()
 {
-	bool incrementalSaveStates = (SystemConf::getInstance()->get("global.incrementalsavestates") != "0");
+	bool incrementalSaveStates = SystemConf::getIncrementalSaveStates();
 
 	mGrid->clear();
 	mGrid->onSizeChanged(); // To Rebuild tiles
@@ -114,19 +114,17 @@ void GuiSaveState::loadGrid()
 
 	mGrid->add(_("START NEW GAME"), ":/freeslot.svg", "", "", false, false, false, false, SaveState(-2));
 
-	std::string autoSaveMode = mGame->getCurrentGameSetting("autosave");
-	if (autoSaveMode.empty() || autoSaveMode == "auto" || autoSaveMode == "2")
+	if (mGame->getCurrentGameSetting("autosave") == "1")
 	{
 		auto autoSave = std::find_if(states.cbegin(), states.cend(), [](SaveState* x) { return x->slot == -1; });
 		if (autoSave == states.cend())
-			mGrid->add(_("START AUTO SAVE"), ":/freeslot.svg", "", "", false, false, false, false, SaveState(-1));
+			mGrid->add(_("START NEW AUTO SAVE"), ":/freeslot.svg", "", "", false, false, false, false, SaveState(-1));
 	}
-
 
 	for (auto item : states)
 	{
 		if (item->slot == -1)
-			mGrid->add(item->creationDate.toLocalTimeString() + std::string("\r\n") + _("AUTO SAVE"), item->getScreenShot(), "", "", false, false, false, false, *item);
+			mGrid->add(_("AUTO SAVE") + std::string("\r\n") + item->creationDate.toLocalTimeString(), item->getScreenShot(), "", "", false, false, false, false, *item);
 		else if (incrementalSaveStates)
 			mGrid->add(item->creationDate.toLocalTimeString(), item->getScreenShot(), "", "", false, false, false, false, *item);
 		else 

--- a/es-app/src/views/gamelist/ISimpleGameListView.cpp
+++ b/es-app/src/views/gamelist/ISimpleGameListView.cpp
@@ -383,7 +383,7 @@ void ISimpleGameListView::launchSelectedGame()
 		if (cursor->getType() == GAME)
 		{
 			if (SaveStateRepository::isEnabled(cursor) &&
-				(cursor->getCurrentGameSetting("autosave") == "2" || (cursor->getCurrentGameSetting("autosave") == "3" && cursor->getSourceFileData()->getSystem()->getSaveStateRepository()->hasSaveStates(cursor))))
+				(cursor->getCurrentGameSetting("savestates") == "1" || (cursor->getCurrentGameSetting("savestates") == "2" && cursor->getSourceFileData()->getSystem()->getSaveStateRepository()->hasSaveStates(cursor))))
 			{
 				mWindow->pushGui(new GuiSaveState(mWindow, cursor, [this, cursor](SaveState state)
 				{

--- a/es-core/src/HttpReq.cpp
+++ b/es-core/src/HttpReq.cpp
@@ -242,9 +242,9 @@ void HttpReq::performRequest(const std::string& url, HttpReqOptions* options)
 			{
 				size_t pxe = proxyServer.find(";", pxs);
 				if (pxe == std::string::npos)
-					pxe = proxyServer.size() - 1;
-
-				proxyServer = proxyServer.substr(pxs + protocol.size(), pxe - pxs - protocol.size());
+					proxyServer = proxyServer.substr(pxs + protocol.size());
+				else 
+					proxyServer = proxyServer.substr(pxs + protocol.size(), pxe - pxs - protocol.size());
 			}
 
 			if (!proxyServer.empty())

--- a/es-core/src/SystemConf.cpp
+++ b/es-core/src/SystemConf.cpp
@@ -267,3 +267,14 @@ bool SystemConf::setBool(const std::string &name, bool value)
 
 	return set(name, value  ? "1" : "0");
 }
+
+bool SystemConf::getIncrementalSaveStates()
+{
+	auto valGSS = SystemConf::getInstance()->get("global.incrementalsavestates");
+	return valGSS != "0" && valGSS != "2";
+}
+
+bool SystemConf::getIncrementalSaveStatesUseCurrentSlot()
+{
+	return SystemConf::getInstance()->get("global.incrementalsavestates") == "2";
+}

--- a/es-core/src/SystemConf.h
+++ b/es-core/src/SystemConf.h
@@ -10,6 +10,9 @@ class SystemConf
 public:
 	static SystemConf* getInstance();
 	
+	static bool getIncrementalSaveStates();
+	static bool getIncrementalSaveStatesUseCurrentSlot();
+
     bool loadSystemConf();
     bool saveSystemConf();
 

--- a/es-core/src/components/OptionListComponent.h
+++ b/es-core/src/components/OptionListComponent.h
@@ -10,6 +10,8 @@
 #include "components/MultiLineMenuEntry.h"
 #include "components/MenuComponent.h"
 
+#include <tuple>
+
 //Used to display a list of options.
 //Can select one or multiple options.
 
@@ -359,7 +361,7 @@ public:
                 return "";
 	}
         
-	void addEx(const std::string name, const std::string description, const T& obj, bool selected, bool treeChild = false)
+	void addEx(const std::string& name, const std::string& description, const T& obj, bool selected, bool treeChild = false)
 	{
 		for (auto sysIt = mEntries.cbegin(); sysIt != mEntries.cend(); sysIt++)
 			if (sysIt->name == name)
@@ -381,7 +383,7 @@ public:
 		onSelectedChanged();
 	}
 
-	void add(const std::string name, const T& obj, bool selected, bool distinct = true, bool treeChild = false)
+	void add(const std::string& name, const T& obj, bool selected, bool distinct = true, bool treeChild = false)
 	{
 		if (distinct)
 		{
@@ -413,11 +415,20 @@ public:
 		if (!hasSelection())
 			selectFirstItem();
 	}
-
+	
 	void addRange(const std::vector<std::pair<std::string, T>> values, const T selectedValue)
 	{
 		for (auto value : values)
 			add(value.first.c_str(), value.second, selectedValue == value.second);
+
+		if (!hasSelection())
+			selectFirstItem();
+	}
+
+	void addRange(const std::vector<std::tuple<std::string, std::string, T>> values, const T selectedValue)
+	{
+		for (auto value : values)
+			addEx(std::get<0>(value), std::get<1>(value), std::get<2>(value), selectedValue == std::get<2>(value));
 
 		if (!hasSelection())
 			selectFirstItem();


### PR DESCRIPTION
- SaveStates : Split "AUTO SAVE/LOAD" option in two options : "AUTO SAVE/LOAD" & DISPLAY SAVE STATE MANAGER
- INCREMENTAL SAVESTATES option : Add "DISABLED - NEW GAME OVERWRITES CURRENT SLOT" value -> Using this will cause new games not to find the next free slot anymore.
- Win32/HttpReq : Fix wrong proxy server extraction in some cases 