### PR TITLE
Limit song title length sent to notification

### DIFF
--- a/es-core/src/AudioManager.cpp
+++ b/es-core/src/AudioManager.cpp
@@ -393,7 +393,8 @@ void AudioManager::playSong(const std::string& song)
 		else if (fread(&info, sizeof(info), 1, file) != 1)
 			LOG(LogError) << "Error AudioManager reading " << song;
 		else if (strncmp(info.tag, "TAG", 3) == 0) {
-			setSongName(info.title);
+			std::string songTitle(info.title, 30);
+			setSongName(songTitle);
 			fclose(file);
 			return;
 		}


### PR DESCRIPTION
If an mp3 file has an id3 v1 song title at or over 30 characters the notification window will overflow into the next id3 fields trying to display it.

The files I was using actually also have v2 tags, the default behaviour of that app I used to set them was to do both. It might be better to prefer v2 tags if both exist.