### PR TITLE
Track music history to stop songs replaying

### DIFF
--- a/es-core/src/AudioManager.cpp
+++ b/es-core/src/AudioManager.cpp
@@ -17,6 +17,10 @@
 #include <unistd.h>
 #endif
 
+// batocera
+// Size of last played music history as a percentage of file total
+#define LAST_PLAYED_SIZE 0.4
+
 AudioManager* AudioManager::sInstance = NULL;
 std::vector<std::shared_ptr<Sound>> AudioManager::sSoundVector;
 
@@ -55,6 +59,7 @@ void AudioManager::init()
 	mSongNameChanged = false;
 	mMusicVolume = 0;
 	mPlayingSystemThemeSong = "none";
+	std::deque<std::string> mLastPlayed;
 
 	if (SDL_InitSubSystem(SDL_INIT_AUDIO) != 0)
 	{
@@ -169,6 +174,39 @@ void AudioManager::getMusicIn(const std::string &path, std::vector<std::string>&
 }
 
 // batocera
+// Add the current song to the last played history, truncating as needed
+void AudioManager::addLastPlayed(const std::string& newSong, int totalMusic)
+{
+	int historySize = std::floor(totalMusic * LAST_PLAYED_SIZE);
+	if (historySize < 1)
+	{
+		// Number of songs is too small to bother with
+		return;
+	}
+	
+	while (mLastPlayed.size() > historySize) {
+		mLastPlayed.pop_back();
+	}
+	mLastPlayed.push_front(newSong);
+	
+	LOG(LogDebug) << "Adding " << newSong << " to last played, " << mLastPlayed.size() << " in history";
+}
+
+// batocera
+// Check if current song exists in last played history
+bool AudioManager::songWasPlayedRecently(const std::string& song)
+{
+	for (std::string i : mLastPlayed)
+	{
+		if (song == i)
+		{
+			return true;
+		}
+	}
+	return false;
+}
+
+// batocera
 void AudioManager::playRandomMusic(bool continueIfPlaying) 
 {
 	if (!Settings::getInstance()->getBool("audio.bgmusic"))
@@ -196,6 +234,11 @@ void AudioManager::playRandomMusic(bool continueIfPlaying)
 		return;
 
 	int randomIndex = Randomizer::random(musics.size());
+	while (songWasPlayedRecently(musics.at(randomIndex)))
+	{
+		LOG(LogDebug) << "Music \"" << musics.at(randomIndex) << "\" was played recently, trying again";
+		randomIndex = Randomizer::random(musics.size());
+	}
 
 	// continue playing ?
 	if (mCurrentMusic != nullptr && continueIfPlaying)
@@ -203,6 +246,7 @@ void AudioManager::playRandomMusic(bool continueIfPlaying)
 
 	playMusic(musics.at(randomIndex));
 	playSong(musics.at(randomIndex));
+	addLastPlayed(musics.at(randomIndex), musics.size());
 	mPlayingSystemThemeSong = "";
 }
 

--- a/es-core/src/AudioManager.cpp
+++ b/es-core/src/AudioManager.cpp
@@ -437,7 +437,8 @@ void AudioManager::playSong(const std::string& song)
 		else if (fread(&info, sizeof(info), 1, file) != 1)
 			LOG(LogError) << "Error AudioManager reading " << song;
 		else if (strncmp(info.tag, "TAG", 3) == 0) {
-			setSongName(info.title);
+			std::string songTitle(info.title, 30);
+			setSongName(songTitle);
 			fclose(file);
 			return;
 		}

--- a/es-core/src/AudioManager.h
+++ b/es-core/src/AudioManager.h
@@ -8,6 +8,8 @@
 #include "SDL_mixer.h"
 #include <string> // batocera
 #include <iostream> // batocera
+#include <deque> // batocera
+#include <math.h> // batocera
 
 class Sound;
 class ThemeData;
@@ -29,6 +31,7 @@ private:
 	std::string mCurrentSong;			// batocera (pop-up for SongName.cpp)
 	std::string mCurrentThemeMusicDirectory;
 	std::string mCurrentMusicPath;
+	std::deque<std::string> mLastPlayed;    // batocera
 
 	bool		mInitialized;
 	std::string	mPlayingSystemThemeSong;
@@ -72,6 +75,8 @@ public:
 private:
 	void playSong(const std::string& song);
 	void setSongName(const std::string& song);
+	void addLastPlayed(const std::string& newSong, int totalMusic);
+	bool songWasPlayedRecently(const std::string& song);
 
 	bool mSongNameChanged;
 };


### PR DESCRIPTION
I've changed the behaviour of the music player so it will keep a limited history of previously played songs in memory, and skip playing songs if they're in that list. So it will avoid situations where the current randomness is "not random enough" and repeats recent songs. I have had situations where songs have repeated many times and it gets annoying.

This solution isn't perfect but I think it does an adequate job of fixing this problem, can be easily removed later and adds very little overhead to the current system. It also works when per system music is enabled.

The history size is hardcoded, and I've just made a decision for it to be 40% of the size of the total song collection. 