### PR TITLE
Refactored Renderer apis to use IRenderer interface. 

### DIFF
--- a/es-core/CMakeLists.txt
+++ b/es-core/CMakeLists.txt
@@ -87,6 +87,9 @@ set(CORE_HEADERS
 
 	# Renderers
 	${CMAKE_CURRENT_SOURCE_DIR}/src/renderers/Renderer.h
+	${CMAKE_CURRENT_SOURCE_DIR}/src/renderers/Renderer_GL21.h
+	${CMAKE_CURRENT_SOURCE_DIR}/src/renderers/Renderer_GLES10.h
+	${CMAKE_CURRENT_SOURCE_DIR}/src/renderers/Renderer_GLES20.h
 	${CMAKE_CURRENT_SOURCE_DIR}/src/renderers/GlExtensions.h	
 
 	# Resources

--- a/es-core/src/renderers/Renderer.cpp
+++ b/es-core/src/renderers/Renderer.cpp
@@ -1,5 +1,9 @@
 #include "renderers/Renderer.h"
 
+#include "Renderer_GL21.h"
+#include "Renderer_GLES10.h"
+#include "Renderer_GLES20.h"
+
 #include "math/Transform4x4f.h"
 #include "math/Vector2i.h"
 #include "resources/ResourceManager.h"
@@ -510,5 +514,198 @@ namespace Renderer
 		setStencil(vertex.data(), vertex.size());
 	}
 
+
+	//////////////////////////////////////////////////////////////////////////
+
+	std::vector<std::string> getRendererNames()
+	{
+		std::vector<std::string> ret;
+	
+#ifdef RENDERER_GLES_20
+		{
+			GLES20Renderer rd;				
+			ret.push_back(rd.getDriverName());
+		}
+#endif
+
+#ifdef RENDERER_OPENGL_21
+		{
+			OpenGL21Renderer rd;
+			ret.push_back(rd.getDriverName());
+		}
+#endif
+
+#ifdef RENDERER_OPENGLES_10
+		{
+			GLES10Renderer rd;
+			ret.push_back(rd.getDriverName());
+		}
+#endif
+		return ret;
+	}
+
+	IRenderer* getRendererFromName(const std::string& name)
+	{
+		if (name.empty())
+			return nullptr;
+
+#ifdef RENDERER_GLES_20
+		{
+			GLES20Renderer rd;
+			if (rd.getDriverName() == name)
+				return new GLES20Renderer();
+		}
+#endif
+
+#ifdef RENDERER_OPENGL_21
+		{
+			OpenGL21Renderer rd;
+			if (rd.getDriverName() == name)
+				return new OpenGL21Renderer();
+		}
+#endif
+
+#ifdef RENDERER_OPENGLES_10
+		{
+			GLES10Renderer rd;
+			if (rd.getDriverName() == name)
+				return new GLES10Renderer();
+		}
+#endif
+
+		return nullptr;
+	}
+
+	static IRenderer* _instance = nullptr;
+
+	static IRenderer* Instance()
+	{
+		if (_instance == nullptr)
+		{
+			// Windows Renderers :
+			// <string name="Renderer" value="OPENGL 2.1" />
+			// <string name="Renderer" value="OPENGL 2.1 / GLSL" />
+
+			_instance = getRendererFromName(Settings::getInstance()->getString("Renderer"));
+			if (_instance == nullptr)
+			{
+#ifdef RENDERER_GLES_20
+				_instance = new GLES20Renderer();
+#elif RENDERER_OPENGL_21
+				_instance = new OpenGL21Renderer();
+#elif RENDERER_OPENGLES_10
+				_instance = new GLES10Renderer();
+#endif
+			}
+		}
+
+		return _instance;
+	}
+
+	//////////////////////////////////////////////////////////////////////////
+	std::string getDriverName()
+	{
+		return Instance()->getDriverName();
+	}
+
+	std::vector<std::pair<std::string, std::string>> getDriverInformation()
+	{
+		return Instance()->getDriverInformation();
+	}
+
+	unsigned int getWindowFlags()
+	{
+		return Instance()->getWindowFlags();
+	}
+
+	void setupWindow()
+	{
+		return Instance()->setupWindow();
+	}
+
+	void createContext() 
+	{
+		Instance()->createContext();
+	}
+
+	void destroyContext()
+	{
+		Instance()->destroyContext();
+	}
+
+	unsigned int createTexture(const Texture::Type _type, const bool _linear, const bool _repeat, const unsigned int _width, const unsigned int _height, void* _data)
+	{
+		return Instance()->createTexture(_type, _linear, _repeat, _width, _height, _data);
+	}
+
+	void  destroyTexture(const unsigned int _texture)
+	{
+		Instance()->destroyTexture(_texture);
+	}
+
+	void updateTexture(const unsigned int _texture, const Texture::Type _type, const unsigned int _x, const unsigned _y, const unsigned int _width, const unsigned int _height, void* _data)
+	{
+		Instance()->updateTexture(_texture, _type, _x, _y, _width, _height, _data);
+	}
+
+	void bindTexture(const unsigned int _texture)
+	{
+		Instance()->bindTexture(_texture);
+	}
+
+	void drawLines(const Vertex* _vertices, const unsigned int _numVertices, const Blend::Factor _srcBlendFactor, const Blend::Factor _dstBlendFactor)
+	{
+		Instance()->drawLines(_vertices, _numVertices, _srcBlendFactor, _dstBlendFactor);
+	}
+
+	void drawTriangleStrips(const Vertex* _vertices, const unsigned int _numVertices, const Blend::Factor _srcBlendFactor, const Blend::Factor _dstBlendFactor)
+	{
+		Instance()->drawTriangleStrips(_vertices, _numVertices, _srcBlendFactor, _dstBlendFactor);
+	}
+
+	void drawTriangleFan(const Vertex* _vertices, const unsigned int _numVertices, const Blend::Factor _srcBlendFactor, const Blend::Factor _dstBlendFactor)
+	{
+		Instance()->drawTriangleFan(_vertices, _numVertices, _srcBlendFactor, _dstBlendFactor);
+	}
+
+	void setProjection(const Transform4x4f& _projection)
+	{
+		Instance()->setProjection(_projection);
+	}
+
+	void setMatrix(const Transform4x4f& _matrix)
+	{
+		Instance()->setMatrix(_matrix);
+	}
+
+	void setViewport(const Rect& _viewport)
+	{
+		return Instance()->setViewport(_viewport);
+	}
+
+	void setScissor(const Rect& _scissor)
+	{
+		Instance()->setScissor(_scissor);
+	}
+
+	void setStencil(const Vertex* _vertices, const unsigned int _numVertices)
+	{
+		Instance()->setStencil(_vertices, _numVertices);
+	}
+
+	void disableStencil()
+	{
+		Instance()->disableStencil();
+	}
+
+	void setSwapInterval()
+	{
+		Instance()->setSwapInterval();
+	}
+
+	void swapBuffers() 
+	{
+		Instance()->swapBuffers();
+	}
 
 } // Renderer::

--- a/es-core/src/renderers/Renderer.h
+++ b/es-core/src/renderers/Renderer.h
@@ -63,6 +63,42 @@ namespace Renderer
 
 	}; // Vertex
 
+	class IRenderer
+	{
+	public:
+		virtual std::string getDriverName() = 0;
+
+		virtual std::vector<std::pair<std::string, std::string>> getDriverInformation() = 0;
+
+		virtual unsigned int getWindowFlags() = 0;
+		virtual void         setupWindow() = 0;
+
+		virtual void         createContext() = 0;
+		virtual void         destroyContext() = 0;
+
+		virtual unsigned int createTexture(const Texture::Type _type, const bool _linear, const bool _repeat, const unsigned int _width, const unsigned int _height, void* _data) = 0;
+		virtual void         destroyTexture(const unsigned int _texture) = 0;
+		virtual void         updateTexture(const unsigned int _texture, const Texture::Type _type, const unsigned int _x, const unsigned _y, const unsigned int _width, const unsigned int _height, void* _data) = 0;
+		virtual void         bindTexture(const unsigned int _texture) = 0;
+
+		virtual void         drawLines(const Vertex* _vertices, const unsigned int _numVertices, const Blend::Factor _srcBlendFactor = Blend::SRC_ALPHA, const Blend::Factor _dstBlendFactor = Blend::ONE_MINUS_SRC_ALPHA) = 0;
+		virtual void         drawTriangleStrips(const Vertex* _vertices, const unsigned int _numVertices, const Blend::Factor _srcBlendFactor = Blend::SRC_ALPHA, const Blend::Factor _dstBlendFactor = Blend::ONE_MINUS_SRC_ALPHA) = 0;
+		virtual void		 drawTriangleFan(const Vertex* _vertices, const unsigned int _numVertices, const Blend::Factor _srcBlendFactor = Blend::SRC_ALPHA, const Blend::Factor _dstBlendFactor = Blend::ONE_MINUS_SRC_ALPHA) = 0;
+
+		virtual void         setProjection(const Transform4x4f& _projection) = 0;
+		virtual void         setMatrix(const Transform4x4f& _matrix) = 0;
+		virtual void         setViewport(const Rect& _viewport) = 0;
+		virtual void         setScissor(const Rect& _scissor) = 0;
+
+		virtual void         setStencil(const Vertex* _vertices, const unsigned int _numVertices) = 0;
+		virtual void		 disableStencil() = 0;
+
+		virtual void         setSwapInterval() = 0;
+		virtual void         swapBuffers() = 0;
+	};
+	
+	std::vector<std::string> getRendererNames();
+
  	bool        init            ();
  	void        deinit          ();
 	void        pushClipRect    (const Vector2i& _pos, const Vector2i& _size);
@@ -98,6 +134,8 @@ namespace Renderer
 	void         setScissor        (const Rect& _scissor);
 	void         setSwapInterval   ();
 	void         swapBuffers       ();
+
+	std::string  getDriverName();
 	std::vector<std::pair<std::string, std::string>> getDriverInformation();
 
 	// batocera methods

--- a/es-core/src/renderers/Renderer_GL21.cpp
+++ b/es-core/src/renderers/Renderer_GL21.cpp
@@ -1,4 +1,6 @@
-#if defined(USE_OPENGL_21_OLD)
+#include "Renderer_GL21.h"
+
+#ifdef RENDERER_OPENGL_21
 
 #include "renderers/Renderer.h"
 #include "math/Transform4x4f.h"
@@ -12,6 +14,7 @@
 namespace Renderer
 {
 	static SDL_GLContext sdlContext = nullptr;
+	static unsigned int boundTexture = 0;
 
 	static GLenum convertBlendFactor(const Blend::Factor _blendFactor)
 	{
@@ -55,13 +58,13 @@ namespace Renderer
 
 	} // convertColor
 
-	unsigned int getWindowFlags()
+	unsigned int OpenGL21Renderer::getWindowFlags()
 	{
 		return SDL_WINDOW_OPENGL;
 
 	} // getWindowFlags
 
-	void setupWindow()
+	void OpenGL21Renderer::setupWindow()
 	{
 		SDL_GL_SetAttribute(SDL_GL_STENCIL_SIZE, 1);
 
@@ -80,11 +83,16 @@ namespace Renderer
 
 	} // setupWindow
 
-	std::vector<std::pair<std::string, std::string>> getDriverInformation()
+	std::string OpenGL21Renderer::getDriverName()
+	{
+		return "OPENGL 2.1";
+	}
+
+	std::vector<std::pair<std::string, std::string>> OpenGL21Renderer::getDriverInformation()
 	{
 		std::vector<std::pair<std::string, std::string>> info;
 
-		info.push_back(std::pair<std::string, std::string>("GRAPHICS API", "DESKTOP OPENGL 2.1"));
+		info.push_back(std::pair<std::string, std::string>("GRAPHICS API", getDriverName()));
 
 		const std::string vendor = glGetString(GL_VENDOR) ? (const char*)glGetString(GL_VENDOR) : "";
 		if (!vendor.empty())
@@ -101,7 +109,7 @@ namespace Renderer
 		return info;
 	}
 
-	void createContext()
+	void OpenGL21Renderer::createContext()
 	{
 		sdlContext = SDL_GL_CreateContext(getSDLWindow());
 		SDL_GL_MakeCurrent(getSDLWindow(), sdlContext);
@@ -114,14 +122,14 @@ namespace Renderer
 
 	} // createContext
 
-	void destroyContext()
+	void OpenGL21Renderer::destroyContext()
 	{
 		SDL_GL_DeleteContext(sdlContext);
 		sdlContext = nullptr;
 
 	} // destroyContext
 
-	unsigned int createTexture(const Texture::Type _type, const bool _linear, const bool _repeat, const unsigned int _width, const unsigned int _height, void* _data)
+	unsigned int OpenGL21Renderer::createTexture(const Texture::Type _type, const bool _linear, const bool _repeat, const unsigned int _width, const unsigned int _height, void* _data)
 	{
 		const GLenum type = convertTextureType(_type);
 		unsigned int texture;
@@ -153,13 +161,13 @@ namespace Renderer
 
 	} // createTexture
 	
-	void destroyTexture(const unsigned int _texture)
+	void OpenGL21Renderer::destroyTexture(const unsigned int _texture)
 	{
 		glDeleteTextures(1, &_texture);
 
 	} // destroyTexture
 
-	void updateTexture(const unsigned int _texture, const Texture::Type _type, const unsigned int _x, const unsigned _y, const unsigned int _width, const unsigned int _height, void* _data)
+	void OpenGL21Renderer::updateTexture(const unsigned int _texture, const Texture::Type _type, const unsigned int _x, const unsigned _y, const unsigned int _width, const unsigned int _height, void* _data)
 	{
 		glBindTexture(GL_TEXTURE_2D, _texture);
 
@@ -175,9 +183,7 @@ namespace Renderer
 
 	} // updateTexture
 
-	static unsigned int boundTexture = 0;
-
-	void bindTexture(const unsigned int _texture)
+	void OpenGL21Renderer::bindTexture(const unsigned int _texture)
 	{
 		if (boundTexture == _texture)
 			return;
@@ -191,7 +197,7 @@ namespace Renderer
 
 	} // bindTexture
 
-	void drawLines(const Vertex* _vertices, const unsigned int _numVertices, const Blend::Factor _srcBlendFactor, const Blend::Factor _dstBlendFactor)
+	void OpenGL21Renderer::drawLines(const Vertex* _vertices, const unsigned int _numVertices, const Blend::Factor _srcBlendFactor, const Blend::Factor _dstBlendFactor)
 	{
 		glEnable(GL_BLEND);
 		glBlendFunc(convertBlendFactor(_srcBlendFactor), convertBlendFactor(_dstBlendFactor));
@@ -214,7 +220,7 @@ namespace Renderer
 
 	} // drawLines
 
-	void setGrayscale()
+	static void setGrayscale()
 	{
 		glMatrixMode(GL_COLOR);
 
@@ -265,7 +271,7 @@ namespace Renderer
 		v4.tex *= isnan(d3) || d3 == 0.0f ? 1.0f : (d4 + d3) / d3;
 	}
 
-	void drawTriangleStrips(const Vertex* _vertices, const unsigned int _numVertices, const Blend::Factor _srcBlendFactor, const Blend::Factor _dstBlendFactor)
+	void OpenGL21Renderer::drawTriangleStrips(const Vertex* _vertices, const unsigned int _numVertices, const Blend::Factor _srcBlendFactor, const Blend::Factor _dstBlendFactor)
 	{
 		glEnable(GL_BLEND);
 		glBlendFunc(convertBlendFactor(_srcBlendFactor), convertBlendFactor(_dstBlendFactor));
@@ -314,14 +320,14 @@ namespace Renderer
 
 	} // drawTriangleStrips
 
-	void setProjection(const Transform4x4f& _projection)
+	void OpenGL21Renderer::setProjection(const Transform4x4f& _projection)
 	{
 		glMatrixMode(GL_PROJECTION);
 		glLoadMatrixf((GLfloat*)&_projection);
 
 	} // setProjection
 
-	void setMatrix(const Transform4x4f& _matrix)
+	void OpenGL21Renderer::setMatrix(const Transform4x4f& _matrix)
 	{
 		Transform4x4f matrix = _matrix;
 		matrix.round();
@@ -330,14 +336,14 @@ namespace Renderer
 
 	} // setMatrix
 
-	void setViewport(const Rect& _viewport)
+	void OpenGL21Renderer::setViewport(const Rect& _viewport)
 	{
 		// glViewport starts at the bottom left of the window
 		glViewport( _viewport.x, getWindowHeight() - _viewport.y - _viewport.h, _viewport.w, _viewport.h);
 
 	} // setViewport
 
-	void setScissor(const Rect& _scissor)
+	void OpenGL21Renderer::setScissor(const Rect& _scissor)
 	{
 		if((_scissor.x == 0) && (_scissor.y == 0) && (_scissor.w == 0) && (_scissor.h == 0))
 		{
@@ -352,7 +358,7 @@ namespace Renderer
 
 	} // setScissor
 
-	void setSwapInterval()
+	void OpenGL21Renderer::setSwapInterval()
 	{
 		// vsync
 		if(Settings::getInstance()->getBool("VSync"))
@@ -371,7 +377,7 @@ namespace Renderer
 
 	} // setSwapInterval
 
-	void swapBuffers()
+	void OpenGL21Renderer::swapBuffers()
 	{		
 #ifdef WIN32		
 		glFlush();
@@ -389,7 +395,7 @@ namespace Renderer
 	} // swapBuffers
 
 
-	void drawTriangleFan(const Vertex* _vertices, const unsigned int _numVertices, const Blend::Factor _srcBlendFactor, const Blend::Factor _dstBlendFactor)
+	void OpenGL21Renderer::drawTriangleFan(const Vertex* _vertices, const unsigned int _numVertices, const Blend::Factor _srcBlendFactor, const Blend::Factor _dstBlendFactor)
 	{
 		glEnable(GL_MULTISAMPLE);
 
@@ -414,7 +420,7 @@ namespace Renderer
 		glDisable(GL_MULTISAMPLE);
 	}
 
-	void setStencil(const Vertex* _vertices, const unsigned int _numVertices)
+	void OpenGL21Renderer::setStencil(const Vertex* _vertices, const unsigned int _numVertices)
 	{
 		bool tx = glIsEnabled(GL_TEXTURE_2D);
 		glDisable(GL_TEXTURE_2D);
@@ -441,7 +447,7 @@ namespace Renderer
 			glEnable(GL_TEXTURE_2D);
 	}
 
-	void disableStencil()
+	void OpenGL21Renderer::disableStencil()
 	{
 		glDisable(GL_STENCIL_TEST);
 	}

--- a/es-core/src/renderers/Renderer_GL21.h
+++ b/es-core/src/renderers/Renderer_GL21.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#ifndef ES_CORE_RENDERER_OPENGL21_H
+#define ES_CORE_RENDERER_OPENGL21_H
+
+#if defined(USE_OPENGL_21)
+
+#define RENDERER_OPENGL_21
+
+#include "Renderer.h"
+
+namespace Renderer
+{
+	class OpenGL21Renderer : public IRenderer
+	{
+	public:
+		std::string getDriverName() override;
+		std::vector<std::pair<std::string, std::string>> getDriverInformation() override;
+
+		unsigned int getWindowFlags() override;
+		void         setupWindow() override;
+
+		void         createContext() override;
+		void         destroyContext() override;
+
+		unsigned int createTexture(const Texture::Type _type, const bool _linear, const bool _repeat, const unsigned int _width, const unsigned int _height, void* _data) override;
+		void         destroyTexture(const unsigned int _texture) override;
+		void         updateTexture(const unsigned int _texture, const Texture::Type _type, const unsigned int _x, const unsigned _y, const unsigned int _width, const unsigned int _height, void* _data) override;
+		void         bindTexture(const unsigned int _texture) override;
+
+		void         drawLines(const Vertex* _vertices, const unsigned int _numVertices, const Blend::Factor _srcBlendFactor = Blend::SRC_ALPHA, const Blend::Factor _dstBlendFactor = Blend::ONE_MINUS_SRC_ALPHA) override;
+		void         drawTriangleStrips(const Vertex* _vertices, const unsigned int _numVertices, const Blend::Factor _srcBlendFactor = Blend::SRC_ALPHA, const Blend::Factor _dstBlendFactor = Blend::ONE_MINUS_SRC_ALPHA) override;
+		void		 drawTriangleFan(const Vertex* _vertices, const unsigned int _numVertices, const Blend::Factor _srcBlendFactor = Blend::SRC_ALPHA, const Blend::Factor _dstBlendFactor = Blend::ONE_MINUS_SRC_ALPHA) override;
+
+		void         setProjection(const Transform4x4f& _projection) override;
+		void         setMatrix(const Transform4x4f& _matrix) override;
+		void         setViewport(const Rect& _viewport) override;
+		void         setScissor(const Rect& _scissor) override;
+
+		void         setStencil(const Vertex* _vertices, const unsigned int _numVertices) override;
+		void		 disableStencil() override;
+
+		void         setSwapInterval() override;
+		void         swapBuffers() override;
+	};
+}
+
+#endif // USE_OPENGL_21_OLD
+
+#endif

--- a/es-core/src/renderers/Renderer_GLES10.cpp
+++ b/es-core/src/renderers/Renderer_GLES10.cpp
@@ -1,11 +1,18 @@
-#if defined(USE_OPENGLES_10)
+#include "Renderer_GLES10.h"
+
+#ifdef RENDERER_OPENGLES_10
 
 #include "renderers/Renderer.h"
 #include "math/Transform4x4f.h"
 #include "Log.h"
 #include "Settings.h"
 
+#if WIN32
+#include "GlExtensions.h" // TEMPORAIRE
+#else
 #include <GLES/gl.h>
+#endif
+
 #include <SDL.h>
 #include <vector>
 
@@ -55,13 +62,13 @@ namespace Renderer
 
 	} // convertColor
 
-	unsigned int getWindowFlags()
+	unsigned int GLES10Renderer::getWindowFlags()
 	{
 		return SDL_WINDOW_OPENGL;
 
 	} // getWindowFlags
 
-	void setupWindow()
+	void GLES10Renderer::setupWindow()
 	{
 		SDL_GL_SetAttribute(SDL_GL_STENCIL_SIZE, 1);
 
@@ -76,7 +83,12 @@ namespace Renderer
 
 	} // setupWindow
 
-	std::vector<std::pair<std::string, std::string>> getDriverInformation()
+	std::string GLES10Renderer::getDriverName()
+	{
+		return "OPENGL ES 1.0";
+	}
+
+	std::vector<std::pair<std::string, std::string>> GLES10Renderer::getDriverInformation()
 	{
 		std::vector<std::pair<std::string, std::string>> info;
 
@@ -97,7 +109,7 @@ namespace Renderer
 		return info;
 	}
 
-	void createContext()
+	void GLES10Renderer::createContext()
 	{
 		sdlContext = SDL_GL_CreateContext(getSDLWindow());
 		SDL_GL_MakeCurrent(getSDLWindow(), sdlContext);
@@ -110,14 +122,14 @@ namespace Renderer
 
 	} // createContext
 
-	void destroyContext()
+	void GLES10Renderer::destroyContext()
 	{
 		SDL_GL_DeleteContext(sdlContext);
 		sdlContext = nullptr;
 
 	} // destroyContext
 
-	unsigned int createTexture(const Texture::Type _type, const bool _linear, const bool _repeat, const unsigned int _width, const unsigned int _height, void* _data)
+	unsigned int GLES10Renderer::createTexture(const Texture::Type _type, const bool _linear, const bool _repeat, const unsigned int _width, const unsigned int _height, void* _data)
 	{
 		const GLenum type = convertTextureType(_type);
 		unsigned int texture;
@@ -148,13 +160,13 @@ namespace Renderer
 
 	} // createTexture
 
-	void destroyTexture(const unsigned int _texture)
+	void GLES10Renderer::destroyTexture(const unsigned int _texture)
 	{
 		glDeleteTextures(1, &_texture);
 
 	} // destroyTexture
 
-	void updateTexture(const unsigned int _texture, const Texture::Type _type, const unsigned int _x, const unsigned _y, const unsigned int _width, const unsigned int _height, void* _data)
+	void GLES10Renderer::updateTexture(const unsigned int _texture, const Texture::Type _type, const unsigned int _x, const unsigned _y, const unsigned int _width, const unsigned int _height, void* _data)
 	{
 		bindTexture(_texture);
 
@@ -170,7 +182,7 @@ namespace Renderer
 
 	} // updateTexture
 
-	void bindTexture(const unsigned int _texture)
+	void GLES10Renderer::bindTexture(const unsigned int _texture)
 	{
 		glBindTexture(GL_TEXTURE_2D, _texture);
 
@@ -179,7 +191,7 @@ namespace Renderer
 
 	} // bindTexture
 
-	void drawLines(const Vertex* _vertices, const unsigned int _numVertices, const Blend::Factor _srcBlendFactor, const Blend::Factor _dstBlendFactor)
+	void GLES10Renderer::drawLines(const Vertex* _vertices, const unsigned int _numVertices, const Blend::Factor _srcBlendFactor, const Blend::Factor _dstBlendFactor)
 	{
 		glEnable(GL_BLEND);
 		glBlendFunc(convertBlendFactor(_srcBlendFactor), convertBlendFactor(_dstBlendFactor));
@@ -202,7 +214,7 @@ namespace Renderer
 
 	} // drawLines
 
-	void drawTriangleStrips(const Vertex* _vertices, const unsigned int _numVertices, const Blend::Factor _srcBlendFactor, const Blend::Factor _dstBlendFactor)
+	void GLES10Renderer::drawTriangleStrips(const Vertex* _vertices, const unsigned int _numVertices, const Blend::Factor _srcBlendFactor, const Blend::Factor _dstBlendFactor)
 	{
 		glEnable(GL_BLEND);
 		glBlendFunc(convertBlendFactor(_srcBlendFactor), convertBlendFactor(_dstBlendFactor));
@@ -225,14 +237,14 @@ namespace Renderer
 
 	} // drawTriangleStrips
 
-	void setProjection(const Transform4x4f& _projection)
+	void GLES10Renderer::setProjection(const Transform4x4f& _projection)
 	{
 		glMatrixMode(GL_PROJECTION);
 		glLoadMatrixf((GLfloat*)&_projection);
 
 	} // setProjection
 
-	void setMatrix(const Transform4x4f& _matrix)
+	void GLES10Renderer::setMatrix(const Transform4x4f& _matrix)
 	{
 		Transform4x4f matrix = _matrix;
 		matrix.round();
@@ -241,14 +253,14 @@ namespace Renderer
 
 	} // setMatrix
 
-	void setViewport(const Rect& _viewport)
+	void GLES10Renderer::setViewport(const Rect& _viewport)
 	{
 		// glViewport starts at the bottom left of the window
 		glViewport( _viewport.x, getWindowHeight() - _viewport.y - _viewport.h, _viewport.w, _viewport.h);
 
 	} // setViewport
 
-	void setScissor(const Rect& _scissor)
+	void GLES10Renderer::setScissor(const Rect& _scissor)
 	{
 		if((_scissor.x == 0) && (_scissor.y == 0) && (_scissor.w == 0) && (_scissor.h == 0))
 		{
@@ -263,7 +275,7 @@ namespace Renderer
 
 	} // setScissor
 
-	void setSwapInterval()
+	void GLES10Renderer::setSwapInterval()
 	{
 		// vsync
 		if(Settings::getInstance()->getBool("VSync"))
@@ -282,14 +294,14 @@ namespace Renderer
 
 	} // setSwapInterval
 
-	void swapBuffers()
+	void GLES10Renderer::swapBuffers()
 	{
 		SDL_GL_SwapWindow(getSDLWindow());
 		glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 
 	} // swapBuffers
 
-	void drawTriangleFan(const Vertex* _vertices, const unsigned int _numVertices, const Blend::Factor _srcBlendFactor, const Blend::Factor _dstBlendFactor)
+	void GLES10Renderer::drawTriangleFan(const Vertex* _vertices, const unsigned int _numVertices, const Blend::Factor _srcBlendFactor, const Blend::Factor _dstBlendFactor)
 	{
 		glEnable(GL_BLEND);
 		glBlendFunc(convertBlendFactor(_srcBlendFactor), convertBlendFactor(_dstBlendFactor));
@@ -310,7 +322,7 @@ namespace Renderer
 		glDisable(GL_BLEND);
 	}
 
-	void setStencil(const Vertex* _vertices, const unsigned int _numVertices)
+	void GLES10Renderer::setStencil(const Vertex* _vertices, const unsigned int _numVertices)
 	{
 		bool tx = glIsEnabled(GL_TEXTURE_2D);
 		glDisable(GL_TEXTURE_2D);
@@ -337,7 +349,7 @@ namespace Renderer
 			glEnable(GL_TEXTURE_2D);
 	}
 
-	void disableStencil()
+	void GLES10Renderer::disableStencil()
 	{
 		glDisable(GL_STENCIL_TEST);
 	}

--- a/es-core/src/renderers/Renderer_GLES10.h
+++ b/es-core/src/renderers/Renderer_GLES10.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#ifndef ES_CORE_RENDERER_GLES10_H
+#define ES_CORE_RENDERER_GLES10_H
+
+#if defined(USE_OPENGLES_10)
+
+#define RENDERER_OPENGLES_10
+
+#include "Renderer.h"
+
+namespace Renderer
+{
+	class GLES10Renderer : public IRenderer
+	{
+	public:
+		std::string getDriverName() override;
+		std::vector<std::pair<std::string, std::string>> getDriverInformation() override;
+
+		unsigned int getWindowFlags() override;
+		void         setupWindow() override;
+
+		void         createContext() override;
+		void         destroyContext() override;
+
+		unsigned int createTexture(const Texture::Type _type, const bool _linear, const bool _repeat, const unsigned int _width, const unsigned int _height, void* _data) override;
+		void         destroyTexture(const unsigned int _texture) override;
+		void         updateTexture(const unsigned int _texture, const Texture::Type _type, const unsigned int _x, const unsigned _y, const unsigned int _width, const unsigned int _height, void* _data) override;
+		void         bindTexture(const unsigned int _texture) override;
+
+		void         drawLines(const Vertex* _vertices, const unsigned int _numVertices, const Blend::Factor _srcBlendFactor = Blend::SRC_ALPHA, const Blend::Factor _dstBlendFactor = Blend::ONE_MINUS_SRC_ALPHA) override;
+		void         drawTriangleStrips(const Vertex* _vertices, const unsigned int _numVertices, const Blend::Factor _srcBlendFactor = Blend::SRC_ALPHA, const Blend::Factor _dstBlendFactor = Blend::ONE_MINUS_SRC_ALPHA) override;
+		void		 drawTriangleFan(const Vertex* _vertices, const unsigned int _numVertices, const Blend::Factor _srcBlendFactor = Blend::SRC_ALPHA, const Blend::Factor _dstBlendFactor = Blend::ONE_MINUS_SRC_ALPHA) override;
+
+		void         setProjection(const Transform4x4f& _projection) override;
+		void         setMatrix(const Transform4x4f& _matrix) override;
+		void         setViewport(const Rect& _viewport) override;
+		void         setScissor(const Rect& _scissor) override;
+
+		void         setStencil(const Vertex* _vertices, const unsigned int _numVertices) override;
+		void		 disableStencil() override;
+
+		void         setSwapInterval() override;
+		void         swapBuffers() override;
+	};
+};
+
+#endif // USE_OPENGLES_10
+
+#endif

--- a/es-core/src/renderers/Renderer_GLES20.cpp
+++ b/es-core/src/renderers/Renderer_GLES20.cpp
@@ -1,5 +1,8 @@
-#if defined(USE_OPENGLES_20) || defined (USE_OPENGL_21)
+#include "Renderer_GLES20.h"
 
+#ifdef RENDERER_GLES_20
+
+#include "Renderer_GLES20.h"
 #include "renderers/Renderer.h"
 #include "math/Transform4x4f.h"
 #include "Log.h"
@@ -12,6 +15,7 @@
 
 namespace Renderer
 {
+
 //////////////////////////////////////////////////////////////////////////
 
 	static SDL_GLContext sdlContext       = nullptr;
@@ -30,9 +34,9 @@ namespace Renderer
 
 	static GLuint        vertexBuffer     = 0;
 
-//////////////////////////////////////////////////////////////////////////
+	static unsigned int boundTexture = 0;
 
-	#define SHADER_VERSION_STRING "#version 100\n"
+//////////////////////////////////////////////////////////////////////////
 
 	static ShaderProgram* currentProgram = nullptr;
 	
@@ -99,34 +103,50 @@ namespace Renderer
 	{
 		bool result = false;
 
+		std::string SHADER_VERSION_STRING = "#version 100\n";
+
+		const std::string shaders = glGetString(GL_SHADING_LANGUAGE_VERSION) ? (const char*)glGetString(GL_SHADING_LANGUAGE_VERSION) : "";
+		
+#if WIN32
+		if (shaders.find("NVIDIA") != std::string::npos && shaders[0] >= '3' && shaders[0] <= '9')
+			SHADER_VERSION_STRING = "#version 120\n";
+		else if (shaders.find("Intel") != std::string::npos)
+		{
+			if (shaders.find("1.2") != std::string::npos)
+				SHADER_VERSION_STRING = "#version 120\n";
+			else if (shaders.find("1.1") != std::string::npos)
+				SHADER_VERSION_STRING = "#version 110\n";
+		}			
+#endif
+
 		// vertex shader (no texture)
-		const GLchar* vertexSourceNoTexture =
-			SHADER_VERSION_STRING
-			"uniform   mat4 u_mvp; \n"
-			"attribute vec2 a_pos; \n"
-			"attribute vec4 a_col; \n"
-			"varying   vec4 v_col; \n"
-			"void main(void)                                     \n"
-			"{                                                   \n"
-			"    gl_Position = u_mvp * vec4(a_pos.xy, 0.0, 1.0); \n"
-			"    v_col       = a_col;                            \n"
-			"}                                                   \n";
+		std::string vertexSourceNoTexture =
+				SHADER_VERSION_STRING +
+				"uniform   mat4 u_mvp; \n"
+				"attribute vec2 a_pos; \n"
+				"attribute vec4 a_col; \n"
+				"varying   vec4 v_col; \n"
+				"void main(void)                                     \n"
+				"{                                                   \n"
+				"    gl_Position = u_mvp * vec4(a_pos.xy, 0.0, 1.0); \n"
+				"    v_col       = a_col;                            \n"
+				"}                                                   \n";
 
 		// fragment shader (no texture)
-		const GLchar* fragmentSourceNoTexture =
-			SHADER_VERSION_STRING
+		std::string fragmentSourceNoTexture =
+			SHADER_VERSION_STRING +
 			"precision highp float;     \n"
 			"varying   vec4  v_col;     \n"
 			"void main(void)            \n"
 			"{                          \n"
 			"    gl_FragColor = v_col;  \n"
 			"}                          \n";
-		
+
 		// Compile each shader, link them to make a full program
 		const GLuint vertexShaderColorTextureId = glCreateShader(GL_VERTEX_SHADER);
-		result = vertexShaderNoTexture.compile(vertexShaderColorTextureId, vertexSourceNoTexture);
+		result = vertexShaderNoTexture.compile(vertexShaderColorTextureId, vertexSourceNoTexture.c_str());
 		const GLuint fragmentShaderNoTextureId = glCreateShader(GL_FRAGMENT_SHADER);
-		result = fragmentShaderColorNoTexture.compile(fragmentShaderNoTextureId, fragmentSourceNoTexture);
+		result = fragmentShaderColorNoTexture.compile(fragmentShaderNoTextureId, fragmentSourceNoTexture.c_str());
 		result = shaderProgramColorNoTexture.linkShaderProgram(vertexShaderNoTexture, fragmentShaderColorNoTexture);
 		
 		// Set shader active, retrieve attributes and uniforms locations
@@ -137,8 +157,8 @@ namespace Renderer
 		shaderProgramColorNoTexture.texAttrib = -1;
 
 		// vertex shader (texture)
-		const GLchar* vertexSourceTexture =
-			SHADER_VERSION_STRING
+		std::string vertexSourceTexture =
+			SHADER_VERSION_STRING +
 			"uniform   mat4 u_mvp; \n"
 			"attribute vec2 a_pos; \n"
 			"attribute vec2 a_tex; \n"
@@ -153,8 +173,8 @@ namespace Renderer
 			"}                                                   \n";
 
 		// fragment shader (texture)
-		const GLchar* fragmentSourceTexture =
-			SHADER_VERSION_STRING
+		std::string fragmentSourceTexture =
+			SHADER_VERSION_STRING +
 			"precision highp float;       \n"
 #if defined(USE_OPENGLES_20)
 			"precision mediump sampler2D; \n"
@@ -169,10 +189,10 @@ namespace Renderer
 		
 		// Compile each shader, link them to make a full program
 		const GLuint vertexShaderColorNoTextureId = glCreateShader(GL_VERTEX_SHADER);
-		result = vertexShaderTexture.compile(vertexShaderColorNoTextureId, vertexSourceTexture);
+		result = vertexShaderTexture.compile(vertexShaderColorNoTextureId, vertexSourceTexture.c_str());
 
 		const GLuint fragmentShaderTextureId = glCreateShader(GL_FRAGMENT_SHADER);
-		result = fragmentShaderColorTexture.compile(fragmentShaderTextureId, fragmentSourceTexture);
+		result = fragmentShaderColorTexture.compile(fragmentShaderTextureId, fragmentSourceTexture.c_str());
 		result = shaderProgramColorTexture.linkShaderProgram(vertexShaderTexture, fragmentShaderColorTexture);
 		
 		// Set shader active, retrieve attributes and uniforms locations
@@ -232,7 +252,7 @@ namespace Renderer
 
 //////////////////////////////////////////////////////////////////////////
 
-	unsigned int convertColor(const unsigned int _color)
+	static unsigned int convertColor(const unsigned int _color)
 	{
 		// convert from rgba to abgr
 		const unsigned char r = ((_color & 0xff000000) >> 24) & 255;
@@ -246,7 +266,43 @@ namespace Renderer
 
 //////////////////////////////////////////////////////////////////////////
 
-	unsigned int getWindowFlags()
+	static int getAvailableVideoMemory()
+	{
+		float total = 0;
+
+		float megabytes = 10.0;
+		int sz = sqrtf(megabytes * 1024.0 * 1024.0 / 4.0f);
+
+		std::vector<unsigned int> textures;
+		textures.reserve(1000000);
+
+		while (true)
+		{
+			unsigned int textureId;
+			glGenTextures(1, &textureId);
+			if (glGetError() != GL_NO_ERROR)
+				break;
+
+			textures.push_back(textureId);
+
+			bindTexture(textureId);
+			glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, sz, sz, 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
+			if (glGetError() != GL_NO_ERROR)
+				break;
+
+			textures.push_back(textureId);
+			total += megabytes;
+		}
+
+		for (auto tx : textures)
+			Renderer::destroyTexture(tx);
+
+		return total;
+	}
+
+//////////////////////////////////////////////////////////////////////////
+
+	unsigned int GLES20Renderer::getWindowFlags()
 	{
 		return SDL_WINDOW_OPENGL;
 
@@ -254,7 +310,7 @@ namespace Renderer
 
 //////////////////////////////////////////////////////////////////////////
 
-	void setupWindow()
+	void GLES20Renderer::setupWindow()
 	{
 #if OPENGL_EXTENSIONS
 		SDL_SetHint(SDL_HINT_RENDER_DRIVER, "opengl");
@@ -278,16 +334,20 @@ namespace Renderer
 	} // setupWindow
 
 //////////////////////////////////////////////////////////////////////////
+	std::string GLES20Renderer::getDriverName()
+	{
+#if OPENGL_EXTENSIONS
+		return "OPENGL 2.1 / GLSL";
+#else 
+		return "OPENGL ES 2.0";
+#endif
+	}
 
-	std::vector<std::pair<std::string, std::string>> getDriverInformation()
+	std::vector<std::pair<std::string, std::string>> GLES20Renderer::getDriverInformation()
 	{
 		std::vector<std::pair<std::string, std::string>> info;
 
-#if OPENGL_EXTENSIONS
-		info.push_back(std::pair<std::string, std::string>("GRAPHICS API", "DESKTOP OPENGL 2.1"));
-#else 
-		info.push_back(std::pair<std::string, std::string>("GRAPHICS API", "OPENGL ES 2.0"));
-#endif
+		info.push_back(std::pair<std::string, std::string>("GRAPHICS API", getDriverName()));
 
 		const std::string vendor = glGetString(GL_VENDOR) ? (const char*)glGetString(GL_VENDOR) : "";
 		if (!vendor.empty())
@@ -308,7 +368,7 @@ namespace Renderer
 		return info;
 	}
 
-	void createContext()
+	void GLES20Renderer::createContext()
 	{
 		sdlContext = SDL_GL_CreateContext(getSDLWindow());
 		SDL_GL_MakeCurrent(getSDLWindow(), sdlContext);
@@ -347,43 +407,9 @@ namespace Renderer
 		
 	} // createContext
 
-	int getAvailableVideoMemory()
-	{
-		float total = 0;
-
-		float megabytes = 10.0;
-		int sz = sqrtf(megabytes * 1024.0 * 1024.0 / 4.0f);
-
-		std::vector<unsigned int> textures;
-		textures.reserve(1000000);
-
-		while (true)
-		{
-			unsigned int textureId;
-			glGenTextures(1, &textureId);
-			if (glGetError() != GL_NO_ERROR)
-				break;
-
-			textures.push_back(textureId);
-
-			bindTexture(textureId);
-			glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, sz, sz, 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
-			if (glGetError() != GL_NO_ERROR)
-				break;
-
-			textures.push_back(textureId);
-			total += megabytes;
-		}
-
-		for (auto tx : textures)
-			Renderer::destroyTexture(tx);
-
-		return total;
-	}
-
 //////////////////////////////////////////////////////////////////////////
 
-	void destroyContext()
+	void GLES20Renderer::destroyContext()
 	{
 		SDL_GL_DeleteContext(sdlContext);
 		sdlContext = nullptr;
@@ -392,7 +418,7 @@ namespace Renderer
 
 //////////////////////////////////////////////////////////////////////////
 
-	unsigned int createTexture(const Texture::Type _type, const bool _linear, const bool _repeat, const unsigned int _width, const unsigned int _height, void* _data)
+	unsigned int GLES20Renderer::createTexture(const Texture::Type _type, const bool _linear, const bool _repeat, const unsigned int _width, const unsigned int _height, void* _data)
 	{
 		const GLenum type = convertTextureType(_type);
 		unsigned int texture;
@@ -403,13 +429,7 @@ namespace Renderer
 			LOG(LogError) << "CreateTexture error: glGenTextures failed";
 			return 0;
 		}
-/*
-		if (texture > 50)
-		{
-			destroyTexture(texture);
-			return 0;
-		}
-		*/
+
 		bindTexture(texture);
 
 		GL_CHECK_ERROR(glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, _repeat ? GL_REPEAT : GL_CLAMP_TO_EDGE));
@@ -459,7 +479,7 @@ namespace Renderer
 
 //////////////////////////////////////////////////////////////////////////
 
-	void destroyTexture(const unsigned int _texture)
+	void GLES20Renderer::destroyTexture(const unsigned int _texture)
 	{
 		GL_CHECK_ERROR(glDeleteTextures(1, &_texture));
 
@@ -467,7 +487,7 @@ namespace Renderer
 
 //////////////////////////////////////////////////////////////////////////
 
-	void updateTexture(const unsigned int _texture, const Texture::Type _type, const unsigned int _x, const unsigned _y, const unsigned int _width, const unsigned int _height, void* _data)
+	void GLES20Renderer::updateTexture(const unsigned int _texture, const Texture::Type _type, const unsigned int _x, const unsigned _y, const unsigned int _width, const unsigned int _height, void* _data)
 	{
 		const GLenum type = convertTextureType(_type);
 
@@ -498,9 +518,7 @@ namespace Renderer
 
 //////////////////////////////////////////////////////////////////////////
 
-	static unsigned int boundTexture = 0;
-
-	void bindTexture(const unsigned int _texture)
+	void GLES20Renderer::bindTexture(const unsigned int _texture)
 	{
 		if (boundTexture == _texture)
 			return;
@@ -522,7 +540,7 @@ namespace Renderer
 
 //////////////////////////////////////////////////////////////////////////
 
-	void drawLines(const Vertex* _vertices, const unsigned int _numVertices, const Blend::Factor _srcBlendFactor, const Blend::Factor _dstBlendFactor)
+	void GLES20Renderer::drawLines(const Vertex* _vertices, const unsigned int _numVertices, const Blend::Factor _srcBlendFactor, const Blend::Factor _dstBlendFactor)
 	{
 		// Pass buffer data
 		GL_CHECK_ERROR(glBufferData(GL_ARRAY_BUFFER, sizeof(Vertex) * _numVertices, _vertices, GL_DYNAMIC_DRAW));
@@ -540,7 +558,7 @@ namespace Renderer
 //////////////////////////////////////////////////////////////////////////
 
 
-	void drawTriangleStrips(const Vertex* _vertices, const unsigned int _numVertices, const Blend::Factor _srcBlendFactor, const Blend::Factor _dstBlendFactor)
+	void GLES20Renderer::drawTriangleStrips(const Vertex* _vertices, const unsigned int _numVertices, const Blend::Factor _srcBlendFactor, const Blend::Factor _dstBlendFactor)
 	{
 		// Pass buffer data
 		GL_CHECK_ERROR(glBufferData(GL_ARRAY_BUFFER, sizeof(Vertex) * _numVertices, _vertices, GL_DYNAMIC_DRAW));		
@@ -561,7 +579,7 @@ namespace Renderer
 
 //////////////////////////////////////////////////////////////////////////
 
-	void setProjection(const Transform4x4f& _projection)
+	void GLES20Renderer::setProjection(const Transform4x4f& _projection)
 	{
 		projectionMatrix = _projection;
 		mvpMatrix = projectionMatrix * worldViewMatrix;
@@ -569,7 +587,7 @@ namespace Renderer
 
 //////////////////////////////////////////////////////////////////////////
 
-	void setMatrix(const Transform4x4f& _matrix)
+	void GLES20Renderer::setMatrix(const Transform4x4f& _matrix)
 	{
 		worldViewMatrix = _matrix;
 		worldViewMatrix.round();
@@ -578,7 +596,7 @@ namespace Renderer
 
 //////////////////////////////////////////////////////////////////////////
 
-	void setViewport(const Rect& _viewport)
+	void GLES20Renderer::setViewport(const Rect& _viewport)
 	{
 		// glViewport starts at the bottom left of the window
 		GL_CHECK_ERROR(glViewport( _viewport.x, getWindowHeight() - _viewport.y - _viewport.h, _viewport.w, _viewport.h));
@@ -587,7 +605,7 @@ namespace Renderer
 
 //////////////////////////////////////////////////////////////////////////
 
-	void setScissor(const Rect& _scissor)
+	void GLES20Renderer::setScissor(const Rect& _scissor)
 	{
 		if((_scissor.x == 0) && (_scissor.y == 0) && (_scissor.w == 0) && (_scissor.h == 0))
 		{
@@ -604,7 +622,7 @@ namespace Renderer
 
 //////////////////////////////////////////////////////////////////////////
 
-	void setSwapInterval()
+	void GLES20Renderer::setSwapInterval()
 	{
 		// vsync
 		if(Settings::getInstance()->getBool("VSync"))
@@ -625,7 +643,7 @@ namespace Renderer
 
 //////////////////////////////////////////////////////////////////////////
 
-	void swapBuffers()
+	void GLES20Renderer::swapBuffers()
 	{
 		useProgram(nullptr);
 		SDL_GL_SwapWindow(getSDLWindow());
@@ -634,7 +652,7 @@ namespace Renderer
 
 //////////////////////////////////////////////////////////////////////////
 	
-	void drawTriangleFan(const Vertex* _vertices, const unsigned int _numVertices, const Blend::Factor _srcBlendFactor, const Blend::Factor _dstBlendFactor)
+	void GLES20Renderer::drawTriangleFan(const Vertex* _vertices, const unsigned int _numVertices, const Blend::Factor _srcBlendFactor, const Blend::Factor _dstBlendFactor)
 	{		
 		// Pass buffer data
 		GL_CHECK_ERROR(glBufferData(GL_ARRAY_BUFFER, sizeof(Vertex) * _numVertices, _vertices, GL_DYNAMIC_DRAW));
@@ -652,7 +670,7 @@ namespace Renderer
 		GL_CHECK_ERROR(glDisable(GL_BLEND));
 	}
 
-	void setStencil(const Vertex* _vertices, const unsigned int _numVertices)
+	void GLES20Renderer::setStencil(const Vertex* _vertices, const unsigned int _numVertices)
 	{
 		useProgram(&shaderProgramColorNoTexture);
 
@@ -674,7 +692,7 @@ namespace Renderer
 		glStencilFunc(GL_EQUAL, 1, 0xFF);
 	}
 
-	void disableStencil()
+	void GLES20Renderer::disableStencil()
 	{
 		glDisable(GL_STENCIL_TEST);
 	}

--- a/es-core/src/renderers/Renderer_GLES20.h
+++ b/es-core/src/renderers/Renderer_GLES20.h
@@ -1,0 +1,49 @@
+#pragma once
+#ifndef ES_CORE_RENDERER_GLES20_H
+#define ES_CORE_RENDERER_GLES20_H
+
+#if defined(USE_OPENGLES_20) || defined (USE_OPENGL_21)
+
+#define RENDERER_GLES_20
+
+#include "Renderer.h"
+
+namespace Renderer
+{
+	class GLES20Renderer : public IRenderer
+	{
+	public:
+		std::string getDriverName() override;
+		std::vector<std::pair<std::string, std::string>> getDriverInformation() override;
+
+		unsigned int getWindowFlags() override;
+		void         setupWindow() override;
+
+		void         createContext() override;
+		void         destroyContext() override;
+
+		unsigned int createTexture(const Texture::Type _type, const bool _linear, const bool _repeat, const unsigned int _width, const unsigned int _height, void* _data) override;
+		void         destroyTexture(const unsigned int _texture) override;
+		void         updateTexture(const unsigned int _texture, const Texture::Type _type, const unsigned int _x, const unsigned _y, const unsigned int _width, const unsigned int _height, void* _data) override;
+		void         bindTexture(const unsigned int _texture) override;
+
+		void         drawLines(const Vertex* _vertices, const unsigned int _numVertices, const Blend::Factor _srcBlendFactor = Blend::SRC_ALPHA, const Blend::Factor _dstBlendFactor = Blend::ONE_MINUS_SRC_ALPHA) override;
+		void         drawTriangleStrips(const Vertex* _vertices, const unsigned int _numVertices, const Blend::Factor _srcBlendFactor = Blend::SRC_ALPHA, const Blend::Factor _dstBlendFactor = Blend::ONE_MINUS_SRC_ALPHA) override;
+		void		 drawTriangleFan(const Vertex* _vertices, const unsigned int _numVertices, const Blend::Factor _srcBlendFactor = Blend::SRC_ALPHA, const Blend::Factor _dstBlendFactor = Blend::ONE_MINUS_SRC_ALPHA) override;
+
+		void         setProjection(const Transform4x4f& _projection) override;
+		void         setMatrix(const Transform4x4f& _matrix) override;
+		void         setViewport(const Rect& _viewport) override;
+		void         setScissor(const Rect& _scissor) override;
+
+		void         setStencil(const Vertex* _vertices, const unsigned int _numVertices) override;
+		void		 disableStencil() override;
+
+		void         setSwapInterval() override;
+		void         swapBuffers() override;
+	};
+}
+
+#endif // USE_OPENGLES_20
+
+#endif


### PR DESCRIPTION
This allow multiple drivers ( for Windows mainly ), and set the Renderer to use with es_settings.cfg file

For Windows, you can add the following entries in es_settings. Renderers are :
`<string name="Renderer" value="OPENGL 2.1 / GLSL" />` 
-> default, used if "Renderer" is not defined

or

`<string name="Renderer" value="OPENGL 2.1" />` 
-> forces the old OpenGL driver