### PR TITLE
Squashed commit of the following:

### DIFF
--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -116,7 +116,7 @@ GuiMenu::GuiMenu(Window *window, bool animate) : GuiComponent(window), mMenu(win
 	// KODI >
 	// GAMES SETTINGS >
 	// CONTROLLER & BLUETOOTH >
-	// UI SETTINGS >
+	// USER INTERFACE SETTINGS >
 	// SOUND SETTINGS >
 	// NETWORK >
 	// SCRAPER >
@@ -150,7 +150,7 @@ GuiMenu::GuiMenu(Window *window, bool animate) : GuiComponent(window), mMenu(win
 #if BATOCERA
 		addEntry(_("GAME SETTINGS").c_str(), true, [this] { openGamesSettings(); }, "iconGames");
 		addEntry(controllers_settings_label.c_str(), true, [this] { openControllersSettings(); }, "iconControllers");
-		addEntry(_("UI SETTINGS").c_str(), true, [this] { openUISettings(); }, "iconUI");
+		addEntry(_("USER INTERFACE SETTINGS").c_str(), true, [this] { openUISettings(); }, "iconUI");
 		addEntry(_("GAME COLLECTION SETTINGS").c_str(), true, [this] { openCollectionSystemSettings(); }, "iconAdvanced");
 		addEntry(_("SOUND SETTINGS").c_str(), true, [this] { openSoundSettings(); }, "iconSound");
 
@@ -160,7 +160,7 @@ GuiMenu::GuiMenu(Window *window, bool animate) : GuiComponent(window), mMenu(win
 		if (ApiSystem::getInstance()->isScriptingSupported(ApiSystem::GAMESETTINGS))
 			addEntry(_("GAME SETTINGS").c_str(), true, [this] { openGamesSettings(); }, "iconGames");
 
-		addEntry(_("UI SETTINGS").c_str(), true, [this] { openUISettings(); }, "iconUI");
+		addEntry(_("USER INTERFACE SETTINGS").c_str(), true, [this] { openUISettings(); }, "iconUI");
 
 		if (ApiSystem::getInstance()->isScriptingSupported(ApiSystem::GAMESETTINGS))		
 			addEntry(controllers_settings_label.c_str(), true, [this] { openControllersSettings(); }, "iconControllers");
@@ -195,7 +195,7 @@ GuiMenu::GuiMenu(Window *window, bool animate) : GuiComponent(window), mMenu(win
 	else
 	{
 		addEntry(_("INFORMATION").c_str(), true, [this] { openSystemInformations(); }, "iconSystem");
-		addEntry(_("UNLOCK UI MODE").c_str(), true, [this] { exitKidMode(); }, "iconAdvanced");
+		addEntry(_("UNLOCK USER INTERFACE MODE").c_str(), true, [this] { exitKidMode(); }, "iconAdvanced");
 	}
 
 #ifdef WIN32
@@ -369,7 +369,7 @@ class ExitKidModeMsgBox : public GuiSettings
 	{
 		if (UIModeController::getInstance()->listen(config, input))
 		{
-			mWindow->pushGui(new GuiMsgBox(mWindow, _("THE UI MODE IS NOW UNLOCKED"),
+			mWindow->pushGui(new GuiMsgBox(mWindow, _("THE USER INTERFACE MODE IS NOW UNLOCKED"),
 				_("OK"), [this] 
 				{
 					Window* window = mWindow;
@@ -396,7 +396,7 @@ void GuiMenu::exitKidMode()
 			delete window->peekGui();
 	}
 	else
-		mWindow->pushGui(new ExitKidModeMsgBox(mWindow, _("UNLOCK UI MODE"), _("ENTER THE CODE TO UNLOCK THE CURRENT UI MODE")));
+		mWindow->pushGui(new ExitKidModeMsgBox(mWindow, _("UNLOCK USER INTERFACE MODE"), _("ENTER THE CODE NOW TO UNLOCK")));
 }
 
 void GuiMenu::openSystemInformations()
@@ -408,7 +408,7 @@ void GuiMenu::openDeveloperSettings()
 {
 	Window *window = mWindow;
 
-	auto s = new GuiSettings(mWindow, _("DEVELOPER").c_str());
+	auto s = new GuiSettings(mWindow, _("FRONTEND DEVELOPER OPTIONS").c_str());
 	
 	s->addGroup(_("VIDEO OPTIONS"));
 
@@ -418,7 +418,7 @@ void GuiMenu::openDeveloperSettings()
 	s->addWithLabel(_("VRAM LIMIT"), max_vram);
 	s->addSaveFunc([max_vram] { Settings::getInstance()->setInt("MaxVRAM", (int)round(max_vram->getValue())); });
 	
-	s->addSwitch(_("SHOW FRAMERATE"), "DrawFramerate", true);
+	s->addSwitch(_("SHOW FRAMERATE"), _("Also turns on the emulator's native FPS counter, if available."), "DrawFramerate", true, nullptr);
 	s->addSwitch(_("VSYNC"), "VSync", true, [] { Renderer::setSwapInterval(); });
 
 #ifdef BATOCERA
@@ -482,7 +482,7 @@ void GuiMenu::openDeveloperSettings()
 
 	auto webAccess = std::make_shared<SwitchComponent>(mWindow);
 	webAccess->setState(Settings::getInstance()->getBool("PublicWebAccess"));
-	s->addWithDescription(_("ENABLE PUBLIC WEB ACCESS"), Utils::String::format(_("Allow public web access API using %s").c_str(), std::string("http://" + hostName + ":1234").c_str()), webAccess);
+	s->addWithDescription(_("ENABLE PUBLIC WEB API ACCESS"), Utils::String::format(_("Allow public web access API using %s").c_str(), std::string("http://" + hostName + ":1234").c_str()), webAccess);
 	s->addSaveFunc([webAccess, window, s]
 	{ 
 	  if (Settings::getInstance()->setBool("PublicWebAccess", webAccess->getState())) 
@@ -523,7 +523,7 @@ void GuiMenu::openDeveloperSettings()
 		// support
 		s->addEntry(_("CREATE A SUPPORT FILE"), true, [window] 
 		{
-			window->pushGui(new GuiMsgBox(window, _("CREATE A SUPPORT FILE?"), _("YES"),
+			window->pushGui(new GuiMsgBox(window, _("CREATE A SUPPORT FILE? THIS INCLUDES ALL DATA IN YOUR SYSTEM FOLDER."), _("YES"),
 				[window] 
 				{
 					if (ApiSystem::getInstance()->generateSupportFile())
@@ -646,7 +646,7 @@ void GuiMenu::openDeveloperSettings()
 	// enable filters (ForceDisableFilters)
 	auto enable_filter = std::make_shared<SwitchComponent>(mWindow);
 	enable_filter->setState(!Settings::getInstance()->getBool("ForceDisableFilters"));
-	s->addWithLabel(_("ENABLE FILTERS"), enable_filter);
+	s->addWithDescription(_("ENABLE GAME FILTERING"), _("Whether to show or hide game filtering related settings in the view options."), enable_filter);
 	s->addSaveFunc([this, enable_filter]
 	{
 		Settings::getInstance()->setBool("ForceDisableFilters", !enable_filter->getState());
@@ -661,16 +661,16 @@ void GuiMenu::openDeveloperSettings()
 	// gamelist
 	auto parse_gamelists = std::make_shared<SwitchComponent>(mWindow);
 	parse_gamelists->setState(Settings::getInstance()->getBool("ParseGamelistOnly"));
-	s->addWithLabel(_("PARSE GAMESLISTS ONLY"), parse_gamelists);
+	s->addWithDescription(_("PARSE GAMELISTS ONLY"), _("Debug tool: Don't check if the ROMs actually exist. Can cause problems!"), parse_gamelists);
 	s->addSaveFunc([parse_gamelists] { Settings::getInstance()->setBool("ParseGamelistOnly", parse_gamelists->getState()); });
 
 	// Local Art
 	auto local_art = std::make_shared<SwitchComponent>(mWindow);
 	local_art->setState(Settings::getInstance()->getBool("LocalArt"));
-	s->addWithLabel(_("SEARCH FOR LOCAL ART"), local_art);
+	s->addWithDescription(_("SEARCH FOR LOCAL ART"), _("If no image is specified in the gamelist, try to find media with the same filename to use."), local_art);
 	s->addSaveFunc([local_art] { Settings::getInstance()->setBool("LocalArt", local_art->getState()); });
 
-	s->addGroup(_("UI"));
+	s->addGroup(_("USER INTERFACE"));
 
 	// carousel transition option
 	auto move_carousel = std::make_shared<SwitchComponent>(mWindow);
@@ -949,7 +949,7 @@ void GuiMenu::openSystemSettings()
 	language_choice->add("简体中文", 	     "zh_CN", language == "zh_CN");
 	language_choice->add("正體中文", 	     "zh_TW", language == "zh_TW");
 
-	s->addWithLabel(_("LANGUAGE"), language_choice);
+	s->addWithLabel(_("LANGUAGE (REGION)"), language_choice);
 	s->addSaveFunc([window, language_choice, language, s]
 	{
 		if (language_choice->changed() && SystemConf::getInstance()->set("system.language", language_choice->getSelected()))
@@ -992,9 +992,9 @@ void GuiMenu::openSystemSettings()
 	s->addSwitch(_("SHOW CLOCK IN 12-HOUR FORMAT"), "ClockMode12", true);
 
 	// power saver
-	auto power_saver = std::make_shared< OptionListComponent<std::string> >(mWindow, _("POWER SAVER MODES"), false);
+	auto power_saver = std::make_shared< OptionListComponent<std::string> >(mWindow, _("POWER SAVING MODE"), false);
 	power_saver->addRange({ { _("DISABLED"), "disabled" }, { _("DEFAULT"), "default" }, { _("ENHANCED"), "enhanced" }, { _("INSTANT"), "instant" }, }, Settings::PowerSaverMode());
-	s->addWithLabel(_("POWER SAVER MODES"), power_saver);
+	s->addWithDescription(_("POWER SAVING MODE"), _("Reduces power consumption when idle (useful for handhelds)."), power_saver);
 	s->addSaveFunc([this, power_saver] 
 	{
 		if (Settings::PowerSaverMode() != "instant" && power_saver->getSelected() == "instant")
@@ -1020,12 +1020,12 @@ void GuiMenu::openSystemSettings()
 #endif
 
 	// UI RESTRICTIONS
-	auto UImodeSelection = std::make_shared< OptionListComponent<std::string> >(mWindow, _("UI MODE"), false);
+	auto UImodeSelection = std::make_shared< OptionListComponent<std::string> >(mWindow, _("USER INTERFACE MODE"), false);
 	std::vector<std::string> UImodes = UIModeController::getInstance()->getUIModes();
 	for (auto it = UImodes.cbegin(); it != UImodes.cend(); it++)
 		UImodeSelection->add(_(it->c_str()), *it, Settings::getInstance()->getString("UIMode") == *it);
 
-	s->addWithLabel(_("UI MODE"), UImodeSelection);
+	s->addWithDescription(_("USER INTERFACE MODE"), _("Lock down certain config menus for use with guest users/kids."), UImodeSelection);
 	s->addSaveFunc([UImodeSelection, window]
 	{
 		if (UImodeSelection->changed())
@@ -1035,12 +1035,12 @@ void GuiMenu::openSystemSettings()
 				Settings::getInstance()->setString("UIMode", selectedMode);
 			else
 			{
-				std::string msg = _("You are changing the UI to a restricted mode:\nThis will hide most menu options to prevent changes to the system.\nTo unlock and return to the full UI, enter this code:") + "\n";
+				std::string msg = _("You are changing the user interface to a restricted mode:\nThis will hide most menu options to prevent changes to the system.\nTo unlock and return to the full user interface, enter this code:") + "\n";
 				msg += "\"" + UIModeController::getInstance()->getFormattedPassKeyStr() + "\"\n\n";
 				msg += _("Do you want to proceed?");
 				window->pushGui(new GuiMsgBox(window, msg,
 					_("YES"), [selectedMode] {
-					LOG(LogDebug) << "Setting UI mode to " << selectedMode;
+					LOG(LogDebug) << "Setting user interface mode to " << selectedMode;
 					Settings::getInstance()->setString("UIMode", selectedMode);
 					Settings::getInstance()->saveFile();
 				}, _("NO"), nullptr));
@@ -1200,7 +1200,7 @@ void GuiMenu::openSystemSettings()
 			if (afound == false)
 				optionsAudioProfile->add(selectedAudioProfile, selectedAudioProfile, true);
 
-			s->addWithLabel(_("AUDIO PROFILE"), optionsAudioProfile);
+			s->addWithDescription(_("AUDIO PROFILE"), _("Available options can change depending on current audio output."), optionsAudioProfile);
 
 			s->addSaveFunc([this, optionsAudioProfile, selectedAudioProfile]
 			{
@@ -1462,7 +1462,7 @@ void GuiMenu::openSystemSettings()
 		GuiSettings *securityGui = new GuiSettings(mWindow, _("SECURITY").c_str());
 		auto securityEnabled = std::make_shared<SwitchComponent>(mWindow);
 		securityEnabled->setState(SystemConf::getInstance()->get("system.security.enabled") == "1");
-		securityGui->addWithLabel(_("ENFORCE SECURITY"), securityEnabled);
+		securityGui->addWithDescription(_("ENFORCE SECURITY"), _("Require a password for accessing the network share."), securityEnabled);
 
 		auto rootpassword = std::make_shared<TextComponent>(mWindow, ApiSystem::getInstance()->getRootPassword(), ThemeData::getMenuTheme()->Text.font, ThemeData::getMenuTheme()->Text.color);
 		securityGui->addWithLabel(_("ROOT PASSWORD"), rootpassword);
@@ -1487,7 +1487,7 @@ void GuiMenu::openSystemSettings()
 	
 	// Developer options
 	if (isFullUI)
-		s->addEntry(_("DEVELOPER"), true, [this] { openDeveloperSettings(); });
+		s->addEntry(_("FRONTEND DEVELOPER OPTIONS"), true, [this] { openDeveloperSettings(); });
 
 	auto pthis = this;
 	s->onFinalize([s, pthis, window]
@@ -1876,7 +1876,7 @@ void GuiMenu::openGamesSettings()
 	if (!hasGlobalFeature("ratio"))
 	{
 		auto ratio_choice = createRatioOptionList(mWindow, "global");
-		s->addWithLabel(_("GAME ASPECT RATIO"), ratio_choice);
+		s->addWithDescription(_("GAME ASPECT RATIO"), _("Force the game to render in this aspect ratio."), ratio_choice);
 		s->addSaveFunc([ratio_choice] { SystemConf::getInstance()->set("global.ratio", ratio_choice->getSelected()); });
 	}
 
@@ -1884,7 +1884,7 @@ void GuiMenu::openGamesSettings()
 	if (ApiSystem::getInstance()->isScriptingSupported(ApiSystem::RESOLUTION) && !hasGlobalFeature("videomode"))
 	{
 		auto videoModeOptionList = createVideoResolutionModeOptionList(mWindow, "global");
-		s->addWithLabel(_("VIDEO MODE"), videoModeOptionList);
+		s->addWithDescription(_("VIDEO MODE"), _("Force the emulator to run at this resolution."), videoModeOptionList);
 		s->addSaveFunc([this, videoModeOptionList] { SystemConf::getInstance()->set("global.videomode", videoModeOptionList->getSelected()); });
 	}
 
@@ -1902,7 +1902,7 @@ void GuiMenu::openGamesSettings()
 	{
 		auto rewind_enabled = std::make_shared<OptionListComponent<std::string>>(mWindow, _("REWIND"));
 		rewind_enabled->addRange({ { _("AUTO"), "auto" },{ _("ON") , "1" },{ _("OFF") , "0" } }, SystemConf::getInstance()->get("global.rewind"));
-		s->addWithLabel(_("REWIND"), rewind_enabled);
+		s->addWithDescription(_("REWIND"), _("Store past states to rewind to in realtime, if the core supports it."), rewind_enabled);
 		s->addSaveFunc([rewind_enabled] { SystemConf::getInstance()->set("global.rewind", rewind_enabled->getSelected()); });
 	}
 	
@@ -2106,15 +2106,15 @@ void GuiMenu::openGamesSettings()
 	// AUTO SAVE/LOAD
 	auto autosave_enabled = std::make_shared<SwitchComponent>(mWindow);
 	autosave_enabled->setState(SystemConf::getInstance()->get("global.autosave") == "1");
-	s->addWithLabel(_("AUTO SAVE/LOAD"), autosave_enabled);
+	s->addWithDescription(_("AUTO SAVE/LOAD"), _("Load latest save state on game launch and save state when exiting game."), autosave_enabled);
 	s->addSaveFunc([autosave_enabled] { SystemConf::getInstance()->set("global.autosave", autosave_enabled->getState() ? "1" : ""); });
 
 	// INCREMENTAL SAVESTATES
 	auto incrementalSaveStates = std::make_shared<OptionListComponent<std::string>>(mWindow, _("INCREMENTAL SAVESTATES"));
 	incrementalSaveStates->addRange({ 
-		{ _("YES"), "", "" }, // Don't use 1 -> 1 is YES, auto too
-		{ _("NO") , _("NEW GAME CREATES NEW SLOT"), "0" },
-		{ _("DISABLED"), _("NEW GAME OVERWRITES CURRENT SLOT"), "2" } },
+		{ _("INCREMENT PER SAVE"), _("Never overwrite old savestates, always make new ones."), "" }, // Don't use 1 -> 1 is YES, auto too
+		{ _("INCREMENT SLOT"), _("Increment slot on a new game."), "0" },
+		{ _("DO NOT INCREMENT"), _("Use current slot on a new game."), "2" } },
 		SystemConf::getInstance()->get("global.incrementalsavestates"));
 
 	s->addWithLabel(_("INCREMENTAL SAVESTATES"), incrementalSaveStates);
@@ -2351,6 +2351,22 @@ void GuiMenu::openControllersSettings(int autoSel)
 		});
 	}
 
+	// CONTROLLER ACTIVITY
+	auto activity = std::make_shared<SwitchComponent>(mWindow);
+	activity->setState(Settings::getInstance()->getBool("ShowControllerActivity"));	
+	s->addWithLabel(_("SHOW CONTROLLER ACTIVITY"), activity, autoSel == 1);
+	activity->setOnChangedCallback([this, s, activity]
+	{ 
+		if (Settings::getInstance()->setBool("ShowControllerActivity", activity->getState()))
+		{
+			delete s;
+			openControllersSettings(1);
+		}
+	});
+	
+	if (Settings::getInstance()->getBool("ShowControllerActivity"))
+		s->addSwitch(_("SHOW CONTROLLER BATTERY LEVEL"), "ShowControllerBattery", true);
+
 	ComponentListRow row;
 
 	// Here we go; for each player
@@ -2459,22 +2475,6 @@ void GuiMenu::openControllersSettings(int autoSel)
 		// this is dependant of this configuration, thus update it
 		InputManager::getInstance()->computeLastKnownPlayersDeviceIndexes();
 	});
-
-	// CONTROLLER ACTIVITY
-	auto activity = std::make_shared<SwitchComponent>(mWindow);
-	activity->setState(Settings::getInstance()->getBool("ShowControllerActivity"));	
-	s->addWithLabel(_("SHOW CONTROLLER ACTIVITY"), activity, autoSel == 1);
-	activity->setOnChangedCallback([this, s, activity]
-	{ 
-		if (Settings::getInstance()->setBool("ShowControllerActivity", activity->getState()))
-		{
-			delete s;
-			openControllersSettings(1);
-		}
-	});
-	
-	if (Settings::getInstance()->getBool("ShowControllerActivity"))
-		s->addSwitch(_("SHOW CONTROLLER BATTERY LEVEL"), "ShowControllerBattery", true);
 
 	window->pushGui(s);
 }
@@ -3059,7 +3059,7 @@ void GuiMenu::openUISettings()
 	auto pthis = this;
 	Window* window = mWindow;
 
-	auto s = new GuiSettings(mWindow, _("UI SETTINGS").c_str());
+	auto s = new GuiSettings(mWindow, _("USER INTERFACE SETTINGS").c_str());
 
 	// theme set
 	auto theme = ThemeData::getMenuTheme();
@@ -3171,7 +3171,7 @@ void GuiMenu::openUISettings()
 
 	s->addGroup(_("DISPLAY OPTIONS"));
 	s->addEntry(_("SCREENSAVER SETTINGS"), true, std::bind(&GuiMenu::openScreensaverOptions, this));
-	s->addOptionList(_("LIST TRANSITION STYLE"), { { _("auto"), "auto" },{ _("fade") , "fade" },{ _("slide"), "slide" },{ _("fade & slide"), "fade & slide" },{ _("instant"), "instant" } }, "TransitionStyle", true);
+	s->addOptionList(_("LIST TRANSITION"), { { _("auto"), "auto" },{ _("fade") , "fade" },{ _("slide"), "slide" },{ _("fade & slide"), "fade & slide" },{ _("instant"), "instant" } }, "TransitionStyle", true);
 	s->addOptionList(_("GAME LAUNCH TRANSITION"), { { _("auto"), "auto" },{ _("fade") , "fade" },{ _("slide"), "slide" },{ _("instant"), "instant" } }, "GameTransitionStyle", true);
 	s->addSwitch(_("SHOW CLOCK"), "DrawClock", true);
 	s->addSwitch(_("ON-SCREEN HELP"), "ShowHelpPrompts", true, [s] { s->setVariable("reloadAll", true); });
@@ -3195,7 +3195,7 @@ void GuiMenu::openUISettings()
 			s->setVariable("reloadCollections", true);
 			s->setVariable("reloadAll", true); 
 		});
-	s->addSwitch(_("IGNORE LEADING ARTICLES WHEN SORTING"), "IgnoreLeadingArticles", true, [s] { s->setVariable("reloadAll", true); });
+	s->addSwitch(_("IGNORE LEADING ARTICLES WHEN SORTING"), _("Ignore 'The' and 'A' if at the start."), "IgnoreLeadingArticles", true, [s] { s->setVariable("reloadAll", true); });
 	
 	s->onFinalize([s, pthis, window]
 	{
@@ -3437,7 +3437,7 @@ void GuiMenu::openQuitMenu_static(Window *window, bool quickAccessMenu, bool ani
 		
 		if (ApiSystem::getInstance()->isScriptingSupported(ApiSystem::ScriptId::PDFEXTRACTION) && Utils::FileSystem::exists(Paths::getUserManualPath()))
 		{
-			s->addEntry(_("VIEW USER'S MANUAL"), false, [s, window]
+			s->addEntry(_("VIEW USER MANUAL"), false, [s, window]
 			{
 				GuiImageViewer::showPdf(window, Paths::getUserManualPath());
 				delete s;
@@ -3620,7 +3620,7 @@ void GuiMenu::popSpecificConfigurationGui(Window* mWindow, std::string title, st
 	if (systemData->isFeatureSupported(currentEmulator, currentCore, EmulatorFeatures::ratio))
 	{
 		auto ratio_choice = createRatioOptionList(mWindow, configName);
-		systemConfiguration->addWithLabel(_("GAME ASPECT RATIO"), ratio_choice);
+		systemConfiguration->addWithDescription(_("GAME ASPECT RATIO"), _("Force the game to render in this aspect ratio."), ratio_choice);
 		systemConfiguration->addSaveFunc([configName, ratio_choice] { SystemConf::getInstance()->set(configName + ".ratio", ratio_choice->getSelected()); });
 	}
 
@@ -3628,7 +3628,7 @@ void GuiMenu::popSpecificConfigurationGui(Window* mWindow, std::string title, st
 	if (systemData->isFeatureSupported(currentEmulator, currentCore, EmulatorFeatures::videomode))
 	{
 		auto videoResolutionMode_choice = createVideoResolutionModeOptionList(mWindow, configName);
-		systemConfiguration->addWithLabel(_("VIDEO MODE"), videoResolutionMode_choice);
+		systemConfiguration->addWithDescription(_("VIDEO MODE"), _("Force the emulator to run at this resolution."), videoResolutionMode_choice);
 		systemConfiguration->addSaveFunc([configName, videoResolutionMode_choice] { SystemConf::getInstance()->set(configName + ".videomode", videoResolutionMode_choice->getSelected()); });
 	}
 
@@ -3653,9 +3653,9 @@ void GuiMenu::popSpecificConfigurationGui(Window* mWindow, std::string title, st
 	// AUTO SAVE/LOAD
 	if (systemData->isFeatureSupported(currentEmulator, currentCore, EmulatorFeatures::autosave) && !customFeatures.hasFeature("autosave"))
 	{
-		auto autosave_enabled = std::make_shared<OptionListComponent<std::string>>(mWindow, _("AUTO SAVE/LOAD"));
+		auto autosave_enabled = std::make_shared<OptionListComponent<std::string>>(mWindow, _("AUTO SAVE/LOAD ON GAME LAUNCH"));
 		autosave_enabled->addRange({ { _("AUTO"), "auto" }, { _("ON") , "1" }, { _("OFF"), "0" } }, SystemConf::getInstance()->get(configName + ".autosave"));
-		systemConfiguration->addWithLabel(_("AUTO SAVE/LOAD ON GAME LAUNCH"), autosave_enabled);
+		systemConfiguration->addWithDescription(_("AUTO SAVE/LOAD ON GAME LAUNCH"), _("Load latest save state on game launch and save state when exiting game."), autosave_enabled);
 		systemConfiguration->addSaveFunc([configName, autosave_enabled] { SystemConf::getInstance()->set(configName + ".autosave", autosave_enabled->getSelected()); });
 	}
 	

--- a/es-app/src/guis/GuiNetPlaySettings.cpp
+++ b/es-app/src/guis/GuiNetPlaySettings.cpp
@@ -18,7 +18,7 @@ GuiNetPlaySettings::GuiNetPlaySettings(Window* window) : GuiSettings(window, _("
 	addInputTextRow(_("NICKNAME"), "global.netplay.nickname", false);
 	addInputTextRow(_("PORT"), "global.netplay.port", false);
 	addOptionList(_("USE RELAY SERVER"), { { _("NONE"), "" },{ _("NEW YORK") , "nyc" },{ _("MADRID") , "madrid" },{ _("MONTREAL") , "montreal" },{ _("SAO PAULO") , "saopaulo" } }, "global.netplay.relay", false);
-	addSwitch(_("SHOW UNAVAILABLE GAMES"), "NetPlayShowMissingGames", true);
+	addSwitch(_("SHOW UNAVAILABLE GAMES"), _("Show rooms for games not present on this machine."), "NetPlayShowMissingGames", true, nullptr);
 
 	addGroup(_("GAME INDEXES"));
 

--- a/es-app/src/guis/GuiRetroAchievementsSettings.cpp
+++ b/es-app/src/guis/GuiRetroAchievementsSettings.cpp
@@ -22,11 +22,11 @@ GuiRetroAchievementsSettings::GuiRetroAchievementsSettings(Window* window) : Gui
 	retroachievements_enabled->setState(retroachievementsEnabled);
 	addWithLabel(_("RETROACHIEVEMENTS"), retroachievements_enabled);
 
-	addSwitch(_("HARDCORE MODE"), "global.retroachievements.hardcore", false);
-	addSwitch(_("LEADERBOARDS"), "global.retroachievements.leaderboards", false);
+	addSwitch(_("HARDCORE MODE"), _("Disable loading states (as well as auto-load) for more points."), "global.retroachievements.hardcore", false, nullptr);
+	addSwitch(_("LEADERBOARDS"), _("Compete in high-score and best time leaderboards (requires hardcore)."), "global.retroachievements.leaderboards", false, nullptr);
 	addSwitch(_("VERBOSE MODE"), "global.retroachievements.verbose", false);
-	addSwitch(_("ENCORE MODE"), "global.retroachievements.encore", false);
-	addSwitch(_("AUTOMATIC SCREENSHOT"), "global.retroachievements.screenshot", false);
+	addSwitch(_("ENCORE MODE"), _("Reset achievements to be able to earn them again."), "global.retroachievements.encore", false, nullptr);
+	addSwitch(_("AUTOMATIC SCREENSHOT"), _("Automatically take a screenshot when an achievement is earned."), "global.retroachievements.screenshot", false, nullptr);
 	addSwitch(_("CHALLENGE INDICATORS"), _("Shows icons in the bottom right corner when eligible achievements can be earned."), "global.retroachievements.challenge_indicators", false, nullptr);
 
 	// Unlock sound
@@ -53,7 +53,7 @@ GuiRetroAchievementsSettings::GuiRetroAchievementsSettings(Window* window) : Gui
 	addInputTextRow(_("PASSWORD"), "global.retroachievements.password", true);
 
 	// retroachievements_hardcore_mode
-	addSwitch(_("SHOW RETROACHIEVEMENTS ENTRY IN MAIN MENU"), "RetroachievementsMenuitem", true);
+	addSwitch(_("SHOW RETROACHIEVEMENTS ENTRY IN MAIN MENU"), _("View your RetroAchievement stats right from the main menu!"), "RetroachievementsMenuitem", true, nullptr);
 
 	addGroup(_("GAME INDEXES"));
 	addSwitch(_("INDEX NEW GAMES AT STARTUP"), "CheevosCheckIndexesAtStart", true);

--- a/es-app/src/guis/GuiScraperSettings.cpp
+++ b/es-app/src/guis/GuiScraperSettings.cpp
@@ -116,27 +116,28 @@ GuiScraperSettings::GuiScraperSettings(Window* window) : GuiSettings(window, _("
 		addSaveFunc([logoSource] { Settings::getInstance()->setString("ScrapperLogoSrc", logoSource->getSelected()); });
 	}
 
+	addGroup(_("SCRAPE FOR"));
 
 	if (scrap->isMediaSupported(Scraper::ScraperMediaSource::ShortTitle))
-		addSwitch(_("SCRAPE SHORT NAME"), "ScrapeShortTitle", true);
+		addSwitch(_("SHORT NAME"), "ScrapeShortTitle", true);
 
 	if (scrap->isMediaSupported(Scraper::ScraperMediaSource::Ratings))
-		addSwitch(_("SCRAPE RATINGS"), "ScrapeRatings", true);
+		addSwitch(_("COMMUNITY RATING"), "ScrapeRatings", true);
 
 	if (scrap->isMediaSupported(Scraper::ScraperMediaSource::Video))
-		addSwitch(_("SCRAPE VIDEOS"), "ScrapeVideos", true);
+		addSwitch(_("VIDEO"), "ScrapeVideos", true);
 
 	if (scrap->isMediaSupported(Scraper::ScraperMediaSource::FanArt))
-		addSwitch(_("SCRAPE FANART"), "ScrapeFanart", true);
+		addSwitch(_("FANART"), "ScrapeFanart", true);
 
 	if (scrap->isMediaSupported(Scraper::ScraperMediaSource::Bezel_16_9))
-		addSwitch(_("SCRAPE BEZEL (16:9)"), "ScrapeBezel", true);
+		addSwitch(_("BEZEL (16:9)"), "ScrapeBezel", true);
 
 	if (scrap->isMediaSupported(Scraper::ScraperMediaSource::BoxBack))
-		addSwitch(_("SCRAPE BOX BACKSIDE"), "ScrapeBoxBack", true);
+		addSwitch(_("BOX BACKSIDE"), "ScrapeBoxBack", true);
 
 	if (scrap->isMediaSupported(Scraper::ScraperMediaSource::Map))
-		addSwitch(_("SCRAPE MAP"), "ScrapeMap", true);
+		addSwitch(_("MAP"), "ScrapeMap", true);
 
 	/*
 	if (scrap->isMediaSupported(Scraper::ScraperMediaSource::TitleShot))
@@ -147,10 +148,10 @@ GuiScraperSettings::GuiScraperSettings(Window* window) : GuiSettings(window, _("
 	*/
 
 	if (scrap->isMediaSupported(Scraper::ScraperMediaSource::Manual))
-		addSwitch(_("SCRAPE MANUAL"), "ScrapeManual", true);
+		addSwitch(_("MANUAL"), "ScrapeManual", true);
 
 	if (scrap->isMediaSupported(Scraper::ScraperMediaSource::PadToKey))
-		addSwitch(_("SCRAPE PADTOKEY SETTINGS"), "ScrapePadToKey", true);
+		addSwitch(_("PADTOKEY SETTINGS"), "ScrapePadToKey", true);
 
 	// ScreenScraper Account		
 	if (scraper == "ScreenScraper")


### PR DESCRIPTION
This is a neater PR for https://github.com/batocera-linux/batocera-emulationstation/pull/1158 . For convenience, its description is below:

    Clarity and label improvements

    This makes some more dramatic changes and adds in a lot of description labels into the interface. I am aiming to get some feedback on this before committing it to master.

    The objective of this PR are as follows:
    * To make the menus more friendly for new users who may not have experienced emulation software before.
    * Reduce redundancy in labelling.
    * Explain what the settings do without ambiguity.
    * Reorganise the controller settings to show that there's more than just player order settings.

    Since most strings are new, it would be fine to put this in for the next immediate release. However, some strings (most important, the "UI SETTINGS" string) have been changed and require retranslation to the new sting.

    - All instances of UI to User Interface (where appropriate).
    - More descriptions to confusing options.
    - Incremental savestate option values relabelled and explained.