### PR TITLE
Don't blink cursor on key repeat

### DIFF
--- a/es-core/src/components/TextEditComponent.cpp
+++ b/es-core/src/components/TextEditComponent.cpp
@@ -352,7 +352,7 @@ void TextEditComponent::render(const Transform4x4f& parentTrans)
 			cursorPos[1] = 0;
 		}
 
-		if (!mEditing || mBlinkTime < BLINKTIME / 2)
+		if (!mEditing || mBlinkTime < BLINKTIME / 2 || mCursorRepeatDir != 0)
 		{
 			float cursorHeight = mFont->getHeight() * 0.8f;
 


### PR DESCRIPTION
This change makes it so when you're holding down left or right in a text input the cursor will stop blinking. The current behaviour is annoying because you can't see the cursor half the time and you miss your spot.