### PR TITLE
Shorten "REBOOT SYSTEM TO APPLY THE UPDATE" string

### DIFF
--- a/es-app/src/guis/GuiUpdate.cpp
+++ b/es-app/src/guis/GuiUpdate.cpp
@@ -64,7 +64,7 @@ public:
 			GuiUpdate::state = GuiUpdateState::State::UPDATE_READY;
 
 			mWndNotification->updateTitle(_U("\uF019 ") + _("UPDATE IS READY"));
-			mWndNotification->updateText(_("REBOOT SYSTEM TO APPLY THE UPDATE"));
+			mWndNotification->updateText(_("REBOOT TO APPLY"));
 
 			std::this_thread::yield();
 			std::this_thread::sleep_for(std::chrono::hours(12));


### PR DESCRIPTION
As it is right now, the "UPDATE IS READY" notification is too small to contain this string:
![screenshot-2022 03 21-17h38 24](https://user-images.githubusercontent.com/67527064/159224318-e0f979da-638c-49b1-88da-08838c915a8a.png)

 This shortens it to fit.