### PR TITLE
Support Non-ASCII rom path in windows platform

### DIFF
--- a/es-core/src/platform.cpp
+++ b/es-core/src/platform.cpp
@@ -57,10 +57,10 @@ int runSystemCommand(const std::string& cmd_utf8, const std::string& name, Windo
 
 #define BUFFER_SIZE 8192
 
-	TCHAR szEnvPath[BUFFER_SIZE];
-	DWORD dwLen = ExpandEnvironmentStringsA(command.c_str(), szEnvPath, BUFFER_SIZE);
+	WCHAR szEnvPath[BUFFER_SIZE];
+	DWORD dwLen = ExpandEnvironmentStringsW(Utils::String::convertToWideString(command).c_str(), szEnvPath, BUFFER_SIZE);
 	if (dwLen > 0 && dwLen < BUFFER_SIZE)
-		command = std::string(szEnvPath);
+		command = Utils::String::convertFromWideString(szEnvPath);
 
 	std::string exe;
 	std::string args;


### PR DESCRIPTION
Convert system command  from UTF-8 to ANSI code page to support Non-ASCII rom path in windows platform
before:
2022-05-11 19:23:23.800 [INFO]    "E:\RetroBat\emulationstation\emulatorLauncher.exe"  -p1index 0 -p1guid 030000005e0400008e02000000007200 -p1name "Xbox 360 Controller" -p1nbbuttons 11 -p1nbhats 1 -p1nbaxes 6  -system psp -emulator ppsspp -core  -rom "E:\RetroBat\roms\psp\\**G_古惑狼泰�?cso**"
2022-05-11 19:23:23.858 [ERROR]   rom does not exist

after:
2022-05-11 19:51:54.371 [INFO]    "E:\RetroBat\emulationstation\emulatorLauncher.exe"  -p1index 0 -p1guid 030000005e0400008e02000000007200 -p1name "Xbox 360 Controller" -p1nbbuttons 11 -p1nbhats 1 -p1nbaxes 6  -system psp -emulator ppsspp -core  -rom "E:\RetroBat\roms\psp\\**G_古惑狼泰坦.cso**"
