### PR TITLE
Add game name to game-start event for pixelcade

### DIFF
--- a/es-app/src/FileData.cpp
+++ b/es-app/src/FileData.cpp
@@ -613,7 +613,7 @@ bool FileData::launchGame(Window* window, LaunchGameOptions options)
 	const std::string rom = Utils::FileSystem::getEscapedPath(getPath());
 	const std::string basename = Utils::FileSystem::getStem(getPath());
 
-	Scripting::fireEvent("game-start", rom, basename);
+	Scripting::fireEvent("game-start", rom, basename, getName());
 
 	time_t tstart = time(NULL);
 


### PR DESCRIPTION
After updating Scripting::fireEvent to support additional args, game-start was never updated to include more info. This PR fixes that.