### PR TITLE
Fix /launch API not triggering when screensaver is active

### DIFF
--- a/es-core/src/Window.cpp
+++ b/es-core/src/Window.cpp
@@ -899,7 +899,12 @@ void Window::postToUiThread(const std::function<void()>& func, void* data)
 	PostedFunction pf;
 	pf.func = func;
 	pf.container = data;
-	mFunctions.push_back(pf);	
+	mFunctions.push_back(pf);
+	if (mSleeping || !PowerSaver::getState())
+	{
+		mSleeping = false;
+		PowerSaver::pushRefreshEvent();
+	}
 }
 
 void Window::processPostedFunctions()

--- a/es-core/src/Window.cpp
+++ b/es-core/src/Window.cpp
@@ -903,6 +903,7 @@ void Window::postToUiThread(const std::function<void()>& func, void* data)
 	if (mSleeping || !PowerSaver::getState())
 	{
 		mSleeping = false;
+		mTimeSinceLastInput = 0;
 		PowerSaver::pushRefreshEvent();
 	}
 }


### PR DESCRIPTION
# Issue
If the screensaver is active due to inactivity and the `/launch` API is called.  No 'launch' happens until a button is press or something is done to wake the device up.

# Fix
When posting updates to the UI thread, check if the device is sleeping or in power save mode.  
- If UI is sleeping or in powersave: unset sleep and also unset the screensaver inactivity timeout.  
- Then send a 'refresh' message so UI is updated and launch event processed.