### PR TITLE
Optimisation & Fixes

### DIFF
--- a/es-app/src/CustomFeatures.cpp
+++ b/es-app/src/CustomFeatures.cpp
@@ -402,23 +402,8 @@ CustomFeatures CustomFeatures::loadCustomFeatures(pugi::xml_node node)
 
 void CustomFeatures::sort()
 {
-  // sorting not keeping the order in case values equals
-  //std::sort(begin(), end(), [](CustomFeature& feat1, CustomFeature& feat2) { return feat1.order < feat2.order; });
-  auto pass = size();
-  bool swapped = true;
-  while (pass > 0 && swapped)
-    {
-      swapped = false;
-      for (auto i = 0; i < size() - 1; i++)
-        {
-	  if (at(i).order > at(i + 1).order)
-            {
-	      std::swap(at(i), at(i + 1));
-	      swapped = true;
-            }
-	}
-      pass--;
-    }
+	// std::sort is not always keeping the original sequence, when elements equals. Use stable_sort
+	std::stable_sort(begin(), end(), [](auto feat1, auto feat2) { return feat1.order < feat2.order; });
 }
 
 bool CustomFeatures::hasFeature(const std::string& name) const

--- a/es-app/src/components/RatingComponent.cpp
+++ b/es-app/src/components/RatingComponent.cpp
@@ -62,6 +62,8 @@ void RatingComponent::setUnfilledColor(unsigned int color)
 
 void RatingComponent::onSizeChanged()
 {
+	GuiComponent::onSizeChanged();
+
 	if (mSize.y() == 0)
 		mSize[1] = mSize.x() / NUM_RATING_STARS;
 	else if (mSize.x() == 0)

--- a/es-app/src/components/ScraperSearchComponent.cpp
+++ b/es-app/src/components/ScraperSearchComponent.cpp
@@ -94,6 +94,8 @@ ScraperSearchComponent::~ScraperSearchComponent()
 
 void ScraperSearchComponent::onSizeChanged()
 {
+	GuiComponent::onSizeChanged();
+
 	mGrid.setSize(mSize);
 
 	if (mSize.x() == 0 || mSize.y() == 0)

--- a/es-app/src/guis/GuiBatoceraStore.cpp
+++ b/es-app/src/guis/GuiBatoceraStore.cpp
@@ -117,6 +117,8 @@ void GuiBatoceraStore::update(int deltaTime)
 
 void GuiBatoceraStore::onSizeChanged()
 {
+	GuiComponent::onSizeChanged();
+
 	mBackground.fitTo(mSize, Vector3f::Zero(), Vector2f(-32, -32));
 
 	mGrid.setSize(mSize);
@@ -234,7 +236,7 @@ void GuiBatoceraStore::loadList(bool updatePackageList, bool restoreIndex)
 		ComponentListRow row;
 		row.selectable = false;
 		auto text = std::make_shared<TextComponent>(mWindow, _("No items"), theme->TextSmall.font, theme->Text.color, ALIGN_CENTER);
-		row.addElement(text, true, false);
+		row.addElement(text, true);
 		mList->addRow(row, false, false);
 	}
 

--- a/es-app/src/guis/GuiFileBrowser.cpp
+++ b/es-app/src/guis/GuiFileBrowser.cpp
@@ -99,7 +99,7 @@ void GuiFileBrowser::navigateTo(const std::string path)
 		mMenu.addEntry(icon + Utils::FileSystem::getFileName(file.path), false, [this, file]()
 		{
 			navigateTo(Utils::FileSystem::combine(mCurrentPath, Utils::FileSystem::getFileName(file.path)));
-		}, "", isSelected, true, false, file.path, false);
+		}, "", isSelected, false, file.path, false);
 	}
 
 	if (mTypes != FileTypes::DIRECTORY)
@@ -136,7 +136,7 @@ void GuiFileBrowser::navigateTo(const std::string path)
 					mOkCallback(file.path);
 
 				delete this;
-			}, "", isSelected, true, false, file.path, false);
+			}, "", isSelected, false, file.path, false);
 		}
 	}
 

--- a/es-app/src/guis/GuiGameAchievements.cpp
+++ b/es-app/src/guis/GuiGameAchievements.cpp
@@ -60,10 +60,11 @@ public:
 		setEntry(mText, Vector2i(2, 0), false, true);
 		setEntry(mSubstring, Vector2i(2, 1), false, true);
 
-		setColWidthPerc(0, IMAGESIZE / WINDOW_WIDTH);
-		setColWidthPerc(1, IMAGESPACER / WINDOW_WIDTH);
-
 		int height = Math::max(IMAGESIZE + IMAGESPACER, mText->getSize().y() + mSubstring->getSize().y());
+
+		setColWidthPerc(0, (height - IMAGESPACER) / WINDOW_WIDTH);
+		setColWidthPerc(1, IMAGESPACER / WINDOW_WIDTH);
+	
 		mImage->setMaxSize(height - IMAGESPACER, height - IMAGESPACER);
 		mImage->setImage(mGameInfo.getBadgeUrl());
 

--- a/es-app/src/guis/GuiGameOptions.cpp
+++ b/es-app/src/guis/GuiGameOptions.cpp
@@ -124,7 +124,7 @@ GuiGameOptions::GuiGameOptions(Window* window, FileData* game) : GuiComponent(wi
 				{
 					GuiGameAchievements::show(window, Utils::String::toInteger(game->getMetadata(MetaDataId::CheevosId)));
 					close();
-				}, "", false, true, true);
+				}, "", false, true);
 			}
 			else
 			{

--- a/es-app/src/guis/GuiGameScraper.cpp
+++ b/es-app/src/guis/GuiGameScraper.cpp
@@ -91,6 +91,8 @@ GuiGameScraper::GuiGameScraper(Window* window, ScraperSearchParams params, std::
 
 void GuiGameScraper::onSizeChanged()
 {
+	GuiComponent::onSizeChanged();
+
 	mBox.fitTo(mSize, Vector3f::Zero(), Vector2f(-32, -32));
 
 	mGrid.setRowHeightPerc(0, 0.04f, false);

--- a/es-app/src/guis/GuiKeyMappingEditor.cpp
+++ b/es-app/src/guis/GuiKeyMappingEditor.cpp
@@ -167,6 +167,8 @@ GuiKeyMappingEditor::GuiKeyMappingEditor(Window* window, IKeyboardMapContainer* 
 
 void GuiKeyMappingEditor::onSizeChanged()
 {
+	GuiComponent::onSizeChanged();
+
 	mBackground.fitTo(mSize, Vector3f::Zero(), Vector2f(-32, -32));
 
 	mGrid.setSize(mSize);
@@ -373,7 +375,7 @@ void GuiKeyMappingEditor::loadList(bool restoreIndex)
 				{ _("LEFT ANALOG STICK") , "joystick1" },
 				{ _("RIGHT ANALOG STICK") , "joystick2" } }, mouseMapping);
 
-			mouseRow.addElement(imageSource, false, true);
+			mouseRow.addElement(imageSource, false);
 
 			mList->addRow(mouseRow, idx > 0 && last);
 
@@ -390,7 +392,7 @@ void GuiKeyMappingEditor::loadList(bool restoreIndex)
 		{
 			auto info = std::make_shared<TextComponent>(mWindow, mouseMapping == "joystick1" ? _("LEFT ANALOG STICK") : _("RIGHT ANALOG STICK"), theme->Text.font, theme->Text.color);
 			info->setPadding(Vector4f(0, 0, Renderer::getScreenWidth() * 0.01f, 0));
-			mouseRow.addElement(info, false, true);
+			mouseRow.addElement(info, false);
 			mList->addRow(mouseRow, idx > 0 && last);
 		}
 

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -2504,10 +2504,10 @@ void GuiMenu::openThemeConfiguration(Window* mWindow, GuiComponent* s, std::shar
 
 	std::map<std::string, ThemeConfigOption> options;
 
-	Utils::String::stringVector subsetNames = theme->getSubSetNames(viewName);
-
+	auto subsetNames = theme->getSubSetNames(viewName);
+	
 	// push appliesTo at end of list
-	std::sort(subsetNames.begin(), subsetNames.end(), [themeSubSets](const std::string& a, const std::string& b) -> bool
+	std::stable_sort(subsetNames.begin(), subsetNames.end(), [themeSubSets](const std::string& a, const std::string& b) -> bool
 	{ 
 		auto sa = ThemeData::getSubSet(themeSubSets, a);
 		auto sb = ThemeData::getSubSet(themeSubSets, b);

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -393,7 +393,7 @@ void GuiMenu::openDeveloperSettings()
 	s->addSaveFunc([max_vram] { Settings::getInstance()->setInt("MaxVRAM", (int)round(max_vram->getValue())); });
 	
 	s->addSwitch(_("SHOW FRAMERATE"), "DrawFramerate", true);
-	s->addSwitch(_("VSYNC"), "VSync", true);
+	s->addSwitch(_("VSYNC"), "VSync", true, [] { Renderer::setSwapInterval(); });
 
 #if !defined(WIN32) || defined(_DEBUG)
 	// overscan

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -78,13 +78,13 @@
 #define fake_gettext_cpu_frequency _("Cpu max frequency")
 #define fake_gettext_cpu_feature  _("Cpu feature")
 
-#define fake_gettext_scanlines		_("SCANLINES")
-#define fake_gettext_retro			_("RETRO")
-#define fake_gettext_enhanced		_("ENHANCED")
-#define fake_gettext_curvature		_("CURVATURE")
-#define fake_gettext_zfast			_("ZFAST")
-#define fake_gettext_flatten_glow	_("FLATTEN-GLOW")
-#define fake_gettext_rgascaling		_("RGA SCALING")
+#define fake_gettext_scanlines		pgettext("game_options", "SCANLINES")
+#define fake_gettext_retro			pgettext("game_options", "RETRO")
+#define fake_gettext_enhanced		pgettext("game_options", "ENHANCED")
+#define fake_gettext_curvature		pgettext("game_options", "CURVATURE")
+#define fake_gettext_zfast			pgettext("game_options", "ZFAST")
+#define fake_gettext_flatten_glow	pgettext("game_options", "FLATTEN-GLOW")
+#define fake_gettext_rgascaling		pgettext("game_options", "RGA SCALING")
 
 #define fake_gettext_glvendor		_("VENDOR")
 #define fake_gettext_glvrenderer	_("RENDERER")
@@ -267,6 +267,8 @@ void GuiMenu::openCollectionSystemSettings()
 
 void GuiMenu::onSizeChanged()
 {
+	GuiComponent::onSizeChanged();
+
 	float h = mMenu.getButtonGridHeight();
 
 	mVersion.setSize(mSize.x(), h);
@@ -3426,7 +3428,7 @@ void GuiMenu::createDecorationItemTemplate(Window* window, std::vector<Decoratio
 	else
 		label = Utils::String::toUpper(Utils::String::replace(data, "_", " "));
 		
-	row.addElement(std::make_shared<TextComponent>(window, label, font, color, ALIGN_LEFT), true, true);
+	row.addElement(std::make_shared<TextComponent>(window, label, font, color, ALIGN_LEFT), true);
 
 	std::string imageUrl;
 

--- a/es-app/src/guis/GuiMetaDataEd.cpp
+++ b/es-app/src/guis/GuiMetaDataEd.cpp
@@ -204,7 +204,7 @@ GuiMetaDataEd::GuiMetaDataEd(Window* window, MetaDataList* md, const std::vector
 		case MD_BOOL:
 			{
 				ed = std::make_shared<SwitchComponent>(window);
-				row.addElement(ed, false, true);
+				row.addElement(ed, false);
 				break;
 			}
 		case MD_RATING:
@@ -212,7 +212,7 @@ GuiMetaDataEd::GuiMetaDataEd(Window* window, MetaDataList* md, const std::vector
 				ed = std::make_shared<RatingComponent>(window);
 				const float height = lbl->getSize().y() * 0.71f;
 				ed->setSize(0, height);
-				row.addElement(ed, false, true);
+				row.addElement(ed, false);
 
 				auto spacer = std::make_shared<GuiComponent>(mWindow);
 				spacer->setSize(Renderer::getScreenWidth() * 0.0025f, 0);
@@ -378,6 +378,8 @@ GuiMetaDataEd::GuiMetaDataEd(Window* window, MetaDataList* md, const std::vector
 
 void GuiMetaDataEd::onSizeChanged()
 {
+	GuiComponent::onSizeChanged();
+
 	mBackground.fitTo(mSize, Vector3f::Zero(), Vector2f(-32, -32));
 
 	mGrid.setSize(mSize);

--- a/es-app/src/guis/GuiNetPlay.cpp
+++ b/es-app/src/guis/GuiNetPlay.cpp
@@ -217,6 +217,8 @@ GuiNetPlay::GuiNetPlay(Window* window)
 
 void GuiNetPlay::onSizeChanged()
 {
+	GuiComponent::onSizeChanged();
+
 	mBackground.fitTo(mSize, Vector3f::Zero(), Vector2f(-32, -32));
 
 	mGrid.setSize(mSize);

--- a/es-app/src/guis/GuiRetroAchievements.cpp
+++ b/es-app/src/guis/GuiRetroAchievements.cpp
@@ -46,6 +46,8 @@ RetroAchievementProgress::RetroAchievementProgress(Window* window, int value, in
 
 void RetroAchievementProgress::onSizeChanged()
 {
+	GuiComponent::onSizeChanged();
+
 	float padding = mSize.x() * 0.1f;
 		
 	float y = (mSize.y() + PROGRESSHEIGHT) / 2.0f;
@@ -117,11 +119,12 @@ public:
 
 		setEntry(mProgress, Vector2i(3, 0), false, true, Vector2i(1, 2));
 
-		setColWidthPerc(0, IMAGESIZE / WINDOW_WIDTH);
+		int height = Math::max(IMAGESIZE + IMAGESPACER, mText->getSize().y() + mSubstring->getSize().y());
+
+		setColWidthPerc(0, (height - IMAGESPACER) / WINDOW_WIDTH);
 		setColWidthPerc(1, IMAGESPACER / WINDOW_WIDTH);
 		setColWidthPerc(3, 0.25f);
-
-		int height = Math::max(IMAGESIZE + IMAGESPACER, mText->getSize().y() + mSubstring->getSize().y());
+	
 		mImage->setMaxSize(height - IMAGESPACER, height - IMAGESPACER);
 		mImage->setImage(ra.badge.empty() ? ":/cartridge.svg" : ra.badge);
 

--- a/es-app/src/guis/GuiSaveState.cpp
+++ b/es-app/src/guis/GuiSaveState.cpp
@@ -135,6 +135,8 @@ void GuiSaveState::loadGrid()
 
 void GuiSaveState::onSizeChanged()
 {	
+	GuiComponent::onSizeChanged();
+
 	float helpSize = 0.02;
 
 	if (Settings::getInstance()->getBool("ShowHelpPrompts"))

--- a/es-app/src/guis/GuiSettings.h
+++ b/es-app/src/guis/GuiSettings.h
@@ -26,9 +26,9 @@ public:
 	inline void addRow(const ComponentListRow& row) { mMenu.addRow(row); };
 	inline void addWithLabel(const std::string& label, const std::shared_ptr<GuiComponent>& comp, bool setCursorHere = false) { mMenu.addWithLabel(label, comp, nullptr, "", setCursorHere); };
 	inline void addWithDescription(const std::string& label, const std::string& description, const std::shared_ptr<GuiComponent>& comp, bool setCursorHere = false) { mMenu.addWithDescription(label, description, comp, nullptr, "", setCursorHere); };
-	inline void addWithDescription(const std::string& label, const std::string& description, const std::shared_ptr<GuiComponent>& comp, const std::function<void()>& func, const std::string iconName = "", bool setCursorHere = false, bool invert_when_selected = true, bool multiLine = false) { mMenu.addWithDescription(label, description, comp, func, iconName, setCursorHere, invert_when_selected, multiLine); };
+	inline void addWithDescription(const std::string& label, const std::string& description, const std::shared_ptr<GuiComponent>& comp, const std::function<void()>& func, const std::string iconName = "", bool setCursorHere = false, /*bool invert_when_selected = true,*/ bool multiLine = false) { mMenu.addWithDescription(label, description, comp, func, iconName, setCursorHere, multiLine); };
 	inline void addSaveFunc(const std::function<void()>& func) { mSaveFuncs.push_back(func); };
-	inline void addEntry(const std::string name, bool add_arrow = false, const std::function<void()>& func = nullptr, const std::string iconName = "", bool onButtonRelease = false, bool setCursorHere = false) { mMenu.addEntry(name, add_arrow, func, iconName, setCursorHere, true, onButtonRelease); };
+	inline void addEntry(const std::string name, bool add_arrow = false, const std::function<void()>& func = nullptr, const std::string iconName = "", bool onButtonRelease = false, bool setCursorHere = false) { mMenu.addEntry(name, add_arrow, func, iconName, setCursorHere, onButtonRelease); };
 
 	inline void addGroup(const std::string& label) { mMenu.addGroup(label); };
 	inline void removeLastRowIfGroup() { mMenu.removeLastRowIfGroup(); };

--- a/es-core/src/GuiComponent.cpp
+++ b/es-core/src/GuiComponent.cpp
@@ -17,7 +17,7 @@ bool GuiComponent::isLaunchTransitionRunning = false;
 GuiComponent::GuiComponent(Window* window) : mWindow(window), mParent(NULL), mOpacity(255),
 	mPosition(Vector3f::Zero()), mOrigin(Vector2f::Zero()), mRotationOrigin(0.5, 0.5), mScaleOrigin(0.5f, 0.5f),
 	mSize(Vector2f::Zero()), mTransform(Transform4x4f::Identity()), mIsProcessing(false), mVisible(true), mShowing(false),
-	mStaticExtra(false), mStoryboardAnimator(nullptr), mScreenOffset(0.0f)
+	mStaticExtra(false), mStoryboardAnimator(nullptr), mScreenOffset(0.0f), mTransformDirty(true)
 {
 	mClipRect = Vector4f();
 }
@@ -89,11 +89,11 @@ void GuiComponent::render(const Transform4x4f& parentTrans)
 
 	Transform4x4f trans = parentTrans * getTransform();
 
-	if (!Renderer::isVisibleOnScreen(trans.translation().x(), trans.translation().y(), mSize.x(), mSize.y()))
+	if (!Renderer::isVisibleOnScreen(trans.translation().x(), trans.translation().y(), mSize.x() * trans.r0().x(), mSize.y() * trans.r1().y()))
 		return;
 	
 	if (!mClipRect.empty() && !GuiComponent::isLaunchTransitionRunning)
-		Renderer::pushClipRect(Vector2i(mClipRect.x(), mClipRect.y()), Vector2i(mClipRect.z(), mClipRect.w()));
+		Renderer::pushClipRect(mClipRect.x(), mClipRect.y(), mClipRect.z(), mClipRect.w());
 
 	renderChildren(trans);
 
@@ -104,7 +104,8 @@ void GuiComponent::render(const Transform4x4f& parentTrans)
 void GuiComponent::renderChildren(const Transform4x4f& transform) const
 {
 	for (auto child : mChildren)
-		TRYCATCH("GuiComponent::renderChildren", child->render(transform));
+		if (child->mVisible)
+			TRYCATCH("GuiComponent::renderChildren", child->render(transform));
 }
 
 Vector3f GuiComponent::getPosition() const
@@ -114,8 +115,12 @@ Vector3f GuiComponent::getPosition() const
 
 void GuiComponent::setPosition(float x, float y, float z)
 {
-	mPosition = Vector3f(x, y, z);
-	onPositionChanged();
+	auto position = Vector3f(x, y, z);
+	if (position == mPosition)
+		return;
+	
+	mPosition = position;
+	onPositionChanged();	
 }
 
 Vector2f GuiComponent::getOrigin() const
@@ -125,7 +130,11 @@ Vector2f GuiComponent::getOrigin() const
 
 void GuiComponent::setOrigin(float x, float y)
 {
-	mOrigin = Vector2f(x, y);
+	auto origin = Vector2f(x, y);
+	if (origin == mOrigin)
+		return;
+
+	mOrigin = origin;
 	onOriginChanged();
 }
 
@@ -136,7 +145,12 @@ Vector2f GuiComponent::getRotationOrigin() const
 
 void GuiComponent::setRotationOrigin(float x, float y)
 {
-	mRotationOrigin = Vector2f(x, y);
+	auto origin = Vector2f(x, y);
+	if (origin == mRotationOrigin)
+		return;
+
+	mRotationOrigin = origin;
+	onRotationOriginChanged();
 }
 
 Vector2f GuiComponent::getSize() const
@@ -146,7 +160,11 @@ Vector2f GuiComponent::getSize() const
 
 void GuiComponent::setSize(float w, float h)
 {
-	mSize = Vector2f(w, h);
+	auto size = Vector2f(w, h);
+	if (size == mSize)
+		return;
+
+	mSize = size;
     onSizeChanged();
 }
 
@@ -157,7 +175,11 @@ float GuiComponent::getRotation() const
 
 void GuiComponent::setRotation(float rotation)
 {
+	if (rotation == mRotation)
+		return;
+
 	mRotation = rotation;
+	onRotationChanged();
 }
 
 float GuiComponent::getScale() const
@@ -167,7 +189,11 @@ float GuiComponent::getScale() const
 
 void GuiComponent::setScale(float scale)
 {
+	if (scale == mScale)
+		return;
+
 	mScale = scale;
+	onScaleChanged();
 }
 
 Vector2f GuiComponent::getScaleOrigin() const
@@ -177,7 +203,25 @@ Vector2f GuiComponent::getScaleOrigin() const
 
 void GuiComponent::setScaleOrigin(const Vector2f& scaleOrigin)
 {
+	if (scaleOrigin == mScaleOrigin)
+		return;
+
 	mScaleOrigin = scaleOrigin;
+	onScaleOriginChanged();
+}
+
+Vector2f GuiComponent::getScreenOffset() const
+{
+	return mScreenOffset;
+}
+
+void GuiComponent::setScreenOffset(const Vector2f& screenOffset)
+{
+	if (screenOffset == mScreenOffset)
+		return;
+
+	mScreenOffset = screenOffset;
+	onScreenOffsetChanged();
 }
 
 float GuiComponent::getZIndex() const
@@ -299,11 +343,15 @@ void GuiComponent::setOpacity(unsigned char opacity)
 
 const Transform4x4f& GuiComponent::getTransform()
 {
+	if (!mTransformDirty)
+		return mTransform;
+
+	mTransformDirty = false;
 	mTransform = Transform4x4f::Identity();
 	mTransform.translate(mPosition);
 
 	if (!mScreenOffset.empty())
-		mTransform.translate(Vector3f(mScreenOffset, 0.0f));
+		mTransform.translate(mScreenOffset.x(), mScreenOffset.y());
 
 	if (mScale != 1.0)
 	{
@@ -311,12 +359,12 @@ const Transform4x4f& GuiComponent::getTransform()
 		float yOff = mSize.y() * mScaleOrigin.y();
 
 		if (mScaleOrigin != Vector2f::Zero())
-			mTransform.translate(Vector3f(xOff, yOff, 0.0f));
+			mTransform.translate(xOff, yOff);
 
 		mTransform.scale(mScale);
 		
 		if (mScaleOrigin != Vector2f::Zero())
-			mTransform.translate(Vector3f(-xOff, -yOff, 0.0f));
+			mTransform.translate(-xOff, -yOff);
 	}
 
 	if (mRotation != 0.0)
@@ -328,19 +376,17 @@ const Transform4x4f& GuiComponent::getTransform()
 
 		// transform to offset point
 		if (xOff != 0.0 || yOff != 0.0)
-			mTransform.translate(Vector3f(xOff * -1, yOff * -1, 0.0f));
+			mTransform.translate(xOff * -1, yOff * -1);
 
 		// apply rotation transform
 		mTransform.rotateZ(mRotation);
 
 		// Tranform back to original point
 		if (xOff != 0.0 || yOff != 0.0)
-			mTransform.translate(Vector3f(xOff, yOff, 0.0f));
+			mTransform.translate(xOff, yOff);
 	}
 
-	mTransform.translate(Vector3f(mOrigin.x() * mSize.x() * -1, mOrigin.y() * mSize.y() * -1, 0.0f));
-
-
+	mTransform.translate(mOrigin.x() * mSize.x() * -1, mOrigin.y() * mSize.y() * -1);	
 	return mTransform;
 }
 
@@ -663,19 +709,19 @@ void GuiComponent::applyTheme(const std::shared_ptr<ThemeData>& theme, const std
 	if (properties & POSITION && elem->has("offset"))
 	{
 		Vector2f denormalized = elem->get<Vector2f>("offset") * screenScale;
-		mScreenOffset = denormalized;
+		setScreenOffset(denormalized);
 	}
 
 	if (properties & POSITION && elem->has("offsetX"))
 	{
 		float denormalized = elem->get<float>("offsetX") * screenScale.x();
-		mScreenOffset = Vector2f(denormalized, mScreenOffset.y());
+		setScreenOffset(Vector2f(denormalized, mScreenOffset.y()));
 	}
 
 	if (properties & POSITION && elem->has("offsetY"))
 	{
 		float denormalized = elem->get<float>("offsetY") * scale.y();
-		mScreenOffset = Vector2f(mScreenOffset.x(), denormalized);
+		setScreenOffset(Vector2f(mScreenOffset.x(), denormalized));
 	}
 
 	if (properties & POSITION && elem->has("clipRect"))
@@ -687,6 +733,7 @@ void GuiComponent::applyTheme(const std::shared_ptr<ThemeData>& theme, const std
 		setClipRect(Vector4f());
 
 	applyStoryboard(elem);
+	mTransformDirty = true;
 }
 
 void GuiComponent::updateHelpPrompts()
@@ -950,16 +997,18 @@ void GuiComponent::setProperty(const std::string name, const ThemeData::ThemeEle
 		setScaleOrigin(Vector2f(value.v.x(), value.v.y()));
 
 	if (name == "offset" && value.type == ThemeData::ThemeElement::Property::PropertyType::Pair)
-		mScreenOffset = Vector2f(value.v.x() * screenScale.x(), value.v.y() * screenScale.y());
+		setScreenOffset(Vector2f(value.v.x() * screenScale.x(), value.v.y() * screenScale.y()));
 	
 	if (name == "offsetX" && value.type == ThemeData::ThemeElement::Property::PropertyType::Float)
-		mScreenOffset = Vector2f(value.f * screenScale.x(), mScreenOffset.y());
+		setScreenOffset(Vector2f(value.f * screenScale.x(), mScreenOffset.y()));
 
 	if (name == "offsetY" && value.type == ThemeData::ThemeElement::Property::PropertyType::Float)
-		mScreenOffset = Vector2f(mScreenOffset.x(), value.f * screenScale.y());
+		setScreenOffset(Vector2f(mScreenOffset.x(), value.f * screenScale.y()));
 
 	if (name == "clipRect" && value.type == ThemeData::ThemeElement::Property::PropertyType::Rect)
 		setClipRect(Vector4f(value.r.x() * screenScale.x(), value.r.y() * screenScale.y(), value.r.z() * screenScale.x(), value.r.w() * screenScale.y()));
+
+	mTransformDirty = true;
 }
 
 void GuiComponent::setClipRect(const Vector4f& vec)
@@ -997,7 +1046,7 @@ void GuiComponent::beginCustomClipRect()
 		mTransform.translate(Vector3f(mOrigin.x() * mSize.x() * -1, mOrigin.y() * mSize.y() * -1, 0.0f));
 	}*/
 
-	Renderer::pushClipRect(Vector2i(mClipRect.x(), mClipRect.y()), Vector2i(mClipRect.z(), mClipRect.w()));
+	Renderer::pushClipRect(mClipRect.x(), mClipRect.y(), mClipRect.z(), mClipRect.w());
 }
 
 void GuiComponent::endCustomClipRect()
@@ -1005,3 +1054,44 @@ void GuiComponent::endCustomClipRect()
 	if (!mClipRect.empty() && !GuiComponent::isLaunchTransitionRunning)
 		Renderer::popClipRect();
 }
+
+void GuiComponent::onPositionChanged() 
+{
+	mTransformDirty = true;
+}
+
+void GuiComponent::onOriginChanged()
+{
+	mTransformDirty = true;
+}
+
+void GuiComponent::onRotationOriginChanged()
+{
+	mTransformDirty = true;
+}
+
+void GuiComponent::onSizeChanged()
+{
+	mTransformDirty = true;
+}
+
+void GuiComponent::onRotationChanged()
+{
+	mTransformDirty = true;
+}
+
+void GuiComponent::onScaleChanged()
+{
+	mTransformDirty = true;
+}
+
+void GuiComponent::onScaleOriginChanged()
+{
+	mTransformDirty = true;
+}
+
+void GuiComponent::onScreenOffsetChanged()
+{
+	mTransformDirty = true;
+}
+

--- a/es-core/src/GuiComponent.h
+++ b/es-core/src/GuiComponent.h
@@ -59,23 +59,24 @@ public:
 	Vector3f getPosition() const;
 	inline void setPosition(const Vector3f& offset) { setPosition(offset.x(), offset.y(), offset.z()); }
 	void setPosition(float x, float y, float z = 0.0f);
-	virtual void onPositionChanged() {};
+	virtual void onPositionChanged();
 
 	//Sets the origin as a percentage of this image (e.g. (0, 0) is top left, (0.5, 0.5) is the center)
 	Vector2f getOrigin() const;
 	void setOrigin(float originX, float originY);
 	inline void setOrigin(Vector2f origin) { setOrigin(origin.x(), origin.y()); }
-	virtual void onOriginChanged() {};
+	virtual void onOriginChanged();
 
 	//Sets the rotation origin as a percentage of this image (e.g. (0, 0) is top left, (0.5, 0.5) is the center)
 	Vector2f getRotationOrigin() const;
 	void setRotationOrigin(float originX, float originY);
 	inline void setRotationOrigin(Vector2f origin) { setRotationOrigin(origin.x(), origin.y()); }
+	virtual void onRotationOriginChanged();
 
 	virtual Vector2f getSize() const;
     inline void setSize(const Vector2f& size) { setSize(size.x(), size.y()); }
     void setSize(float w, float h);
-    virtual void onSizeChanged() {};
+    virtual void onSizeChanged();
 
 	virtual void setColor(unsigned int color) {};
 
@@ -83,13 +84,21 @@ public:
 
 	float getRotation() const;
 	void setRotation(float rotation);
+	virtual void onRotationChanged();
+
 	inline void setRotationDegrees(float rotation) { setRotation((float)ES_DEG_TO_RAD(rotation)); }
 
 	float getScale() const;
 	virtual void setScale(float scale);
+	virtual void onScaleChanged();
 
 	Vector2f getScaleOrigin() const;
 	void setScaleOrigin(const Vector2f& scaleOrigin);
+	virtual void onScaleOriginChanged();
+
+	Vector2f getScreenOffset() const;
+	void setScreenOffset(const Vector2f& screenOffset);
+	virtual void onScreenOffsetChanged();
 
     float getZIndex() const;
     void setZIndex(float zIndex);
@@ -222,6 +231,8 @@ protected:
 	bool mVisible;
 	bool mShowing;
 	bool mStaticExtra;
+
+	bool mTransformDirty;
 
 public:
 	const static unsigned char MAX_ANIMATIONS = 4;

--- a/es-core/src/InputManager.h
+++ b/es-core/src/InputManager.h
@@ -48,7 +48,7 @@ public:
 	std::string configureEmulators();
 
 	// information about last association players/pads // batocera
-	std::map<int, PlayerDeviceInfo> lastKnownPlayersDeviceIndexes() { return m_lastKnownPlayersDeviceIndexes; }
+	std::map<int, PlayerDeviceInfo>& lastKnownPlayersDeviceIndexes() { return m_lastKnownPlayersDeviceIndexes; }
 	void computeLastKnownPlayersDeviceIndexes();
 
 	void updateBatteryLevel(int id, std::string device, int level);

--- a/es-core/src/Settings.cpp
+++ b/es-core/src/Settings.cpp
@@ -423,12 +423,11 @@ void Settings::loadFile()
 //Print a warning message if the setting we're trying to get doesn't already exist in the map, then return the value in the map.
 #define SETTINGS_GETSET(type, mapName, getMethodName, setMethodName, defaultValue) type Settings::getMethodName(const std::string& name) \
 { \
-	if(mapName.find(name) == mapName.cend()) \
-	{ \
-		/* LOG(LogError) << "Tried to use unset setting " << name << "!"; */ \
+	auto it = mapName.find(name); \
+	if (it == mapName.cend()) \
 		return defaultValue; \
-	} \
-	return mapName[name]; \
+\
+	return it->second; \
 } \
 bool Settings::setMethodName(const std::string& name, type value) \
 { \
@@ -446,14 +445,14 @@ bool Settings::setMethodName(const std::string& name, type value) \
 SETTINGS_GETSET(bool, mBoolMap, getBool, setBool, false);
 SETTINGS_GETSET(int, mIntMap, getInt, setInt, 0);
 SETTINGS_GETSET(float, mFloatMap, getFloat, setFloat, 0.0f);
-//SETTINGS_GETSET(const std::string&, mStringMap, getString, setString, mEmptyString);
 
 std::string Settings::getString(const std::string& name)
 {
-	if (mStringMap.find(name) == mStringMap.cend())
+	auto it = mStringMap.find(name);
+	if (it == mStringMap.cend())
 		return mEmptyString;
 
-	return mStringMap[name];
+	return it->second;
 }
 
 bool Settings::setString(const std::string& name, const std::string& value)

--- a/es-core/src/Settings.h
+++ b/es-core/src/Settings.h
@@ -49,6 +49,9 @@ public:
 	DEFINE_BOOL_SETTING(CheevosCheckIndexesAtStart)
 	DEFINE_BOOL_SETTING(NetPlayCheckIndexesAtStart)
 	DEFINE_BOOL_SETTING(NetPlayShowMissingGames)		
+	
+	DEFINE_BOOL_SETTING(ShowControllerActivity)
+	DEFINE_BOOL_SETTING(ShowControllerBattery)
 
 	DEFINE_STRING_SETTING(HiddenSystems)
 	DEFINE_STRING_SETTING(TransitionStyle)
@@ -75,7 +78,7 @@ private:
 	std::map<std::string, bool> mDefaultBoolMap;
 	std::map<std::string, int> mDefaultIntMap;
 	std::map<std::string, float> mDefaultFloatMap;
-	std::map<std::string, std::string> mDefaultStringMap;
+	std::map<std::string, std::string> mDefaultStringMap;	
 };
 
 #endif // ES_CORE_SETTINGS_H

--- a/es-core/src/anim/StoryboardAnimator.cpp
+++ b/es-core/src/anim/StoryboardAnimator.cpp
@@ -105,7 +105,7 @@ void StoryboardAnimator::addNewAnimations()
 		for (auto story : _currentStories)
 			if (story->animation == anim) { exists = true; break; }
 
-		if (!exists)
+		if (!exists && _finishedStories.size())
 		{
 			for (auto story : _finishedStories)
 				if (story->animation == anim) { exists = true; break; }

--- a/es-core/src/components/AnimatedImageComponent.cpp
+++ b/es-core/src/components/AnimatedImageComponent.cpp
@@ -44,10 +44,10 @@ void AnimatedImageComponent::reset()
 
 void AnimatedImageComponent::onSizeChanged()
 {
+	GuiComponent::onSizeChanged();
+
 	for(auto it = mFrames.cbegin(); it != mFrames.cend(); it++)
-	{
 		it->first->setResize(mSize.x(), mSize.y());
-	}
 }
 
 void AnimatedImageComponent::update(int deltaTime)

--- a/es-core/src/components/BusyComponent.cpp
+++ b/es-core/src/components/BusyComponent.cpp
@@ -90,6 +90,8 @@ void BusyComponent::render(const Transform4x4f& parentTrans)
 
 void BusyComponent::onSizeChanged()
 {
+	GuiComponent::onSizeChanged();
+
 	mGrid.setSize(mSize);
 
 	if(mSize.x() == 0 || mSize.y() == 0)

--- a/es-core/src/components/ButtonComponent.cpp
+++ b/es-core/src/components/ButtonComponent.cpp
@@ -29,6 +29,8 @@ ButtonComponent::ButtonComponent(Window* window, const std::string& text, const 
 
 void ButtonComponent::onSizeChanged()
 {
+	GuiComponent::onSizeChanged();
+
 	auto sz = mBox.getCornerSize();
 
 	mBox.fitTo(

--- a/es-core/src/components/ComponentGrid.cpp
+++ b/es-core/src/components/ComponentGrid.cpp
@@ -200,6 +200,8 @@ void ComponentGrid::updateSeparators()
 
 void ComponentGrid::onSizeChanged()
 {
+	GuiComponent::onSizeChanged();
+
 	for(auto it = mCells.cbegin(); it != mCells.cend(); it++)
 		updateCellComponent(*it);
 

--- a/es-core/src/components/ComponentList.h
+++ b/es-core/src/components/ComponentList.h
@@ -18,12 +18,11 @@ namespace ComponentListFlags
 
 struct ComponentListElement
 {
-	ComponentListElement(const std::shared_ptr<GuiComponent>& cmp = nullptr, bool resize_w = true, bool inv = true)
-		: component(cmp), resize_width(resize_w), invert_when_selected(inv) { };
+	ComponentListElement(const std::shared_ptr<GuiComponent>& cmp = nullptr, bool resize_w = true)
+		: component(cmp), resize_width(resize_w) { };
 
 	std::shared_ptr<GuiComponent> component;
-	bool resize_width;
-	bool invert_when_selected;
+	bool resize_width;	
 };
 
 struct ComponentListRow
@@ -31,8 +30,10 @@ struct ComponentListRow
 	ComponentListRow() 
 	{
 		selectable = true;
+		group = false;
 	};
 
+	bool group;
 	bool selectable;
 	std::vector<ComponentListElement> elements;
 
@@ -42,12 +43,12 @@ struct ComponentListRow
 	// the rightmost element in the currently selected row.
 	std::function<bool(InputConfig*, Input)> input_handler;
 	
-	inline void addElement(const std::shared_ptr<GuiComponent>& component, bool resize_width, bool invert_when_selected = true)
+	inline void addElement(const std::shared_ptr<GuiComponent>& component, bool resize_width)
 	{
 		if (EsLocale::isRTL())
-			elements.insert(elements.begin(), ComponentListElement(component, resize_width, invert_when_selected));
+			elements.insert(elements.begin(), ComponentListElement(component, resize_width));
 		else
-			elements.push_back(ComponentListElement(component, resize_width, invert_when_selected));
+			elements.push_back(ComponentListElement(component, resize_width));
 	}
 
 	// Utility method for making an input handler for "when the users presses A on this, do func."

--- a/es-core/src/components/ComponentTab.cpp
+++ b/es-core/src/components/ComponentTab.cpp
@@ -48,6 +48,8 @@ void ComponentTab::addTab(const ComponentTabItem& row, const std::string value, 
 
 void ComponentTab::onSizeChanged()
 {
+	IList::onSizeChanged();
+
 	for(auto it = mEntries.cbegin(); it != mEntries.cend(); it++)
 	{
 		updateElementSize(it->data);

--- a/es-core/src/components/ControllerActivityComponent.cpp
+++ b/es-core/src/components/ControllerActivityComponent.cpp
@@ -59,6 +59,8 @@ void ControllerActivityComponent::setColorShift(unsigned int color)
 
 void ControllerActivityComponent::onPositionChanged()
 {
+	GuiComponent::onPositionChanged();
+
 	mBatteryText = nullptr;
 	mBatteryFont = nullptr;
 
@@ -68,6 +70,8 @@ void ControllerActivityComponent::onPositionChanged()
 
 void ControllerActivityComponent::onSizeChanged()
 {	
+	GuiComponent::onSizeChanged();
+
 	mBatteryText = nullptr;
 	mBatteryFont = nullptr;
 
@@ -166,31 +170,31 @@ void ControllerActivityComponent::render(const Transform4x4f& parentTrans)
 	int itemsWidth = 0;
 	float batteryTextOffset = 0;
 
-	bool showControllerActivity = Settings::getInstance()->getBool("ShowControllerActivity");
-	bool showControllerBattery = showControllerActivity && Settings::getInstance()->getBool("ShowControllerBattery");
+	bool showControllerActivity = Settings::ShowControllerActivity();
+	bool showControllerBattery = showControllerActivity && Settings::ShowControllerBattery();
 
 	if ((mView & CONTROLLERS) && showControllerActivity)
 	{	
-		auto playerJoysticks = InputManager::getInstance()->lastKnownPlayersDeviceIndexes();
+		auto& playerJoysticks = InputManager::getInstance()->lastKnownPlayersDeviceIndexes();
 
 		int padCount = 0;
 
 		for (int player = 0; player < MAX_PLAYERS; player++)
-			mPads[player].index = -1;
-
-		for (int player = 0; player < MAX_PLAYERS; player++)
 		{
+			PlayerPad& pad = mPads[player];
+			pad.index = -1;
+
 			auto it = playerJoysticks.find(player);
 			if (it == playerJoysticks.cend() || it->second.index < 0 || it->second.index >= MAX_PLAYERS)
 				continue;
 
-			mPads[player].index = it->second.index;
-			mPads[player].batteryLevel = it->second.batteryLevel;
+			pad.index = it->second.index;
+			pad.batteryLevel = it->second.batteryLevel;
 		}
 
 		for (int idx = 0; idx < MAX_PLAYERS; idx++)
 		{
-			auto pad = mPads[idx];
+			PlayerPad& pad = mPads[idx];
 			if (pad.index < 0)
 				continue;
 
@@ -205,11 +209,11 @@ void ControllerActivityComponent::render(const Transform4x4f& parentTrans)
 
 				auto sz = mBatteryFont->sizeText(batteryTextValue, 1.0);
 
-				if (mPads[idx].batteryTextValue != batteryTextValue)
-					mPads[idx].batteryText = nullptr;
+				if (pad.batteryTextValue != batteryTextValue)
+					pad.batteryText = nullptr;
 
-				mPads[idx].batteryTextValue = batteryTextValue;
-				mPads[idx].batteryTextSize = sz.x();
+				pad.batteryTextValue = batteryTextValue;
+				pad.batteryTextSize = sz.x();
 
 				itemsWidth += sz.x() + mSpacing;
 				batteryTextOffset = mSize.y() / 2.0f - sz.y() / 2.0f;

--- a/es-core/src/components/DateTimeEditComponent.cpp
+++ b/es-core/src/components/DateTimeEditComponent.cpp
@@ -307,6 +307,8 @@ void DateTimeEditComponent::setFont(std::shared_ptr<Font> font)
 
 void DateTimeEditComponent::onSizeChanged()
 {
+	GuiComponent::onSizeChanged();
+
 	mAutoSize = false;
 	updateTextCache();
 }

--- a/es-core/src/components/GridTileComponent.h
+++ b/es-core/src/components/GridTileComponent.h
@@ -225,7 +225,7 @@ public:
 	void forceSize(Vector2f size, float selectedZoom = 1.0);
 
 	void renderBackground(const Transform4x4f& parentTrans);
-	void renderContent(const Transform4x4f& parentTrans);
+	void renderContent(const Transform4x4f& parentTrans, bool renderBackground = false);
 
 	bool shouldSplitRendering() { return isAnimationPlaying(3); };
 
@@ -261,7 +261,7 @@ private:
 
 	static void applyThemeToProperties(const ThemeData::ThemeElement* elem, GridTileProperties& properties);
 
-	GridTileProperties getCurrentProperties(bool mixValues = true);
+	GridTileProperties& getCurrentProperties(bool mixValues = true);
 
 	TextComponent mLabel;
 
@@ -272,6 +272,7 @@ private:
 
 	GridTileProperties mDefaultProperties;
 	GridTileProperties mSelectedProperties;
+	GridTileProperties mMixedProperties;
 	GridTileProperties mVideoPlayingProperties;
 
 	std::string mCurrentMarquee;

--- a/es-core/src/components/HelpComponent.cpp
+++ b/es-core/src/components/HelpComponent.cpp
@@ -159,14 +159,29 @@ void HelpComponent::setOpacity(unsigned char opacity)
 {
 	GuiComponent::setOpacity(opacity);
 
-	for (unsigned int i = 0; i < mGrid->getChildCount(); i++)
+	for (auto i = 0; i < mGrid->getChildCount(); i++)
 		mGrid->getChild(i)->setOpacity(opacity);
 }
 
 void HelpComponent::render(const Transform4x4f& parentTrans)
 {
-	Transform4x4f trans = parentTrans * getTransform();
-
 	if (mGrid)
-		mGrid->render(trans);
+	{		
+		// Optimize Help rendering by splitting texts & images rendering ( TextComponents use the same shaders programs ) // mGrid->render(trans);
+		Transform4x4f trans = parentTrans * getTransform() * mGrid->getTransform();
+		
+		std::vector<GuiComponent*> textComponents;
+
+		for (auto i = 0; i < mGrid->getChildCount(); i++)
+		{
+			auto child = mGrid->getChild(i);
+			if (!child->isKindOf<TextComponent>())
+				child->render(trans);
+			else
+				textComponents.push_back(child);
+		}
+
+		for (auto child : textComponents)
+			child->render(trans);
+	}
 }

--- a/es-core/src/components/ImageGridComponent.h
+++ b/es-core/src/components/ImageGridComponent.h
@@ -121,7 +121,7 @@ private:
 	void updateTileAtPos(int tilePos, int imgPos, bool allowAnimation = true, bool updateSelectedState = true);
 	void calcGridDimension();
 	
-	bool isVertical() { return mScrollDirection == SCROLL_VERTICALLY; };
+	inline bool isVertical() { return mScrollDirection == SCROLL_VERTICALLY; };
 
 	bool mEntriesDirty;
 	
@@ -435,7 +435,7 @@ void ImageGridComponent<T>::render(const Transform4x4f& parentTrans)
 	float offsetX = isVertical() ? 0 : mCamera * mCameraDirection * (mTileSize.x() + mMargin.x());
 	float offsetY = isVertical() ? mCamera * mCameraDirection * (mTileSize.y() + mMargin.y()) : 0;
 	
-	tileTrans.translate(Vector3f(offsetX, offsetY, 0.0));
+	tileTrans.translate(offsetX, offsetY);
 
 	if (mEntriesDirty && !(((GuiComponent*)this)->isAnimationPlaying(2)))
 	{
@@ -444,11 +444,8 @@ void ImageGridComponent<T>::render(const Transform4x4f& parentTrans)
 	}
 
 	// Create a clipRect to hide tiles used to buffer texture loading
-	float scaleX = trans.r0().x();
-	float scaleY = trans.r1().y();
-
 	Vector2i pos((int)Math::round(trans.translation()[0]), (int)Math::round(trans.translation()[1]));
-	Vector2i size((int)Math::round(mSize.x() * scaleX), (int)Math::round(mSize.y() * scaleY));
+	Vector2i size((int)Math::round(mSize.x() * trans.r0().x()), (int)Math::round(mSize.y() * trans.r1().y()));
 
 	if (Settings::DebugGrid)
 	{
@@ -473,9 +470,8 @@ void ImageGridComponent<T>::render(const Transform4x4f& parentTrans)
 
 	// Render the selected image background on bottom of the others if needed
 	std::shared_ptr<GridTileComponent> selectedTile = NULL;
-	for(auto it = mTiles.begin(); it != mTiles.end(); it++)
+	for (auto tile : mTiles)
 	{
-		std::shared_ptr<GridTileComponent> tile = (*it);
 		if (tile->isSelected())
 		{
 			selectedTile = tile;
@@ -487,12 +483,9 @@ void ImageGridComponent<T>::render(const Transform4x4f& parentTrans)
 		}
 	}
 	
-	for (auto it = mTiles.begin(); it != mTiles.end(); it++)
-	{
-		std::shared_ptr<GridTileComponent> tile = (*it);
-		if (!tile->isSelected())
+	for (auto tile : mTiles)
+		if (tile != selectedTile)
 			tile->render(tileTrans);
-	}
 
 	// Render the selected image content on top of the others
 	if (selectedTile != NULL)
@@ -758,6 +751,8 @@ void ImageGridComponent<T>::applyTheme(const std::shared_ptr<ThemeData>& theme, 
 template<typename T>
 void ImageGridComponent<T>::onSizeChanged()
 {
+	IList::onSizeChanged();
+
 	if (mTheme == nullptr)
 		return;
 

--- a/es-core/src/components/MenuComponent.cpp
+++ b/es-core/src/components/MenuComponent.cpp
@@ -81,7 +81,7 @@ MenuComponent::MenuComponent(Window* window,
 	mGrid.resetCursor();
 }
 
-void MenuComponent::addWithLabel(const std::string& label, const std::shared_ptr<GuiComponent>& comp, const std::function<void()>& func, const std::string iconName, bool setCursorHere, bool invert_when_selected)
+void MenuComponent::addWithLabel(const std::string& label, const std::shared_ptr<GuiComponent>& comp, const std::function<void()>& func, const std::string iconName, bool setCursorHere)
 {
 	auto theme = ThemeData::getMenuTheme();
 
@@ -112,7 +112,7 @@ void MenuComponent::addWithLabel(const std::string& label, const std::shared_ptr
 	if (EsLocale::isRTL())
 		text->setHorizontalAlignment(Alignment::ALIGN_RIGHT);
 
-	row.addElement(comp, false, invert_when_selected);
+	row.addElement(comp, false);
 
 	if (func != nullptr)
 		row.makeAcceptInputHandler(func);
@@ -120,7 +120,7 @@ void MenuComponent::addWithLabel(const std::string& label, const std::shared_ptr
 	addRow(row, setCursorHere);
 }
 
-void MenuComponent::addWithDescription(const std::string& label, const std::string& description, const std::shared_ptr<GuiComponent>& comp, const std::function<void()>& func, const std::string iconName, bool setCursorHere, bool invert_when_selected, bool multiLine)
+void MenuComponent::addWithDescription(const std::string& label, const std::string& description, const std::shared_ptr<GuiComponent>& comp, const std::function<void()>& func, const std::string iconName, bool setCursorHere, bool multiLine)
 {
 	auto theme = ThemeData::getMenuTheme();
 
@@ -151,7 +151,7 @@ void MenuComponent::addWithDescription(const std::string& label, const std::stri
 		row.addElement(std::make_shared<TextComponent>(mWindow, Utils::String::toUpper(label), theme->Text.font, theme->Text.color), true);
 
 	if (comp != nullptr)
-		row.addElement(comp, false, invert_when_selected);
+		row.addElement(comp, false);
 
 	if (func != nullptr)
 		row.makeAcceptInputHandler(func);
@@ -159,7 +159,7 @@ void MenuComponent::addWithDescription(const std::string& label, const std::stri
 	addRow(row, setCursorHere);
 }
 
-void MenuComponent::addEntry(const std::string name, bool add_arrow, const std::function<void()>& func, const std::string iconName, bool setCursorHere, bool invert_when_selected, bool onButtonRelease, const std::string userData, bool doUpdateSize)
+void MenuComponent::addEntry(const std::string name, bool add_arrow, const std::function<void()>& func, const std::string iconName, bool setCursorHere, bool onButtonRelease, const std::string userData, bool doUpdateSize)
 {
 	auto theme = ThemeData::getMenuTheme();
 	std::shared_ptr<Font> font = theme->Text.font;
@@ -188,7 +188,7 @@ void MenuComponent::addEntry(const std::string name, bool add_arrow, const std::
 	}
 
 	auto text = std::make_shared<TextComponent>(mWindow, name, font, color);
-	row.addElement(text, true, invert_when_selected);
+	row.addElement(text, true);
 
 	if (EsLocale::isRTL())
 		text->setHorizontalAlignment(Alignment::ALIGN_RIGHT);
@@ -355,6 +355,8 @@ void MenuComponent::updateSize()
 
 void MenuComponent::onSizeChanged()
 {
+	GuiComponent::onSizeChanged();
+
 	mBackground.fitTo(mSize, Vector3f::Zero(), Vector2f(-32, -32));
 
 	// update grid row/col sizes

--- a/es-core/src/components/MenuComponent.h
+++ b/es-core/src/components/MenuComponent.h
@@ -32,9 +32,9 @@ public:
 	inline void addRow(const ComponentListRow& row, bool setCursorHere = false, bool doUpdateSize = true, const std::string userData = "") { mList->addRow(row, setCursorHere, true, userData); if (doUpdateSize) updateSize(); }
 	inline void clear() { mList->clear(); }
 
-	void addWithLabel(const std::string& label, const std::shared_ptr<GuiComponent>& comp, const std::function<void()>& func = nullptr, const std::string iconName = "", bool setCursorHere = false, bool invert_when_selected = true);
-	void addWithDescription(const std::string& label, const std::string& description, const std::shared_ptr<GuiComponent>& comp, const std::function<void()>& func = nullptr, const std::string iconName = "", bool setCursorHere = false, bool invert_when_selected = true, bool multiLine = false);
-	void addEntry(const std::string name, bool add_arrow = false, const std::function<void()>& func = nullptr, const std::string iconName = "", bool setCursorHere = false, bool invert_when_selected = true, bool onButtonRelease = false, const std::string userData = "", bool doUpdateSize = true);
+	void addWithLabel(const std::string& label, const std::shared_ptr<GuiComponent>& comp, const std::function<void()>& func = nullptr, const std::string iconName = "", bool setCursorHere = false);
+	void addWithDescription(const std::string& label, const std::string& description, const std::shared_ptr<GuiComponent>& comp, const std::function<void()>& func = nullptr, const std::string iconName = "", bool setCursorHere = false,/* bool invert_when_selected = true, */bool multiLine = false);
+	void addEntry(const std::string name, bool add_arrow = false, const std::function<void()>& func = nullptr, const std::string iconName = "", bool setCursorHere = false, bool onButtonRelease = false, const std::string userData = "", bool doUpdateSize = true);
 	void addGroup(const std::string& label, bool forceVisible = false, bool doUpdateSize = true) { mList->addGroup(label, forceVisible); if (doUpdateSize) updateSize(); }
 	void removeLastRowIfGroup(bool doUpdateSize = true) { mList->removeLastRowIfGroup(); if (doUpdateSize) updateSize(); }
 

--- a/es-core/src/components/NinePatchComponent.cpp
+++ b/es-core/src/components/NinePatchComponent.cpp
@@ -137,7 +137,7 @@ void NinePatchComponent::buildVertices()
 
 void NinePatchComponent::render(const Transform4x4f& parentTrans)
 {
-	if (!isVisible() || mTexture == nullptr || mVertices == nullptr)
+	if (!mVisible || mTexture == nullptr || mVertices == nullptr)
 		return;
 
 	Transform4x4f trans = parentTrans * getTransform();
@@ -204,6 +204,8 @@ void NinePatchComponent::render(const Transform4x4f& parentTrans)
 
 void NinePatchComponent::onSizeChanged()
 {
+	GuiComponent::onSizeChanged();
+
 	if (mPreviousSize == mSize)
 		return;
 

--- a/es-core/src/components/OptionListComponent.h
+++ b/es-core/src/components/OptionListComponent.h
@@ -265,6 +265,8 @@ public:
 	// handles positioning/resizing of text and arrows
 	void onSizeChanged() override
 	{
+		GuiComponent::onSizeChanged();
+
 		mLeftArrow.setResize(0, mText.getFont()->getLetterHeight());
 		mRightArrow.setResize(0, mText.getFont()->getLetterHeight());
 
@@ -578,6 +580,7 @@ private:
 			mText.setText(name);
 			mText.setSize(0, mText.getSize().y());
 			setSize(mText.getSize().x() + mLeftArrow.getSize().x() + mRightArrow.getSize().x() + 24, mText.getSize().y());
+			onSizeChanged();
 			if (mParent) // hack since theres no "on child size changed" callback atm...
 				mParent->onSizeChanged();
 		}
@@ -591,6 +594,8 @@ private:
 
 			mText.setSize(0, mText.getSize().y());
 			setSize(mText.getSize().x() + mRightArrow.getSize().x() + 24, mText.getSize().y());
+			onSizeChanged();
+
 			if(mParent) // hack since theres no "on child size changed" callback atm...
 				mParent->onSizeChanged();
 		}
@@ -604,6 +609,7 @@ private:
 					mText.setText(Utils::String::toUpper(it->name));
 					mText.setSize(0, mText.getSize().y());
 					setSize(mText.getSize().x() + mLeftArrow.getSize().x() + mRightArrow.getSize().x() + 24, mText.getSize().y());
+					onSizeChanged();
 					if(mParent) // hack since theres no "on child size changed" callback atm...
 						mParent->onSizeChanged();
 					break;

--- a/es-core/src/components/SliderComponent.cpp
+++ b/es-core/src/components/SliderComponent.cpp
@@ -122,6 +122,8 @@ float SliderComponent::getValue()
 
 void SliderComponent::onSizeChanged()
 {
+	GuiComponent::onSizeChanged();
+
 	if(!mSuffix.empty())
 		mFont = Font::get((int)(mSize.y()), FONT_PATH_LIGHT);
 	

--- a/es-core/src/components/SwitchComponent.cpp
+++ b/es-core/src/components/SwitchComponent.cpp
@@ -26,6 +26,7 @@ void SwitchComponent::setColor(unsigned int color)
 
 void SwitchComponent::onSizeChanged()
 {
+	GuiComponent::onSizeChanged();
 	mImage.setSize(mSize);
 }
 

--- a/es-core/src/components/TextComponent.cpp
+++ b/es-core/src/components/TextComponent.cpp
@@ -41,6 +41,7 @@ TextComponent::TextComponent(Window* window, const std::string& text, const std:
 
 void TextComponent::onSizeChanged()
 {
+	GuiComponent::onSizeChanged();
 	mAutoCalcExtent = Vector2i((getSize().x() == 0), (getSize().y() == 0));
 	onTextChanged();
 }
@@ -135,7 +136,7 @@ void TextComponent::renderSingleGlow(const Transform4x4f& parentTrans, float yOf
 
 void TextComponent::renderGlow(const Transform4x4f& parentTrans, float yOff, float xOff)
 {
-	Transform4x4f glowTrans = parentTrans * getTransform();
+	Transform4x4f glowTrans = parentTrans;
 	glowTrans.translate(mPadding.x() + mGlowOffset.x() + xOff, mPadding.y() + mGlowOffset.y() + yOff);
 
 	mTextCache->setRenderingGlow(true);
@@ -177,15 +178,15 @@ void TextComponent::renderGlow(const Transform4x4f& parentTrans, float yOff, flo
 
 void TextComponent::render(const Transform4x4f& parentTrans)
 {
-	if (!isVisible())
+	if (!mVisible)
 		return;
 
 	Transform4x4f trans = parentTrans * getTransform();
-	
+
 	if (!Renderer::isVisibleOnScreen(trans.translation().x(), trans.translation().y(), mSize.x() * trans.r0().x(), mSize.y() * trans.r1().y()))
 		return;
 
-	if (mRenderBackground)
+	if (mRenderBackground && mBgColor != 0)
 	{
 		Renderer::setMatrix(trans);
 
@@ -193,7 +194,7 @@ void TextComponent::render(const Transform4x4f& parentTrans)
 		Renderer::drawRect(0.0f, 0.0f, mSize.x(), mSize.y(), bgColor, bgColor);
 	}
 
-	if (mTextCache == nullptr && mFont != nullptr)
+	if (mTextCache == nullptr && mFont != nullptr && !mText.empty())
 	{
 		buildTextCache();
 		onColorChanged();
@@ -203,27 +204,26 @@ void TextComponent::render(const Transform4x4f& parentTrans)
 		return;
 
 	if (mAutoScroll != AutoScrollType::NONE)
-		Renderer::pushClipRect(Vector2i(trans.translation().x(), trans.translation().y()), Vector2i(mSize.x() * trans.r0().x(), mSize.y() * trans.r1().y()));
-	
+		Renderer::pushClipRect(trans.translation().x(), trans.translation().y(), mSize.x() * trans.r0().x(), mSize.y() * trans.r1().y());
+
 	beginCustomClipRect();
 
 	const Vector2f& textSize = mTextCache->metrics.size;
+
 	float yOff = 0;
-	switch(mVerticalAlignment)
+	switch (mVerticalAlignment)
 	{
-		case ALIGN_TOP:
-			yOff = 0;
-			break;
-		case ALIGN_BOTTOM:
-			yOff = (getSize().y() - textSize.y());
-			break;
-		case ALIGN_CENTER:
-			yOff = (getSize().y() - textSize.y()) / 2.0f;
-			break;
+	case ALIGN_BOTTOM:
+		yOff = (getSize().y() - textSize.y());
+		break;
+	case ALIGN_CENTER:
+		yOff = (getSize().y() - textSize.y()) / 2.0f;
+		break;
 	}
+
 	Vector3f off(mPadding.x(), mPadding.y() + yOff, 0);
 
-	if(Settings::DebugText)
+	if (Settings::DebugText)
 	{
 		// draw the "textbox" area, what we are aligned within
 		Renderer::setMatrix(trans);
@@ -233,11 +233,11 @@ void TextComponent::render(const Transform4x4f& parentTrans)
 	if ((mGlowColor & 0x000000FF) != 0 && mGlowSize > 0)
 	{
 		if (mAutoScroll == AutoScrollType::VERTICAL)
-			renderGlow(parentTrans, yOff - mMarqueeOffset, 0);
+			renderGlow(trans, yOff - mMarqueeOffset, 0);
 		else
-			renderGlow(parentTrans, yOff, -mMarqueeOffset);
+			renderGlow(trans, yOff, -mMarqueeOffset);
 
-		onColorChanged();
+		mTextCache->setColor(mColor & 0xFFFFFF00 | (unsigned char)((mColor & 0xFF) * (mOpacity / 255.0)));
 	}
 
 	Transform4x4f drawTrans = trans;
@@ -252,13 +252,12 @@ void TextComponent::render(const Transform4x4f& parentTrans)
 	else
 		trans.translate(off);
 
-//		trans.translate(off);
 	Renderer::setMatrix(trans);
 
 	// draw the text area, where the text actually is going
-	if(Settings::DebugText)
+	if (Settings::DebugText)
 	{
-		switch(mHorizontalAlignment)
+		switch (mHorizontalAlignment)
 		{
 		case ALIGN_LEFT:
 			Renderer::drawRect(0.0f, 0.0f, mTextCache->metrics.size.x(), mTextCache->metrics.size.y(), 0x00000033, 0x00000033);
@@ -271,12 +270,12 @@ void TextComponent::render(const Transform4x4f& parentTrans)
 			break;
 		}
 	}
-		
+
 	mFont->renderTextCache(mTextCache.get());
 
 	// render currently selected item text again if
 	// marquee is scrolled far enough for it to repeat
-		
+
 	if (mMarqueeOffset2 != 0.0 && mAutoScroll != AutoScrollType::VERTICAL)
 	{
 		trans = drawTrans;
@@ -284,7 +283,7 @@ void TextComponent::render(const Transform4x4f& parentTrans)
 
 		if ((mGlowColor & 0x000000FF) != 0 && mGlowSize > 0)
 		{
-			renderGlow(parentTrans, yOff, -mMarqueeOffset2);
+			renderGlow(drawTrans, yOff, -mMarqueeOffset2);
 			onColorChanged();
 		}
 
@@ -306,7 +305,7 @@ void TextComponent::render(const Transform4x4f& parentTrans)
 			mirror.r3().y() = mirror.r3().y() + textSize.y();
 
 		Renderer::setMatrix(mirror);
-			
+
 		float baseOpacity = mOpacity / 255.0;
 		float alpha = baseOpacity * ((mColor & 0x000000ff)) / 255.0;
 		float alpha2 = baseOpacity * alpha * mReflection.y();
@@ -503,11 +502,8 @@ void TextComponent::onShow()
 
 void TextComponent::onColorChanged()
 {
-	if(mTextCache)
-	{
-		auto color = mColor & 0xFFFFFF00 | (unsigned char)((mColor & 0xFF) * (mOpacity / 255.0));
-		mTextCache->setColor(color);
-	}
+	if (mTextCache)
+		mTextCache->setColor(mColor & 0xFFFFFF00 | (unsigned char)((mColor & 0xFF) * (mOpacity / 255.0)));
 }
 
 void TextComponent::setHorizontalAlignment(Alignment align)

--- a/es-core/src/components/TextComponent.cpp
+++ b/es-core/src/components/TextComponent.cpp
@@ -125,22 +125,18 @@ void TextComponent::setUppercase(bool uppercase)
 	onTextChanged();
 }
 
-void TextComponent::renderSingleGlow(const Transform4x4f& parentTrans, float yOff, float x, float y)
+void TextComponent::renderSingleGlow(const Transform4x4f& parentTrans, float yOff, float x, float y, bool verticesChanged)
 {
-	Vector3f off = Vector3f(mPadding.x() + x + mGlowOffset.x(), mPadding.y() + yOff + y + mGlowOffset.y(), 0);
-
-	Transform4x4f trans = parentTrans * getTransform();
-	trans.translate(off);
-
+	Transform4x4f trans = parentTrans;
+	trans.translate(x, y);
 	Renderer::setMatrix(trans);
-	mFont->renderTextCache(mTextCache.get());	
+	mFont->renderTextCache(mTextCache.get(), verticesChanged);
 }
 
 void TextComponent::renderGlow(const Transform4x4f& parentTrans, float yOff, float xOff)
 {
-	Transform4x4f glowTrans = parentTrans;
-	if (xOff != 0.0)
-		glowTrans.translate(Vector3f(xOff, 0, 0));
+	Transform4x4f glowTrans = parentTrans * getTransform();
+	glowTrans.translate(mPadding.x() + mGlowOffset.x() + xOff, mPadding.y() + mGlowOffset.y() + yOff);
 
 	mTextCache->setRenderingGlow(true);
 	
@@ -150,9 +146,9 @@ void TextComponent::renderGlow(const Transform4x4f& parentTrans, float yOff, flo
 		mTextCache->setColor((mGlowColor & 0xFFFFFF00) | (unsigned char)(a * (mOpacity / 255.0)));
 
 		renderSingleGlow(glowTrans, yOff, 1, 0);
-		renderSingleGlow(glowTrans, yOff, 0, 1);
-		renderSingleGlow(glowTrans, yOff, -1, 0);
-		renderSingleGlow(glowTrans, yOff, 0, -1);
+		renderSingleGlow(glowTrans, yOff, 0, 1, false);
+		renderSingleGlow(glowTrans, yOff, -1, 0, false);
+		renderSingleGlow(glowTrans, yOff, 0, -1, false);
 	}
 	else
 	{
@@ -164,16 +160,16 @@ void TextComponent::renderGlow(const Transform4x4f& parentTrans, float yOff, flo
 		renderSingleGlow(glowTrans, yOff, x, y);
 
 		for (int i = 0; i < 2 * mGlowSize; i++)
-			renderSingleGlow(glowTrans, yOff, ++x, y);
+			renderSingleGlow(glowTrans, yOff, ++x, y, false);
 
 		for (int i = 0; i < 2 * mGlowSize; i++)
-			renderSingleGlow(glowTrans, yOff, x, ++y);
+			renderSingleGlow(glowTrans, yOff, x, ++y, false);
 
 		for (int i = 0; i < 2 * mGlowSize; i++)
-			renderSingleGlow(glowTrans, yOff, --x, y);
+			renderSingleGlow(glowTrans, yOff, --x, y, false);
 
 		for (int i = 0; i < 2 * mGlowSize; i++)
-			renderSingleGlow(glowTrans, yOff, x, --y);
+			renderSingleGlow(glowTrans, yOff, x, --y, false);
 	}
 
 	mTextCache->setRenderingGlow(false);
@@ -276,7 +272,6 @@ void TextComponent::render(const Transform4x4f& parentTrans)
 		}
 	}
 		
-
 	mFont->renderTextCache(mTextCache.get());
 
 	// render currently selected item text again if

--- a/es-core/src/components/TextComponent.h
+++ b/es-core/src/components/TextComponent.h
@@ -81,7 +81,7 @@ protected:
 	std::string mSourceText;
 
 private:	
-	void renderSingleGlow(const Transform4x4f& parentTrans, float yOff, float x, float y);
+	void renderSingleGlow(const Transform4x4f& parentTrans, float yOff, float x, float y, bool verticesChanged = true);
 	void renderGlow(const Transform4x4f& parentTrans, float yOff, float xOff);
 
 	void onColorChanged();

--- a/es-core/src/components/TextEditComponent.cpp
+++ b/es-core/src/components/TextEditComponent.cpp
@@ -49,6 +49,7 @@ void TextEditComponent::onFocusLost()
 
 void TextEditComponent::onSizeChanged()
 {
+	GuiComponent::onSizeChanged();
 	mBox.fitTo(mSize, Vector3f::Zero(), Vector2f(-34, -32 - TEXT_PADDING_VERT));
 	onTextChanged(); // wrap point probably changed
 }

--- a/es-core/src/components/VideoComponent.cpp
+++ b/es-core/src/components/VideoComponent.cpp
@@ -98,13 +98,19 @@ VideoComponent::~VideoComponent()
 
 void VideoComponent::onOriginChanged()
 {
-	// Update the embeded static image
+	GuiComponent::onOriginChanged();
 	mStaticImage.setOrigin(mOrigin);
+}
+
+void VideoComponent::onPositionChanged()
+{
+	GuiComponent::onPositionChanged();
+	mStaticImage.setPosition(mPosition);
 }
 
 void VideoComponent::onSizeChanged()
 {
-	// Update the embeded static image
+	GuiComponent::onSizeChanged();
 	mStaticImage.onSizeChanged();
 }
 
@@ -230,11 +236,6 @@ void VideoComponent::renderSnapshot(const Transform4x4f& parentTrans)
 
 		mStaticImage.render(parentTrans);
 	}
-}
-
-void VideoComponent::onPositionChanged()
-{
-	mStaticImage.setPosition(mPosition);
 }
 
 void VideoComponent::applyTheme(const std::shared_ptr<ThemeData>& theme, const std::string& view, const std::string& element, unsigned int properties)

--- a/es-core/src/components/VideoVlcComponent.cpp
+++ b/es-core/src/components/VideoVlcComponent.cpp
@@ -750,7 +750,10 @@ void VideoVlcComponent::applyTheme(const std::shared_ptr<ThemeData>& theme, cons
 void VideoVlcComponent::update(int deltaTime)
 {
 	mElapsed += deltaTime;
-	mStaticImage.update(deltaTime);
+
+	if (mConfig.showSnapshotNoVideo || mConfig.showSnapshotDelay)
+		mStaticImage.update(deltaTime);
+
 	VideoComponent::update(deltaTime);	
 }
 

--- a/es-core/src/guis/GuiDetectDevice.cpp
+++ b/es-core/src/guis/GuiDetectDevice.cpp
@@ -72,6 +72,8 @@ GuiDetectDevice::GuiDetectDevice(Window* window, bool firstRun, const std::funct
 
 void GuiDetectDevice::onSizeChanged()
 {
+	GuiComponent::onSizeChanged();
+
 	mBackground.fitTo(mSize, Vector3f::Zero(), Vector2f(-32, -32));
 
 	// grid

--- a/es-core/src/guis/GuiInputConfig.cpp
+++ b/es-core/src/guis/GuiInputConfig.cpp
@@ -33,28 +33,32 @@ void GuiInputConfig::initInputConfigStructure()
 {
 	GUI_INPUT_CONFIG_LIST =
 	{
-		{ "up",               false, "UP",           ":/help/dpad_up.svg" },
-		{ "down",             false, "DOWN",         ":/help/dpad_down.svg" },
-		{ "left",             false, "LEFT",         ":/help/dpad_left.svg" },
-		{ "right",            false, "RIGHT",        ":/help/dpad_right.svg" },
-		{ "start",            true,  "START",              ":/help/button_start.svg" },
-		{ "select",           true,  "SELECT",             ":/help/button_select.svg" },
-
 		{ "a",                false, InputConfig::buttonLabel("a"),    InputConfig::buttonImage("a") },
 		{ "b",                true,  InputConfig::buttonLabel("b"),    InputConfig::buttonImage("b") },
 		{ "x",                true,  "X",    ":/help/buttons_north.svg" },
 		{ "y",                true,  "Y",    ":/help/buttons_west.svg" },
 
+		{ "start",            true,  "START",              ":/help/button_start.svg" },
+		{ "select",           true,  "SELECT",             ":/help/button_select.svg" },
+
+		{ "up",               false, "UP",           ":/help/dpad_up.svg" },
+		{ "down",             false, "DOWN",         ":/help/dpad_down.svg" },
+		{ "left",             false, "LEFT",         ":/help/dpad_left.svg" },
+		{ "right",            false, "RIGHT",        ":/help/dpad_right.svg" },
+
+		{ "pageup",          true,  "L1",      ":/help/button_l.svg" },
+		{ "pagedown",        true,  "R1",     ":/help/button_r.svg" },
+
 		{ "joystick1up",     true,  "LEFT ANALOG UP",     ":/help/analog_up.svg" },
 		{ "joystick1left",   true,  "LEFT ANALOG LEFT",   ":/help/analog_left.svg" },
 		{ "joystick2up",     true,  "RIGHT ANALOG UP",     ":/help/analog_up.svg" },
 		{ "joystick2left",   true,  "RIGHT ANALOG LEFT",   ":/help/analog_left.svg" },
-		{ "pageup",          true,  "L1",      ":/help/button_l.svg" },
-		{ "pagedown",        true,  "R1",     ":/help/button_r.svg" },
+
 		{ "l2",              true,  "L2",       ":/help/button_lt.svg" },
 		{ "r2",              true,  "R2",      ":/help/button_rt.svg" },
 		{ "l3",              true,  "L3",       ":/help/analog_thumb.svg" },
 		{ "r3",              true,  "R3",      ":/help/analog_thumb.svg" },
+
 		{ "hotkey",          true,  "HOTKEY",      ":/help/button_hotkey.svg" } // batocera
 	};
 }
@@ -244,6 +248,8 @@ GuiInputConfig::GuiInputConfig(Window* window, InputConfig* target, bool reconfi
 
 void GuiInputConfig::onSizeChanged()
 {
+	GuiComponent::onSizeChanged();
+
 	mBackground.fitTo(mSize, Vector3f::Zero(), Vector2f(-32, -32));
 
 	// update grid

--- a/es-core/src/guis/GuiMsgBox.cpp
+++ b/es-core/src/guis/GuiMsgBox.cpp
@@ -183,6 +183,8 @@ bool GuiMsgBox::input(InputConfig* config, Input input)
 
 void GuiMsgBox::onSizeChanged()
 {
+	GuiComponent::onSizeChanged();
+
 	mGrid.setSize(mSize);
 
 	if (mImage != nullptr)

--- a/es-core/src/guis/GuiTextEditPopup.cpp
+++ b/es-core/src/guis/GuiTextEditPopup.cpp
@@ -50,6 +50,8 @@ GuiTextEditPopup::GuiTextEditPopup(Window* window, const std::string& title, con
 
 void GuiTextEditPopup::onSizeChanged()
 {
+	GuiComponent::onSizeChanged();
+
 	mBackground.fitTo(mSize, Vector3f::Zero(), Vector2f(-32, -32));
 
 	mText->setSize(mSize.x() - 40, mText->getSize().y());

--- a/es-core/src/guis/GuiTextEditPopupKeyboard.cpp
+++ b/es-core/src/guis/GuiTextEditPopupKeyboard.cpp
@@ -258,6 +258,8 @@ GuiTextEditPopupKeyboard::GuiTextEditPopupKeyboard(Window* window, const std::st
 
 void GuiTextEditPopupKeyboard::onSizeChanged()
 {
+	GuiComponent::onSizeChanged();
+
 	mBackground.fitTo(mSize, Vector3f::Zero(), Vector2f(-32, -32));
 
 	mText->setSize(mSize.x() - OSK_PADDINGX - OSK_PADDINGX, mText->getSize().y());

--- a/es-core/src/math/Transform4x4f.cpp
+++ b/es-core/src/math/Transform4x4f.cpp
@@ -304,6 +304,18 @@ Transform4x4f& Transform4x4f::translate(const Vector3f& _translation)
 
 } // translate
 
+Transform4x4f& Transform4x4f::translate(const float x, const float y)
+{
+	float*       tm = (float*)this;
+
+	tm[12] += tm[0] * x + tm[4] * y;
+	tm[13] += tm[1] * x + tm[5] * y;
+	tm[14] += tm[2] * x + tm[6] * y;
+
+	return *this;
+
+} // translate
+
 Transform4x4f& Transform4x4f::round()
 {
 	float* tm = (float*)this;

--- a/es-core/src/math/Transform4x4f.h
+++ b/es-core/src/math/Transform4x4f.h
@@ -33,6 +33,7 @@ public:
 	Transform4x4f& rotateY        (const float _angle);
 	Transform4x4f& rotateZ        (const float _angle);
 	Transform4x4f& translate      (const Vector3f& _translation);
+	Transform4x4f& translate	  (const float x, const float y);
 	Transform4x4f& round          ();
 
 	inline       Vector3f& translation()       { return mR3.v3(); }

--- a/es-core/src/renderers/Renderer.cpp
+++ b/es-core/src/renderers/Renderer.cpp
@@ -658,9 +658,9 @@ namespace Renderer
 		Instance()->drawLines(_vertices, _numVertices, _srcBlendFactor, _dstBlendFactor);
 	}
 
-	void drawTriangleStrips(const Vertex* _vertices, const unsigned int _numVertices, const Blend::Factor _srcBlendFactor, const Blend::Factor _dstBlendFactor)
+	void drawTriangleStrips(const Vertex* _vertices, const unsigned int _numVertices, const Blend::Factor _srcBlendFactor, const Blend::Factor _dstBlendFactor, bool verticesChanged)
 	{
-		Instance()->drawTriangleStrips(_vertices, _numVertices, _srcBlendFactor, _dstBlendFactor);
+		Instance()->drawTriangleStrips(_vertices, _numVertices, _srcBlendFactor, _dstBlendFactor, verticesChanged);
 	}
 
 	void drawTriangleFan(const Vertex* _vertices, const unsigned int _numVertices, const Blend::Factor _srcBlendFactor, const Blend::Factor _dstBlendFactor)

--- a/es-core/src/renderers/Renderer.h
+++ b/es-core/src/renderers/Renderer.h
@@ -82,7 +82,7 @@ namespace Renderer
 		virtual void         bindTexture(const unsigned int _texture) = 0;
 
 		virtual void         drawLines(const Vertex* _vertices, const unsigned int _numVertices, const Blend::Factor _srcBlendFactor = Blend::SRC_ALPHA, const Blend::Factor _dstBlendFactor = Blend::ONE_MINUS_SRC_ALPHA) = 0;
-		virtual void         drawTriangleStrips(const Vertex* _vertices, const unsigned int _numVertices, const Blend::Factor _srcBlendFactor = Blend::SRC_ALPHA, const Blend::Factor _dstBlendFactor = Blend::ONE_MINUS_SRC_ALPHA) = 0;
+		virtual void         drawTriangleStrips(const Vertex* _vertices, const unsigned int _numVertices, const Blend::Factor _srcBlendFactor = Blend::SRC_ALPHA, const Blend::Factor _dstBlendFactor = Blend::ONE_MINUS_SRC_ALPHA, bool verticesChanged = true) = 0;
 		virtual void		 drawTriangleFan(const Vertex* _vertices, const unsigned int _numVertices, const Blend::Factor _srcBlendFactor = Blend::SRC_ALPHA, const Blend::Factor _dstBlendFactor = Blend::ONE_MINUS_SRC_ALPHA) = 0;
 
 		virtual void         setProjection(const Transform4x4f& _projection) = 0;
@@ -138,7 +138,7 @@ namespace Renderer
 	void         updateTexture     (const unsigned int _texture, const Texture::Type _type, const unsigned int _x, const unsigned _y, const unsigned int _width, const unsigned int _height, void* _data);
 	void         bindTexture       (const unsigned int _texture);
 	void         drawLines         (const Vertex* _vertices, const unsigned int _numVertices, const Blend::Factor _srcBlendFactor = Blend::SRC_ALPHA, const Blend::Factor _dstBlendFactor = Blend::ONE_MINUS_SRC_ALPHA);
-	void         drawTriangleStrips(const Vertex* _vertices, const unsigned int _numVertices, const Blend::Factor _srcBlendFactor = Blend::SRC_ALPHA, const Blend::Factor _dstBlendFactor = Blend::ONE_MINUS_SRC_ALPHA);
+	void         drawTriangleStrips(const Vertex* _vertices, const unsigned int _numVertices, const Blend::Factor _srcBlendFactor = Blend::SRC_ALPHA, const Blend::Factor _dstBlendFactor = Blend::ONE_MINUS_SRC_ALPHA, bool verticesChanged = true);
 	void         setProjection     (const Transform4x4f& _projection);
 	void         setMatrix         (const Transform4x4f& _matrix);
 	void         setViewport       (const Rect& _viewport);

--- a/es-core/src/renderers/Renderer.h
+++ b/es-core/src/renderers/Renderer.h
@@ -102,6 +102,7 @@ namespace Renderer
  	bool        init            ();
  	void        deinit          ();
 	void        pushClipRect    (const Vector2i& _pos, const Vector2i& _size);
+	void		pushClipRect	(int x, int y, int w, int h);
 	void        popClipRect     ();
 	void        drawRect        (const float _x, const float _y, const float _w, const float _h, const unsigned int _color, const Blend::Factor _srcBlendFactor = Blend::SRC_ALPHA, const Blend::Factor _dstBlendFactor = Blend::ONE_MINUS_SRC_ALPHA);
 	void        drawRect        (const float _x, const float _y, const float _w, const float _h, const unsigned int _color, const unsigned int _colorEnd, bool horizontalGradient = false, const Blend::Factor _srcBlendFactor = Blend::SRC_ALPHA, const Blend::Factor _dstBlendFactor = Blend::ONE_MINUS_SRC_ALPHA);
@@ -117,17 +118,8 @@ namespace Renderer
 	float		getScreenProportion();
 
 	// API specific
-	static unsigned int convertColor (const unsigned int _color)
-	{
-		// convert from rgba to abgr
-		const unsigned char r = ((_color & 0xff000000) >> 24) & 255;
-		const unsigned char g = ((_color & 0x00ff0000) >> 16) & 255;
-		const unsigned char b = ((_color & 0x0000ff00) >>  8) & 255;
-		const unsigned char a = ((_color & 0x000000ff)      ) & 255;
-
-		return ((a << 24) | (b << 16) | (g << 8) | (r));
-
-	} // convertColor
+	inline static unsigned int convertColor (const unsigned int _color) { return ((_color & 0xFF000000) >> 24) | ((_color & 0x00FF0000) >> 8) | ((_color & 0x0000FF00) << 8) | ((_color & 0x000000FF) << 24); } 
+	// convertColor
 
 	unsigned int getWindowFlags    ();
 	void         setupWindow       ();

--- a/es-core/src/renderers/Renderer_GL21.cpp
+++ b/es-core/src/renderers/Renderer_GL21.cpp
@@ -208,58 +208,7 @@ namespace Renderer
 
 	} // drawLines
 
-	static void setGrayscale()
-	{
-		glMatrixMode(GL_COLOR);
-
-		GLfloat grayScale[16] =
-		{
-			.3f, .3f, .3f, 0.0f,
-			.59f, .59f, .59f, 0.0f,
-			.11f, .11f, .11f, 0.0f,
-			0.0f, 0.0f, 0.0f, 1.0f
-		};
-		glLoadMatrixf(grayScale);
-	} // setGrayscale
-
-
-	struct Vertex4f
-	{
-		Vertex4f() { }
-		Vertex4f(const Vector2f& _pos, const Vector2f& _tex, const unsigned int _col) : pos(_pos), tex(_tex), col(_col) { }
-
-		Vector3f		pos;
-		Vector4f		tex;
-
-		unsigned int col;
-
-	}; // Vertex
-
-	static void correctQuad(Vertex4f& v1, Vertex4f& v2, Vertex4f& v3, Vertex4f& v4)
-	{
-		// detects intersection of two diagonal lines
-		float divisor = (v4.pos.y() - v3.pos.y()) * (v2.pos.x() - v1.pos.x()) - (v4.pos.x() - v3.pos.x()) * (v2.pos.y() - v1.pos.y());
-		float ua = ((v4.pos.x() - v3.pos.x()) * (v1.pos.y() - v3.pos.y()) - (v4.pos.y() - v3.pos.y()) * (v1.pos.x() - v3.pos.x())) / divisor;
-		float ub = ((v2.pos.x() - v1.pos.x()) * (v1.pos.y() - v3.pos.y()) - (v2.pos.y() - v1.pos.y()) * (v1.pos.x() - v3.pos.x())) / divisor;
-
-		// calculates the intersection point
-		float centerX = v1.pos.x() + ua * (v2.pos.x() - v1.pos.x());
-		float centerY = v1.pos.y() + ub * (v2.pos.y() - v1.pos.y());
-		Vector3f center(v2.pos.x() - centerX, v2.pos.y() - centerY, 0.5f);
-
-		float d1 = Vector3f(v1.pos - center).length();
-		float d2 = Vector3f(v2.pos - center).length();
-		float d3 = Vector3f(v3.pos - center).length();
-		float d4 = Vector3f(v4.pos - center).length();
-	
-		// calculates quotients used as w component in uvw texture mapping
-		v1.tex *= isnan(d2) || d2 == 0.0f ? 1.0f : (d1 + d2) / d2;
-		v2.tex *= isnan(d1) || d1 == 0.0f ? 1.0f : (d2 + d1) / d1;
-		v3.tex *= isnan(d4) || d4 == 0.0f ? 1.0f : (d3 + d4) / d4;
-		v4.tex *= isnan(d3) || d3 == 0.0f ? 1.0f : (d4 + d3) / d3;
-	}
-
-	void OpenGL21Renderer::drawTriangleStrips(const Vertex* _vertices, const unsigned int _numVertices, const Blend::Factor _srcBlendFactor, const Blend::Factor _dstBlendFactor)
+	void OpenGL21Renderer::drawTriangleStrips(const Vertex* _vertices, const unsigned int _numVertices, const Blend::Factor _srcBlendFactor, const Blend::Factor _dstBlendFactor, bool verticesChanged)
 	{
 		glEnable(GL_BLEND);
 		glBlendFunc(convertBlendFactor(_srcBlendFactor), convertBlendFactor(_dstBlendFactor));
@@ -267,39 +216,12 @@ namespace Renderer
 		glEnableClientState(GL_VERTEX_ARRAY);
 		glEnableClientState(GL_TEXTURE_COORD_ARRAY);
 		glEnableClientState(GL_COLOR_ARRAY);
-		/*
-		if (_numVertices == 4)
-		{
-			Vertex4f v[4];
-			for (int i = 0; i < 4; i++)
-			{
-				v[i].pos = Vector3f(_vertices[i].pos, 0);
-				v[i].tex = Vector4f(_vertices[i].tex, 0, 1);
-				v[i].col = _vertices[i].col;
-			}
 
-#define	ES_PI (3.1415926535897932384626433832795028841971693993751058209749445923)
-#define	ES_RAD_TO_DEG(_x) ((_x) * (180.0 / ES_PI))
-#define	ES_DEG_TO_RAD(_x) ((_x) * (ES_PI / 180.0))
-
-
-			if (_vertices[2].tex.x() != 0)
-				correctQuad(v[0], v[3], v[1], v[2]);
-			
-			glVertexPointer(3, GL_FLOAT, sizeof(Vertex4f), &v[0].pos);
-			glTexCoordPointer(4, GL_FLOAT, sizeof(Vertex4f), &v[0].tex);
-			glColorPointer(4, GL_UNSIGNED_BYTE, sizeof(Vertex4f), &v[0].col);
-			glDrawArrays(GL_TRIANGLE_STRIP, 0, _numVertices);
-
-		}
-		else*/
-		{
-			glVertexPointer(2, GL_FLOAT, sizeof(Vertex), &_vertices[0].pos);
-			glTexCoordPointer(2, GL_FLOAT, sizeof(Vertex), &_vertices[0].tex);
-			glColorPointer(4, GL_UNSIGNED_BYTE, sizeof(Vertex), &_vertices[0].col);
-			glDrawArrays(GL_TRIANGLE_STRIP, 0, _numVertices);
-		}
-
+		glVertexPointer(2, GL_FLOAT, sizeof(Vertex), &_vertices[0].pos);
+		glTexCoordPointer(2, GL_FLOAT, sizeof(Vertex), &_vertices[0].tex);
+		glColorPointer(4, GL_UNSIGNED_BYTE, sizeof(Vertex), &_vertices[0].col);
+		glDrawArrays(GL_TRIANGLE_STRIP, 0, _numVertices);
+		
 		glDisableClientState(GL_COLOR_ARRAY);
 		glDisableClientState(GL_TEXTURE_COORD_ARRAY);
 		glDisableClientState(GL_VERTEX_ARRAY);

--- a/es-core/src/renderers/Renderer_GL21.h
+++ b/es-core/src/renderers/Renderer_GL21.h
@@ -29,7 +29,7 @@ namespace Renderer
 		void         bindTexture(const unsigned int _texture) override;
 
 		void         drawLines(const Vertex* _vertices, const unsigned int _numVertices, const Blend::Factor _srcBlendFactor = Blend::SRC_ALPHA, const Blend::Factor _dstBlendFactor = Blend::ONE_MINUS_SRC_ALPHA) override;
-		void         drawTriangleStrips(const Vertex* _vertices, const unsigned int _numVertices, const Blend::Factor _srcBlendFactor = Blend::SRC_ALPHA, const Blend::Factor _dstBlendFactor = Blend::ONE_MINUS_SRC_ALPHA) override;
+		void         drawTriangleStrips(const Vertex* _vertices, const unsigned int _numVertices, const Blend::Factor _srcBlendFactor = Blend::SRC_ALPHA, const Blend::Factor _dstBlendFactor = Blend::ONE_MINUS_SRC_ALPHA, bool verticesChanged = true) override;
 		void		 drawTriangleFan(const Vertex* _vertices, const unsigned int _numVertices, const Blend::Factor _srcBlendFactor = Blend::SRC_ALPHA, const Blend::Factor _dstBlendFactor = Blend::ONE_MINUS_SRC_ALPHA) override;
 
 		void         setProjection(const Transform4x4f& _projection) override;

--- a/es-core/src/renderers/Renderer_GLES10.cpp
+++ b/es-core/src/renderers/Renderer_GLES10.cpp
@@ -202,7 +202,7 @@ namespace Renderer
 
 	} // drawLines
 
-	void GLES10Renderer::drawTriangleStrips(const Vertex* _vertices, const unsigned int _numVertices, const Blend::Factor _srcBlendFactor, const Blend::Factor _dstBlendFactor)
+	void GLES10Renderer::drawTriangleStrips(const Vertex* _vertices, const unsigned int _numVertices, const Blend::Factor _srcBlendFactor, const Blend::Factor _dstBlendFactor, bool verticesChanged)
 	{
 		glEnable(GL_BLEND);
 		glBlendFunc(convertBlendFactor(_srcBlendFactor), convertBlendFactor(_dstBlendFactor));

--- a/es-core/src/renderers/Renderer_GLES10.h
+++ b/es-core/src/renderers/Renderer_GLES10.h
@@ -29,7 +29,7 @@ namespace Renderer
 		void         bindTexture(const unsigned int _texture) override;
 
 		void         drawLines(const Vertex* _vertices, const unsigned int _numVertices, const Blend::Factor _srcBlendFactor = Blend::SRC_ALPHA, const Blend::Factor _dstBlendFactor = Blend::ONE_MINUS_SRC_ALPHA) override;
-		void         drawTriangleStrips(const Vertex* _vertices, const unsigned int _numVertices, const Blend::Factor _srcBlendFactor = Blend::SRC_ALPHA, const Blend::Factor _dstBlendFactor = Blend::ONE_MINUS_SRC_ALPHA) override;
+		void         drawTriangleStrips(const Vertex* _vertices, const unsigned int _numVertices, const Blend::Factor _srcBlendFactor = Blend::SRC_ALPHA, const Blend::Factor _dstBlendFactor = Blend::ONE_MINUS_SRC_ALPHA, bool verticesChanged = true) override;
 		void		 drawTriangleFan(const Vertex* _vertices, const unsigned int _numVertices, const Blend::Factor _srcBlendFactor = Blend::SRC_ALPHA, const Blend::Factor _dstBlendFactor = Blend::ONE_MINUS_SRC_ALPHA) override;
 
 		void         setProjection(const Transform4x4f& _projection) override;

--- a/es-core/src/renderers/Renderer_GLES20.h
+++ b/es-core/src/renderers/Renderer_GLES20.h
@@ -28,7 +28,7 @@ namespace Renderer
 		void         bindTexture(const unsigned int _texture) override;
 
 		void         drawLines(const Vertex* _vertices, const unsigned int _numVertices, const Blend::Factor _srcBlendFactor = Blend::SRC_ALPHA, const Blend::Factor _dstBlendFactor = Blend::ONE_MINUS_SRC_ALPHA) override;
-		void         drawTriangleStrips(const Vertex* _vertices, const unsigned int _numVertices, const Blend::Factor _srcBlendFactor = Blend::SRC_ALPHA, const Blend::Factor _dstBlendFactor = Blend::ONE_MINUS_SRC_ALPHA) override;
+		void         drawTriangleStrips(const Vertex* _vertices, const unsigned int _numVertices, const Blend::Factor _srcBlendFactor = Blend::SRC_ALPHA, const Blend::Factor _dstBlendFactor = Blend::ONE_MINUS_SRC_ALPHA, bool verticesChanged = true) override;
 		void		 drawTriangleFan(const Vertex* _vertices, const unsigned int _numVertices, const Blend::Factor _srcBlendFactor = Blend::SRC_ALPHA, const Blend::Factor _dstBlendFactor = Blend::ONE_MINUS_SRC_ALPHA) override;
 
 		void         setProjection(const Transform4x4f& _projection) override;

--- a/es-core/src/resources/Font.cpp
+++ b/es-core/src/resources/Font.cpp
@@ -382,7 +382,8 @@ Font::Glyph* Font::getGlyph(unsigned int id)
 	pGlyph->glyphSize = glyphSize;
 
 	// upload glyph bitmap to texture
-	Renderer::updateTexture(tex->textureId, Renderer::Texture::ALPHA, cursor.x(), cursor.y(), glyphSize.x(), glyphSize.y(), g->bitmap.buffer);
+	if (glyphSize.x() > 0 && glyphSize.y() > 0)
+		Renderer::updateTexture(tex->textureId, Renderer::Texture::ALPHA, cursor.x(), cursor.y(), glyphSize.x(), glyphSize.y(), g->bitmap.buffer);
 
 	// update max glyph height
 	if(glyphSize.y() > mMaxGlyphHeight)
@@ -423,7 +424,7 @@ void Font::rebuildTextures()
 	}
 }
 
-void Font::renderTextCache(TextCache* cache)
+void Font::renderTextCache(TextCache* cache, bool verticesChanged)
 {
 	if(cache == NULL)
 	{
@@ -445,10 +446,10 @@ void Font::renderTextCache(TextCache* cache)
 		}
 
 		if (tex != 0)
-			Renderer::drawTriangleStrips(&vertex.verts[0], vertex.verts.size());
+			Renderer::drawTriangleStrips(&vertex.verts[0], vertex.verts.size(), Renderer::Blend::SRC_ALPHA, Renderer::Blend::ONE_MINUS_SRC_ALPHA, cache->vertexLists.size() > 1 || verticesChanged);
 	}
 
-	if (cache->renderingGlow)
+	if (cache->renderingGlow || !verticesChanged)
 		return;
 
 	for (auto sub : cache->imageSubstitutes)

--- a/es-core/src/resources/Font.h
+++ b/es-core/src/resources/Font.h
@@ -53,7 +53,7 @@ public:
 	TextCache* buildTextCache(const std::string& text, float offsetX, float offsetY, unsigned int color);
 	TextCache* buildTextCache(const std::string& text, Vector2f offset, unsigned int color, float xLen, Alignment alignment = ALIGN_LEFT, float lineSpacing = 1.5f);
 	
-	void renderTextCache(TextCache* cache);
+	void renderTextCache(TextCache* cache, bool verticesChanged = true);
 	void renderGradientTextCache(TextCache* cache, unsigned int colorTop, unsigned int colorBottom, bool horz = false);
 	
 	std::string wrapText(std::string text, float xLen); // Inserts newlines into text to make it wrap properly.

--- a/locale/lang/fr/LC_MESSAGES/emulationstation2.po
+++ b/locale/lang/fr/LC_MESSAGES/emulationstation2.po
@@ -1145,7 +1145,7 @@ msgid "RETRO"
 msgstr "GROS PIXELS"
 
 msgid "ENHANCED"
-msgstr "LISSAGE AMÉLIORÉ"
+msgstr "AMÉLIORÉ"
 
 msgid "CURVATURE"
 msgstr "BALAYAGE COURBÉ"
@@ -1538,7 +1538,7 @@ msgid "DISABLED"
 msgstr "DÉSACTIVÉ"
 
 msgid "DEFAULT"
-msgstr "AUCUNE"
+msgstr "PAR DÉFAUT"
 
 msgid "INSTANT"
 msgstr "INSTANTANÉ"


### PR DESCRIPTION
- Optimisations (for better framerating) :
    - GLES20 renderer optimisations : use alpha shaders for fonts (GLES20) & cache vertices for text glows. Thanks to @rtissera 
    - CPU side optimisations : Transform caching, fastest tile properties for grid, fastest access to settings avoiding double queries on internal maps, avoid some useless allocations, optimize renderings of ComponentList (menus)...

     -> Should earn a lot of fps on boards. On Windows, it's about 10% faster in the systemviem & menus. About +25% faster in the gridview.

- Fixes :
   - Menu : Fix vSync not changed anymore when toggling the option
   - Sorting features & theme subsets options : use std::stable_sort instead of std::sort, because we need to make sure we preserve original order when necessary.
   - Fix images sizings on retroachivements screens with some themes.
   
- Input config screen : 
  - Move A/B/X/Y buttons first : It's not possible to skip dpad input because buttons are not yet assigned.