### PR TITLE
Theming : Per-game customization support

### DIFF
--- a/es-app/src/views/gamelist/DetailedContainer.h
+++ b/es-app/src/views/gamelist/DetailedContainer.h
@@ -88,6 +88,10 @@ protected:
 	void createVideo();
 	void createImageComponent(ImageComponent** pImage, bool forceLoad = false, bool allowFading = false);
 	void loadIfThemed(ImageComponent** pImage, const std::shared_ptr<ThemeData>& theme, const std::string& element, bool forceLoad = false, bool loadPath = false);
+	void loadThemedExtras(FileData* file);
+	void resetThemedExtras();
+
+	std::string     mPerGameExtrasPath;
 
 	ImageComponent* mImage;
 	ImageComponent* mThumbnail;
@@ -128,6 +132,9 @@ protected:
 
 	void createFolderGrid(Vector2f targetSize, std::vector<std::string> thumbs);
 	ComponentGrid* mFolderView;
+
+	std::shared_ptr<ThemeData> mTheme;
+	std::shared_ptr<ThemeData> mCustomTheme;
 
 	bool		mState;
 };

--- a/es-core/src/GuiComponent.cpp
+++ b/es-core/src/GuiComponent.cpp
@@ -268,6 +268,7 @@ void GuiComponent::addChild(GuiComponent* cmp)
 		cmp->getParent()->removeChild(cmp);
 
 	cmp->setParent(this);
+	cmp->mShowing = mShowing;
 }
 
 void GuiComponent::removeChild(GuiComponent* cmp)
@@ -317,6 +318,7 @@ GuiComponent* GuiComponent::getChild(unsigned int i) const
 void GuiComponent::setParent(GuiComponent* parent)
 {
 	mParent = parent;
+
 }
 
 GuiComponent* GuiComponent::getParent() const

--- a/es-core/src/ThemeData.cpp
+++ b/es-core/src/ThemeData.cpp
@@ -300,6 +300,8 @@ std::map<std::string, std::map<std::string, ThemeData::ElementPropertyType>> The
 		{ "zIndex", FLOAT } } },
 	{ "sound", {
 		{ "path", PATH } } },
+	{ "gameextras", {
+		{ "path", PATH } } },
 	{ "controllerActivity", {
 		{ "pos", NORMALIZED_PAIR },
 		{ "size", NORMALIZED_PAIR },
@@ -543,6 +545,7 @@ std::string ThemeData::resolvePlaceholders(const char* in)
 
 ThemeData::ThemeData()
 {	
+	mPerGameOverrideTmp = false;
 	mColorset = Settings::getInstance()->getString("ThemeColorSet");
 	mIconset = Settings::getInstance()->getString("ThemeIconSet");
 	mMenu = Settings::getInstance()->getString("ThemeMenu");
@@ -857,6 +860,8 @@ void ThemeData::parseInclude(const pugi::xml_node& node)
 		}
 	}
 
+	appendFile(path);
+	/*
 	mPaths.push_back(path);
 
 	pugi::xml_document includeDoc;
@@ -876,8 +881,9 @@ void ThemeData::parseInclude(const pugi::xml_node& node)
 
 	parseVariables(theme);
 	parseTheme(theme);
-	
+
 	mPaths.pop_back();
+	*/	
 }
 
 void ThemeData::parseFeature(const pugi::xml_node& node)
@@ -1310,7 +1316,7 @@ void ThemeData::parseView(const pugi::xml_node& root, ThemeView& view, bool over
 			off = nameAttr.find_first_of(delim, prevOff);
 
 			parseElement(node, elemTypeIt->second,
-				view.elements.insert(std::pair<std::string, ThemeElement>(elemKey, ThemeElement())).first->second, overwriteElements);
+				view.elements.insert(std::pair<std::string, ThemeElement>(elemKey, ThemeElement())).first->second, view, overwriteElements);
 
 			if (std::find(view.orderedKeys.cbegin(), view.orderedKeys.cend(), elemKey) == view.orderedKeys.cend())
 				view.orderedKeys.push_back(elemKey);
@@ -1401,7 +1407,7 @@ bool ThemeData::parseRegion(const pugi::xml_node& node)
 	return false;
 }
 
-void ThemeData::parseElement(const pugi::xml_node& root, const std::map<std::string, ElementPropertyType>& typeMap, ThemeElement& element, bool overwrite)
+void ThemeData::parseElement(const pugi::xml_node& root, const std::map<std::string, ElementPropertyType>& typeMap, ThemeElement& element, ThemeView& view, bool overwrite)
 {
 	// ThemeException error;
 	// error.setFiles(mPaths);
@@ -1417,7 +1423,30 @@ void ThemeData::parseElement(const pugi::xml_node& root, const std::map<std::str
 			element.extra = 1;
 		else if (extra == "static")
 			element.extra = 2;
+
+		if (element.extra && mPerGameOverrideTmp)
+			element.extra = 3; // Set as "Per-game" Extra
 	}	
+
+	// Import properties from another control
+	if (root.attribute("importProperties"))
+	{
+		std::string imports = Utils::String::toLower(root.attribute("importProperties").as_string());
+
+		auto importIt = view.elements.find(imports);
+		if (importIt != view.elements.cend())
+		{
+			for (auto prop : importIt->second.properties)
+			{
+				auto typeIt = typeMap.find(prop.first);
+				if (typeIt != typeMap.cend())
+					element.properties[prop.first] = prop.second;
+			}
+
+			for (auto sb : importIt->second.mStoryBoards)
+				element.mStoryBoards[sb.first] = new ThemeStoryboard(*sb.second);
+		}
+	}
 
 	for(pugi::xml_node node = root.first_child(); node; node = node.next_sibling())
 	{
@@ -1705,15 +1734,23 @@ std::vector<GuiComponent*> ThemeData::makeExtras(const std::shared_ptr<ThemeData
 		{			
 			if (type != ExtraImportType::ALL_EXTRAS)
 			{
+				bool take = false;
+
 				bool hasActivationStoryBoard = elem.mStoryBoards.size() > 0 && (
 					elem.mStoryBoards.find("activate") != elem.mStoryBoards.cend() ||
 					elem.mStoryBoards.find("activateNext") != elem.mStoryBoards.cend() ||
 					elem.mStoryBoards.find("activatePrev") != elem.mStoryBoards.cend());
 
-				if ((type & ExtraImportType::WITH_ACTIVATESTORYBOARD) == ExtraImportType::WITH_ACTIVATESTORYBOARD && !hasActivationStoryBoard)
-					continue;
+				if ((type & ExtraImportType::WITH_ACTIVATESTORYBOARD) == ExtraImportType::WITH_ACTIVATESTORYBOARD && hasActivationStoryBoard)
+					take = true;
 
-				if ((type & ExtraImportType::WITHOUT_ACTIVATESTORYBOARD) == ExtraImportType::WITHOUT_ACTIVATESTORYBOARD && hasActivationStoryBoard)
+				if ((type & ExtraImportType::WITHOUT_ACTIVATESTORYBOARD) == ExtraImportType::WITHOUT_ACTIVATESTORYBOARD && !hasActivationStoryBoard)
+					take = true;
+
+				if ((type & ExtraImportType::PERGAMEEXTRAS) == ExtraImportType::PERGAMEEXTRAS && elem.extra == 3)
+					take = true;
+
+				if (!take)
 					continue;
 			}
 
@@ -2086,4 +2123,66 @@ ThemeData::ThemeElement::~ThemeElement()
 		delete sb.second;
 
 	mStoryBoards.clear();
+}
+
+std::shared_ptr<ThemeData> ThemeData::clone(const std::string& viewName)
+{
+	auto theme = std::make_shared<ThemeData>();
+	theme->mVersion = mVersion;
+	theme->mDefaultView = mDefaultView;
+	theme->mDefaultTransition = mDefaultTransition;
+	theme->mVariables = mVariables;	
+	theme->mSubsets = mSubsets;
+	theme->mColorset = mColorset;
+	theme->mIconset = mIconset;
+	theme->mMenu = mMenu;
+	theme->mSystemview = mSystemview;
+	theme->mGamelistview = mGamelistview;
+	theme->mSystemThemeFolder = mSystemThemeFolder;
+	theme->mLanguage = mLanguage;
+	theme->mRegion = mRegion;
+
+	if (!viewName.empty())
+	{
+		auto view = mViews.find(viewName);
+		if (view != mViews.cend())
+			theme->mViews.insert(std::pair<std::string, ThemeView>(viewName, view->second));
+	}
+	else
+		theme->mViews = mViews;
+	
+	return theme;
+}
+
+bool ThemeData::appendFile(const std::string& path, bool perGameOverride)
+{
+	mPaths.push_back(path);
+
+	pugi::xml_document includeDoc;
+	pugi::xml_parse_result result = includeDoc.load_file(path.c_str());
+	if (!result)
+	{
+		mPaths.pop_back();
+		LOG(LogWarning) << "Error parsing file: \n    " << result.description() << "    from included file \"" << path << "\":\n    ";
+		return false;
+	}
+
+	pugi::xml_node theme = includeDoc.child("theme");
+	if (!theme)
+	{
+		mPaths.pop_back();
+		LOG(LogWarning) << "Missing <theme> tag!" << "    from included file \"" << path << "\":\n    ";
+		return false;
+	}
+
+	mPerGameOverrideTmp = perGameOverride;
+
+	parseVariables(theme);
+	parseTheme(theme);
+
+	mPerGameOverrideTmp = false;
+
+	mPaths.pop_back();
+
+	return true;
 }

--- a/es-core/src/ThemeData.h
+++ b/es-core/src/ThemeData.h
@@ -312,11 +312,12 @@ public:
 	const ThemeElement* getElement(const std::string& view, const std::string& element, const std::string& expectedType) const;
 	const std::vector<std::string> getElementNames(const std::string& view, const std::string& expectedType) const;
 
-	enum ExtraImportType
+	enum ExtraImportType : unsigned int
 	{
 		WITH_ACTIVATESTORYBOARD = 1,
 		WITHOUT_ACTIVATESTORYBOARD = 2,
-		ALL_EXTRAS = 1 + 2
+		PERGAMEEXTRAS = 4,
+		ALL_EXTRAS = 1 + 2 + 4
 	};
 
 	static std::vector<GuiComponent*> makeExtras(const std::shared_ptr<ThemeData>& theme, const std::string& view, Window* window, bool forceLoad = false, ExtraImportType type = ExtraImportType::ALL_EXTRAS);
@@ -357,6 +358,9 @@ public:
 
 	std::string getViewDisplayName(const std::string& view);
 
+	std::shared_ptr<ThemeData> clone(const std::string& viewName);
+	bool appendFile(const std::string& path, bool perGameOverride = false);
+
 private:
 	static std::map< std::string, std::map<std::string, ElementPropertyType> > sElementMap;
 	static std::vector<std::string> sSupportedFeatures;
@@ -378,7 +382,7 @@ private:
 	void parseCustomView(const pugi::xml_node& node, const pugi::xml_node& root);	
 	void parseViewElement(const pugi::xml_node& node);
 	void parseView(const pugi::xml_node& viewNode, ThemeView& view, bool overwriteElements = true);
-	void parseElement(const pugi::xml_node& elementNode, const std::map<std::string, ElementPropertyType>& typeMap, ThemeElement& element, bool overwrite = true);
+	void parseElement(const pugi::xml_node& elementNode, const std::map<std::string, ElementPropertyType>& typeMap, ThemeElement& element, ThemeView& view, bool overwrite = true);
 	bool parseRegion(const pugi::xml_node& node);
 	bool parseSubset(const pugi::xml_node& node);
 	bool isFirstSubset(const pugi::xml_node& node);
@@ -447,6 +451,8 @@ private:
 
 	static std::shared_ptr<ThemeData::ThemeMenu> mMenuTheme;
 	static ThemeData* mDefaultTheme;	
+
+	bool mPerGameOverrideTmp;
 };
 
 #endif // ES_CORE_THEME_DATA_H

--- a/es-core/src/components/ImageComponent.cpp
+++ b/es-core/src/components/ImageComponent.cpp
@@ -315,18 +315,27 @@ void ImageComponent::uncrop()
 
 void ImageComponent::setFlipX(bool flip)
 {
+	if (mFlipX == flip)
+		return;
+
 	mFlipX = flip;
 	updateVertices();
 }
 
 void ImageComponent::setFlipY(bool flip)
 {
+	if (mFlipY == flip)
+		return;
+
 	mFlipY = flip;
 	updateVertices();
 }
 
 void ImageComponent::setColorShift(unsigned int color)
 {
+	if (mColorShift == color && mColorShiftEnd == color)
+		return;
+
 	mColorShift = color;
 	mColorShiftEnd = color;
 	updateColors();
@@ -334,18 +343,27 @@ void ImageComponent::setColorShift(unsigned int color)
 
 void ImageComponent::setColorShiftEnd(unsigned int color)
 {
+	if (mColorShiftEnd == color)
+		return;
+
 	mColorShiftEnd = color;
 	updateColors();
 }
 
 void ImageComponent::setColorGradientHorizontal(bool horizontal)
 {
+	if (mColorGradientHorizontal == horizontal)
+		return;
+
 	mColorGradientHorizontal = horizontal;
 	updateColors();
 }
 
 void ImageComponent::setOpacity(unsigned char opacity)
 {
+	if (mOpacity == opacity)
+		return;
+
 	mOpacity = opacity;	
 	updateColors();
 }


### PR DESCRIPTION
**Theming : Per-game customization support**

First, declare the folder where per-game customisation are stored, in the view(s) you use : 
```
  <view name="detailed">  
    <gameextras name="gameextras">
      <path>./../games/${system.theme}</path>
    </gameextras>
```
You can define a folder per view, or use the same folder for all views.

In your theme create the folder ( ex : \games\fbneo for the provided sample )

Then create a xml theme file for the game, following one of this naming conventions :
  - create a folder using the "rom" name, and place a theme.xml file in that folder ( ex : 1945kiii/theme.xml )
  - create a folder using the "rom" crc32, and place a theme.xml file in that folder ( ex : 0B7A7EA5/theme.xml )
  - create an xml file in the folder using the "rom" name  ( ex : 1945kiii.xml )
  - create an xml file in the folder using the "rom" name  ( ex : 0B7A7EA5.xml )

The xml file is loaded over the current theme (override), so you should not include files of the main theme.

Here's a sample, replacing the md_video and showing a custom image instead, and adding a new image.

```
<?xml version="1.0" encoding="UTF-8"?>
<theme>
  <formatVersion>7</formatVersion>
  <view name="detailed">
    <image name="image" extra="true" importProperties="md_video">
      <path>./1945kiii-thumb.png</path>
    </image>
  <image name="pergame1" extra="true">
      <tile>false</tile>
      <minSize>0.55 0.85</minSize>
      <pos>0.5 0.5</pos>
      <origin>0.5 0.5</origin>
      <path>./myotherimage.png</path>
     <color>FFFFFF92</color>
      <zIndex>25</zIndex>
    </image>
    <control name="md_video">
      <visible>false</visible>
    </control>
  </view>
</theme>

```

Notes :
- Per-game theming doest not support creation of subsets.
- new attribute importProperties allows to import all the properties (including storyboard) of a control defined in the theme for the new control

**Add non substituable "md_" elements** 

New elements : md_image_only, md_thumbnail_only, md_marquee_only, md_wheel_only...
By default md_image takes thumbnail when the image is missing. md_*_only elements don't try to find alternate medias.