### PR TITLE
OpenGL shaders : Better support & management

### DIFF
--- a/es-app/src/components/TextListComponent.h
+++ b/es-app/src/components/TextListComponent.h
@@ -80,6 +80,8 @@ public:
 	inline void setSelectedColor(unsigned int color) { mSelectedColor = color; }
 	inline void setColor(unsigned int id, unsigned int color) { mColors[id] = color; }
 	inline void setLineSpacing(float lineSpacing) { mLineSpacing = lineSpacing; }
+	inline void setBonusTextColor(unsigned int color) { mBonusColor = color; mHasBonusColor = true; }
+	inline void setBonusSelectedTextColor(unsigned int color) { mBonusSelectedColor = color; mHasBonusSelectedColor = true; }
 
 	virtual void onShow() override;
 
@@ -114,6 +116,12 @@ private:
 	unsigned int mSelectorColorEnd;
 	bool mSelectorColorGradientHorizontal = true;
 	unsigned int mSelectedColor;
+
+	unsigned int mBonusColor;
+	bool mHasBonusColor = false;
+	unsigned int mBonusSelectedColor;
+	bool mHasBonusSelectedColor = false;
+	
 	std::string mScrollSound;
 	static const unsigned int COLOR_ID_COUNT = 2;
 	unsigned int mColors[COLOR_ID_COUNT];
@@ -231,7 +239,12 @@ void TextListComponent<T>::render(const Transform4x4f& parentTrans)
 		if(!entry.data.textCache)
 			entry.data.textCache = std::unique_ptr<TextCache>(font->buildTextCache(mUppercase ? Utils::String::toUpper(entry.name) : entry.name, 0, 0, 0x000000FF));
 
-		entry.data.textCache->setColor(color);
+		if (mCursor == i && mHasBonusSelectedColor)
+			entry.data.textCache->setColors(color, mBonusSelectedColor);
+		else if (mHasBonusColor)
+			entry.data.textCache->setColors(color, mBonusColor);
+		else
+			entry.data.textCache->setColor(color);
 
 		Vector3f offset(0, y, 0);
 
@@ -470,6 +483,10 @@ void TextListComponent<T>::applyTheme(const std::shared_ptr<ThemeData>& theme, c
 			setColor(0, elem->get<unsigned int>("primaryColor"));
 		if(elem->has("secondaryColor"))
 			setColor(1, elem->get<unsigned int>("secondaryColor"));
+		if (elem->has("extraTextColor"))
+			setBonusTextColor(elem->get<unsigned int>("extraTextColor"));
+		if (elem->has("extraTextSelectedColor"))
+			setBonusSelectedTextColor(elem->get<unsigned int>("extraTextSelectedColor"));
 
 		if (elem->has("glowColor"))
 			mGlowColor = elem->get<unsigned int>("glowColor");

--- a/es-app/src/views/ViewController.cpp
+++ b/es-app/src/views/ViewController.cpp
@@ -846,7 +846,7 @@ bool ViewController::input(InputConfig* config, Input input)
 	if (config->getDeviceId() == DEVICE_KEYBOARD && input.value && input.id == SDLK_F5)
 	{
 		mWindow->render();
-
+		
 		FileSorts::reset();
 		ResourceManager::getInstance()->unloadAll();
 		ResourceManager::getInstance()->reloadAll();
@@ -1084,6 +1084,9 @@ ViewController::ViewMode ViewController::getViewMode()
 
 void ViewController::reloadAll(Window* window, bool reloadTheme)
 {
+	if (reloadTheme)
+		Renderer::resetCache();
+
 	Utils::FileSystem::FileSystemCacheActivator fsc;
 
 	if (mCurrentView != nullptr)

--- a/es-app/src/views/gamelist/GameNameFormatter.cpp
+++ b/es-app/src/views/gamelist/GameNameFormatter.cpp
@@ -17,6 +17,8 @@
 #define SAVESTATE	_U("\uF0C7")
 #define MANUAL		_U("\uF02D")
 
+#define GUN			_U("\uF05B")
+
 #define RATINGSTAR _U("\uF005")
 #define SEPARATOR_BEFORE "["
 #define SEPARATOR_AFTER "] "
@@ -64,6 +66,8 @@ GameNameFormatter::GameNameFormatter(SystemData* system)
 
 	mShowManualIcon = system->getBoolSetting("ShowManualIcon");
 	mShowSaveStates = system->getBoolSetting("ShowSaveStates");
+
+	mShowGunIcon = system->getName() != "lightgun";
 
 	mShowFlags = system->getShowFlags();
 
@@ -162,6 +166,9 @@ std::string GameNameFormatter::getDisplayName(FileData* fd, bool showFolderIcon)
 		lang = getLangFlag(LangInfo::getFlag(fd->getMetadata(MetaDataId::Language), fd->getMetadata(MetaDataId::Region))) + " ";
 
 	std::vector<std::string> after;
+
+	if (mShowGunIcon && fd->getSourceFileData()->isLightGunGame())
+		after.push_back(GUN);
 
 	if (mShowCheevosIcon && fd->hasCheevos())
 		after.push_back(CHEEVOSICON);

--- a/es-app/src/views/gamelist/GameNameFormatter.h
+++ b/es-app/src/views/gamelist/GameNameFormatter.h
@@ -26,5 +26,7 @@ private:
 	bool mShowManualIcon;		
 	bool mShowSaveStates;
 
+	bool mShowGunIcon;
+
 	int mShowFlags;
 };

--- a/es-core/src/LocaleES.cpp
+++ b/es-core/src/LocaleES.cpp
@@ -15,7 +15,7 @@ char* ngettext(char* msgid, char* msgid_plural, unsigned long int n)
 
 	return msgid;
 }
-char* pgettext(char* context, char* msgid); {
+char* pgettext(char* context, char* msgid) {
   return msgid;
 }
 #endif

--- a/es-core/src/ThemeData.cpp
+++ b/es-core/src/ThemeData.cpp
@@ -81,6 +81,8 @@ std::map<std::string, std::map<std::string, ThemeData::ElementPropertyType>> The
 		{ "verticalAlignment", STRING },
 		{ "roundCorners", FLOAT },
 		{ "opacity", FLOAT },
+		{ "saturation", FLOAT },
+		{ "shader", PATH },
 		{ "flipX", BOOLEAN },
 		{ "flipY", BOOLEAN },
 		{ "linearSmooth", BOOLEAN },
@@ -215,6 +217,10 @@ std::map<std::string, std::map<std::string, ThemeData::ElementPropertyType>> The
 		{ "glowColor", COLOR },
 		{ "glowSize", FLOAT },
 		{ "glowOffset", NORMALIZED_PAIR },
+
+		// extraText color is for texts located between [] or ()
+		{ "extraTextColor", COLOR },
+		{ "extraTextSelectedColor", COLOR },
 
 		{ "zIndex", FLOAT } } },
 	{ "container", {
@@ -415,6 +421,8 @@ std::map<std::string, std::map<std::string, ThemeData::ElementPropertyType>> The
 		{ "loops", FLOAT }, // Number of loops to do -1 (default) is infinite 
 		{ "audio", BOOLEAN },
 		{ "linearSmooth", BOOLEAN },
+		{ "saturation", FLOAT },
+		{ "shader", PATH },
 		{ "showSnapshotNoVideo", BOOLEAN },
 		{ "showSnapshotDelay", BOOLEAN } } },
 	{ "carousel", {

--- a/es-core/src/components/ImageComponent.cpp
+++ b/es-core/src/components/ImageComponent.cpp
@@ -29,6 +29,7 @@ ImageComponent::ImageComponent(Window* window, bool forceLoad, bool dynamic) : G
 	mFadeOpacity(0), mFading(false), mRotateByTargetSize(false), mTopLeftCrop(0.0f, 0.0f), mBottomRightCrop(1.0f, 1.0f),
 	mReflection(0.0f, 0.0f), mPadding(Vector4f(0, 0, 0, 0))
 {
+	mSaturation = 1.0f;
 	mScaleOrigin = Vector2f::Zero();
 	mCheckClipping = true;
 
@@ -567,6 +568,9 @@ void ImageComponent::render(const Transform4x4f& parentTrans)
 
 		fadeIn(true);
 
+		mVertices->saturation = mSaturation;
+		mVertices->customShader = mCustomShader.empty() ? nullptr : (char*)mCustomShader.c_str();
+
 		if (mRoundCorners > 0 && mRoundCornerStencil.size() > 0)
 		{
 			Renderer::setStencil(mRoundCornerStencil.data(), mRoundCornerStencil.size());
@@ -764,6 +768,12 @@ void ImageComponent::applyTheme(const std::shared_ptr<ThemeData>& theme, const s
 
 		if (elem->has("opacity"))
 			setOpacity((unsigned char) (elem->get<float>("opacity") * 255.0));		
+
+		if (elem->has("saturation"))
+			mSaturation = Math::clamp(elem->get<float>("saturation"), 0.0f, 1.0f);
+
+		if (elem->has("shader"))
+			mCustomShader = elem->get<std::string>("shader");		
 	}	
 
 	if(properties & ThemeFlags::ROTATION) 
@@ -939,6 +949,8 @@ ThemeData::ThemeElement::Property ImageComponent::getProperty(const std::string 
 		return mPath;
 	else if (name == "padding")
 		return mPadding;
+	else if (name == "saturation")
+		return mSaturation;
 
 	return GuiComponent::getProperty(name);
 }
@@ -976,6 +988,8 @@ void ImageComponent::setProperty(const std::string name, const ThemeData::ThemeE
 		mDynamic = false;
 		setImage(value.s, false);
 	}
+	else if (name == "saturation" && value.type == ThemeData::ThemeElement::Property::PropertyType::Float)
+		setSaturation(value.f);
 	else
 		GuiComponent::setProperty(name, value);
 }
@@ -987,4 +1001,9 @@ void ImageComponent::setRoundCorners(float value)
 		
 	mRoundCorners = value; 
 	updateRoundCorners();
+}
+
+void ImageComponent::setSaturation(float saturation)
+{
+	mSaturation = saturation;
 }

--- a/es-core/src/components/ImageComponent.h
+++ b/es-core/src/components/ImageComponent.h
@@ -129,6 +129,9 @@ public:
 	void setProperty(const std::string name, const ThemeData::ThemeElement::Property& value) override;
 	void setTargetIsMax() { mTargetIsMax = true; }
 
+	void setSaturation(float saturation);
+	void setCustomShader(const std::string& customShader) { mCustomShader = customShader; }
+
 protected:
 	std::shared_ptr<TextureResource> mTexture;
 	std::shared_ptr<TextureResource> mLoadingTexture;
@@ -177,8 +180,11 @@ private:
 	Alignment mHorizontalAlignment;
 	Alignment mVerticalAlignment;
 
-	float			mRoundCorners;
-	
+	float mRoundCorners;
+	float mSaturation;
+
+	std::string mCustomShader;
+
 	std::shared_ptr<IPlaylist> mPlaylist;
 	std::map<std::string, std::shared_ptr<TextureResource>> mPlaylistCache;
 

--- a/es-core/src/components/VideoVlcComponent.h
+++ b/es-core/src/components/VideoVlcComponent.h
@@ -90,6 +90,8 @@ public:
 	bool getLinearSmooth() { return mLinearSmooth; }
 	void setLinearSmooth(bool value = true) { mLinearSmooth = value; }
 
+	void setSaturation(float saturation);
+
 private:
 	// Calculates the correct mSize from our resizing information (set by setResize/setMaxSize).
 	// Used internally whenever the resizing parameters or texture change.
@@ -120,6 +122,7 @@ private:
 
 	std::string					    mSubtitlePath;
 	std::string					    mSubtitleTmpFile;
+	std::string						mCustomShader;
 
 	VideoVlcFlags::VideoVlcEffect	mEffect;
 
@@ -130,6 +133,7 @@ private:
 	int								mLoops;
 
 	bool							mLinearSmooth;
+	float							mSaturation;
 };
 
 #endif // ES_CORE_COMPONENTS_VIDEO_VLC_COMPONENT_H

--- a/es-core/src/renderers/GlExtensions.cpp
+++ b/es-core/src/renderers/GlExtensions.cpp
@@ -28,7 +28,11 @@ namespace glext
 	PFNGLUNIFORMMATRIX4FVPROC glUniformMatrix4fv = nullptr;
 	PFNGLCREATESHADERPROC glCreateShader = nullptr;
 	PFNGLACTIVETEXTUREPROC glActiveTexture_ = nullptr;
-
+	PFNGLUNIFORM1FPROC glUniform1f = nullptr;
+	PFNGLUNIFORM2FPROC glUniform2f = nullptr;
+	PFNGLDELETEPROGRAMPROC glDeleteProgram = nullptr;
+	PFNGLDELETESHADERPROC glDeleteShader = nullptr;
+	
 	void* _glProcAddress(const char *proc)
 	{
 		void* ret = SDL_GL_GetProcAddress(proc);
@@ -87,6 +91,12 @@ namespace glext
 		glDisableVertexAttribArray = (PFNGLDISABLEVERTEXATTRIBARRAYPROC)_glProcAddress("glDisableVertexAttribArray");
 		glUniformMatrix4fv = (PFNGLUNIFORMMATRIX4FVPROC)_glProcAddress("glUniformMatrix4fv");
 		glActiveTexture_ = (PFNGLACTIVETEXTUREPROC)_glProcAddress("glActiveTexture");
+		glUniform1f = (PFNGLUNIFORM1FPROC)_glProcAddress("glUniform1f");
+		glUniform2f = (PFNGLUNIFORM2FPROC)_glProcAddress("glUniform2f");		
+		glDeleteProgram = (PFNGLDELETEPROGRAMPROC)_glProcAddress("glDeleteProgram");
+		glDeleteShader = (PFNGLDELETESHADERPROC)_glProcAddress("glDeleteShader");
+
+		typedef void (APIENTRYP PFNGLDELETESHADERPROC) (GLuint shader);
 
 		return 
 			glCreateShader != nullptr && glCompileShader != nullptr && glCreateProgram != nullptr && glGenBuffers != nullptr && 
@@ -94,7 +104,7 @@ namespace glext
 			glLinkProgram != nullptr && glGetProgramiv != nullptr && glGetProgramInfoLog != nullptr && glUseProgram != nullptr &&
 			glUniform1i != nullptr && glGetUniformLocation != nullptr && glGetAttribLocation != nullptr && glBufferData != nullptr &&
 			glVertexAttribPointer != nullptr && glBufferData != nullptr && glBufferSubData != nullptr && glVertexAttribPointer != nullptr && glEnableVertexAttribArray != nullptr &&
-			glDisableVertexAttribArray != nullptr && glUniformMatrix4fv != nullptr && glActiveTexture_ != nullptr;
+			glDisableVertexAttribArray != nullptr && glUniformMatrix4fv != nullptr && glActiveTexture_ != nullptr && glUniform1f != nullptr && glUniform2f != nullptr && glDeleteShader != nullptr && glDeleteProgram != nullptr;
 	}
 }
 #endif

--- a/es-core/src/renderers/GlExtensions.h
+++ b/es-core/src/renderers/GlExtensions.h
@@ -35,6 +35,10 @@ namespace glext
 	extern PFNGLUNIFORMMATRIX4FVPROC glUniformMatrix4fv;
 	extern PFNGLCREATESHADERPROC glCreateShader;
 	extern PFNGLACTIVETEXTUREPROC glActiveTexture_;
+	extern PFNGLUNIFORM1FPROC glUniform1f;
+	extern PFNGLUNIFORM2FPROC glUniform2f;
+	extern PFNGLDELETEPROGRAMPROC glDeleteProgram;
+	extern PFNGLDELETESHADERPROC glDeleteShader;
 };
 
 using namespace glext;

--- a/es-core/src/renderers/Renderer.cpp
+++ b/es-core/src/renderers/Renderer.cpp
@@ -640,6 +640,11 @@ namespace Renderer
 		Instance()->createContext();
 	}
 
+	void resetCache()
+	{
+		Instance()->resetCache();
+	}
+	
 	void destroyContext()
 	{
 		Instance()->destroyContext();

--- a/es-core/src/renderers/Renderer.h
+++ b/es-core/src/renderers/Renderer.h
@@ -54,12 +54,28 @@ namespace Renderer
 
 	struct Vertex
 	{
-		Vertex()                                                                                                      { }
-		Vertex(const Vector2f& _pos, const Vector2f& _tex, const unsigned int _col) : pos(_pos), tex(_tex), col(_col) { }
+		Vertex() 
+			: saturation(1.0f), customShader(nullptr)
+		{ 
+
+		}
+
+		Vertex(const Vector2f& _pos, const Vector2f& _tex, const unsigned int _col) 
+			: pos(_pos)
+			, tex(_tex)
+			, col(_col) 
+			, saturation(1.0f)
+			, customShader(nullptr)
+		{ 
+
+		}
 
 		Vector2f     pos;
 		Vector2f     tex;
 		unsigned int col;
+
+		float saturation;
+		char* customShader;
 
 	}; // Vertex
 
@@ -75,6 +91,8 @@ namespace Renderer
 
 		virtual void         createContext() = 0;
 		virtual void         destroyContext() = 0;
+
+		virtual void         resetCache() = 0;
 
 		virtual unsigned int createTexture(const Texture::Type _type, const bool _linear, const bool _repeat, const unsigned int _width, const unsigned int _height, void* _data) = 0;
 		virtual void         destroyTexture(const unsigned int _texture) = 0;
@@ -126,6 +144,7 @@ namespace Renderer
 	void         setupWindow       ();
 	void         createContext     ();
 	void         destroyContext    ();
+	void         resetCache        ();
 	unsigned int createTexture     (const Texture::Type _type, const bool _linear, const bool _repeat, const unsigned int _width, const unsigned int _height, void* _data);
 	void         destroyTexture    (const unsigned int _texture);
 	void         updateTexture     (const unsigned int _texture, const Texture::Type _type, const unsigned int _x, const unsigned _y, const unsigned int _width, const unsigned int _height, void* _data);

--- a/es-core/src/renderers/Renderer_GL21.cpp
+++ b/es-core/src/renderers/Renderer_GL21.cpp
@@ -110,6 +110,11 @@ namespace Renderer
 
 	} // createContext
 
+	void OpenGL21Renderer::resetCache()
+	{
+		
+	}
+
 	void OpenGL21Renderer::destroyContext()
 	{
 		SDL_GL_DeleteContext(sdlContext);

--- a/es-core/src/renderers/Renderer_GL21.h
+++ b/es-core/src/renderers/Renderer_GL21.h
@@ -23,6 +23,8 @@ namespace Renderer
 		void         createContext() override;
 		void         destroyContext() override;
 
+		void		 resetCache() override;
+
 		unsigned int createTexture(const Texture::Type _type, const bool _linear, const bool _repeat, const unsigned int _width, const unsigned int _height, void* _data) override;
 		void         destroyTexture(const unsigned int _texture) override;
 		void         updateTexture(const unsigned int _texture, const Texture::Type _type, const unsigned int _x, const unsigned _y, const unsigned int _width, const unsigned int _height, void* _data) override;

--- a/es-core/src/renderers/Renderer_GLES10.cpp
+++ b/es-core/src/renderers/Renderer_GLES10.cpp
@@ -110,6 +110,11 @@ namespace Renderer
 
 	} // createContext
 
+	void GLES10Renderer::resetCache()
+	{
+
+	}
+
 	void GLES10Renderer::destroyContext()
 	{
 		SDL_GL_DeleteContext(sdlContext);

--- a/es-core/src/renderers/Renderer_GLES10.h
+++ b/es-core/src/renderers/Renderer_GLES10.h
@@ -23,6 +23,8 @@ namespace Renderer
 		void         createContext() override;
 		void         destroyContext() override;
 
+		void		 resetCache() override;
+
 		unsigned int createTexture(const Texture::Type _type, const bool _linear, const bool _repeat, const unsigned int _width, const unsigned int _height, void* _data) override;
 		void         destroyTexture(const unsigned int _texture) override;
 		void         updateTexture(const unsigned int _texture, const Texture::Type _type, const unsigned int _x, const unsigned _y, const unsigned int _width, const unsigned int _height, void* _data) override;

--- a/es-core/src/renderers/Renderer_GLES20.h
+++ b/es-core/src/renderers/Renderer_GLES20.h
@@ -22,6 +22,8 @@ namespace Renderer
 		void         createContext() override;
 		void         destroyContext() override;
 
+		void		 resetCache() override;
+
 		unsigned int createTexture(const Texture::Type _type, const bool _linear, const bool _repeat, const unsigned int _width, const unsigned int _height, void* _data) override;
 		void         destroyTexture(const unsigned int _texture) override;
 		void         updateTexture(const unsigned int _texture, const Texture::Type _type, const unsigned int _x, const unsigned _y, const unsigned int _width, const unsigned int _height, void* _data) override;

--- a/es-core/src/renderers/Shader.cpp
+++ b/es-core/src/renderers/Shader.cpp
@@ -1,12 +1,34 @@
 #include "Shader.h"
 #include "Log.h"
+#include "renderers/Renderer.h"
+#include "resources/ResourceManager.h"
 
 namespace Renderer
 {
+	std::string SHADER_VERSION_STRING;
+
+	Shader Shader::createShader(GLenum type, const std::string& source)
+	{
+		const GLuint shaderId = glCreateShader(type);
+
+		Shader ret;
+		ret.compile(shaderId, source.c_str());
+		return ret;
+	}
+
+	void Shader::deleteShader()
+	{
+		if (id >= 0 && compileStatus)
+		{
+			glDeleteShader(id);
+			compileStatus = false;
+			id = -1;
+		}
+	}
+
 	bool Shader::compile(GLuint id, const char* source)
 	{
 		// Try to compile GLSL source code
-		compileStatus = false;
 		GL_CHECK_ERROR(glShaderSource(id, 1, &source, nullptr));
 		GL_CHECK_ERROR(glCompileShader(id));
 
@@ -50,10 +72,61 @@ namespace Renderer
 		return false;
 	}
 
-	bool ShaderProgram::linkShaderProgram(Shader &vertexShader, Shader &fragmentShader)
+	ShaderProgram::ShaderProgram() :
+		mPositionAttribute(-1),
+		mColorAttribute(-1),
+		mTexCoordAttribute(-1),
+		mvpUniform(-1),
+		mSaturation(-1),
+		linkStatus(false),
+		mId(-1),
+		mOutputSize(-1),
+		mTextureSize(-1)	
 	{
-		// shader program (texture)
+	}
+
+	void ShaderProgram::deleteProgram()
+	{
+		if (mId >= 0)
+		{
+			for (auto shader : mAttachedShaders)
+				shader.deleteShader();
+
+			mAttachedShaders.clear();
+
+			GL_CHECK_ERROR(glDeleteProgram(mId));
+			mId = -1;
+		}
+	}
+
+	bool ShaderProgram::loadFromFile(const std::string& path)
+	{
+		if (!ResourceManager::getInstance()->fileExists(path))
+			return false;
+		
+		// This will load the entire GLSL source code into the string variable.
+		const ResourceData& shaderData = ResourceManager::getInstance()->getFileData(path);
+
+		std::string shaderCode;
+		shaderCode.assign(reinterpret_cast<const char*>(shaderData.ptr.get()), shaderData.length);
+
+		std::string versionString = SHADER_VERSION_STRING;
+
+		Shader vertex = Shader::createShader(GL_VERTEX_SHADER, versionString + "#define VERTEX\n" + shaderCode);
+		if (vertex.id < 0)
+			return false;
+
+		Shader fragment = Shader::createShader(GL_FRAGMENT_SHADER, versionString + "#define FRAGMENT\n" + shaderCode);
+		if (fragment.id < 0)
+			return false;
+
+		return createShaderProgram(vertex, fragment);
+	}
+
+	bool ShaderProgram::createShaderProgram(Shader &vertexShader, Shader &fragmentShader)
+	{
 		GLuint programId = glCreateProgram();
+
 		GL_CHECK_ERROR(glAttachShader(programId, vertexShader.id));
 		GL_CHECK_ERROR(glAttachShader(programId, fragmentShader.id));
 
@@ -87,15 +160,119 @@ namespace Renderer
 			}
 		}
 
+		mAttachedShaders.push_back(vertexShader);
+		mAttachedShaders.push_back(fragmentShader);
+
 		// Compile OK ? Affect program id
 		this->linkStatus = isCompiled;
 		if (this->linkStatus == GL_TRUE)
 		{
-			this->id = programId;
+			this->mId = programId;
+			findAttribsAndUniforms();
 			return true;
 		}
 
 		return false;
 	}
 
+	void ShaderProgram::findAttribsAndUniforms()
+	{
+		// Matrix
+		mvpUniform = glGetUniformLocation(mId, "MVPMatrix");
+
+		// Attribs
+		mPositionAttribute = glGetAttribLocation(mId, "VertexCoord");
+		if (mPositionAttribute == -1)
+			mPositionAttribute = glGetAttribLocation(mId, "positionVertex");
+
+		mTexCoordAttribute = glGetAttribLocation(mId, "TexCoord");
+		if (mTexCoordAttribute == -1)
+			mTexCoordAttribute = glGetAttribLocation(mId, "texCoordVertex");
+		
+		mColorAttribute = glGetAttribLocation(mId, "COLOR");
+		if (mColorAttribute == -1)
+			mColorAttribute = glGetAttribLocation(mId, "colorVertex");
+		
+		// Uniforms
+		mTextureSize = glGetUniformLocation(mId, "TextureSize");
+		if (mTextureSize == -1)
+			mTextureSize = glGetUniformLocation(mId, "textureSize");
+		
+		mOutputSize = glGetUniformLocation(mId, "OutputSize");
+		if (mOutputSize == -1)
+			mOutputSize = glGetUniformLocation(mId, "outputSize");
+
+		mSaturation = glGetUniformLocation(mId, "saturation");
+
+		GLint texUniform = glGetUniformLocation(mId, "u_tex");		
+		if (texUniform == -1)
+			texUniform = glGetUniformLocation(mId, "textureSampler");
+		
+		if (texUniform != -1)
+		{
+			GL_CHECK_ERROR(glUseProgram(mId));
+			GL_CHECK_ERROR(glUniform1i(texUniform, 0));
+		}
+	}
+
+	void ShaderProgram::setSaturation(GLfloat saturation)
+	{
+		if (mSaturation != -1)
+			GL_CHECK_ERROR(glUniform1f(mSaturation, saturation));
+	}
+
+	void ShaderProgram::setTextureSize(const Vector2f& size)
+	{
+		if (mTextureSize != -1)
+			GL_CHECK_ERROR(glUniform2f(mTextureSize, size.x(), size.y()));
+	}
+	
+	void ShaderProgram::setOutputSize(const Vector2f& size)
+	{
+		if (mOutputSize != -1)
+			GL_CHECK_ERROR(glUniform2f(mOutputSize, size.x(), size.y()));
+	}
+
+	void ShaderProgram::setMatrix(Transform4x4f& mvpMatrix)
+	{
+		if (mvpUniform != -1 && mvpUniform != GL_INVALID_VALUE && mvpUniform != GL_INVALID_OPERATION)
+			GL_CHECK_ERROR(glUniformMatrix4fv(mvpUniform, 1, GL_FALSE, (float*)&mvpMatrix));
+	}
+
+	void ShaderProgram::select()
+	{
+		GL_CHECK_ERROR(glUseProgram(mId));
+
+		if (mPositionAttribute != -1)
+		{
+			GL_CHECK_ERROR(glVertexAttribPointer(mPositionAttribute, 2, GL_FLOAT, GL_FALSE, sizeof(Vertex), (const void*)offsetof(Vertex, pos)));
+			GL_CHECK_ERROR(glEnableVertexAttribArray(mPositionAttribute));
+		}
+
+		if (mColorAttribute != -1)
+		{
+			GL_CHECK_ERROR(glVertexAttribPointer(mColorAttribute, 4, GL_UNSIGNED_BYTE, GL_TRUE, sizeof(Vertex), (const void*)offsetof(Vertex, col)));
+			GL_CHECK_ERROR(glEnableVertexAttribArray(mColorAttribute));
+		}
+
+		if (mTexCoordAttribute != -1)
+		{
+			GL_CHECK_ERROR(glVertexAttribPointer(mTexCoordAttribute, 2, GL_FLOAT, GL_FALSE, sizeof(Vertex), (const void*)offsetof(Vertex, tex)));
+			GL_CHECK_ERROR(glEnableVertexAttribArray(mTexCoordAttribute));
+		}
+	}
+
+	void ShaderProgram::unSelect()
+	{
+		GL_CHECK_ERROR(glUseProgram(0));
+
+		if (mPositionAttribute != -1)
+			GL_CHECK_ERROR(glDisableVertexAttribArray(mPositionAttribute));
+
+		if (mColorAttribute != -1)
+			GL_CHECK_ERROR(glDisableVertexAttribArray(mColorAttribute));
+
+		if (mTexCoordAttribute != -1);
+			GL_CHECK_ERROR(glDisableVertexAttribArray(mTexCoordAttribute));
+	}
 }

--- a/es-core/src/renderers/Shader.h
+++ b/es-core/src/renderers/Shader.h
@@ -3,15 +3,29 @@
 #define ES_CORE_RENDERER_SHADER_H
 
 #include "GlExtensions.h"
+#include "math/Transform4x4f.h"
+
+#include <string>
+#include <vector>
 
 namespace Renderer
 {
 	class Shader
 	{
 	public:
+		Shader()
+		{
+			id = -1;
+			compileStatus = false;
+		}
+
+		static Shader createShader(GLenum type, const std::string& source);
+		void deleteShader();
+
 		GLuint id;
 		bool compileStatus;
 
+	private:
 		// Compile a shader
 		// id should be a valid shader id created by glCreateShader with GL_VERTEX_SHADER or GL_FRAGMENT_SHADER type
 		bool compile(GLuint id, const char* source);
@@ -20,15 +34,41 @@ namespace Renderer
 	class ShaderProgram
 	{
 	public:
-		GLuint id;
-		bool linkStatus;
-		GLint posAttrib;
-		GLint colAttrib;
-		GLint texAttrib;
-		GLint mvpUniform;
+		ShaderProgram();
+
+		bool loadFromFile(const std::string& path);
 
 		// Links vertex and fragment shaders together to make a GLSL program
-		bool linkShaderProgram(Shader &vertexShader, Shader &fragmentShader);
+		bool createShaderProgram(Shader &vertexShader, Shader &fragmentShader);
+
+		void select();
+		void unSelect();
+
+		void setMatrix(Transform4x4f& mvpMatrix);
+		void setSaturation(GLfloat saturation);
+		void setTextureSize(const Vector2f& size);
+		void setOutputSize(const Vector2f& size);
+
+		bool supportsTextureSize() { return mTextureSize != -1; }
+
+		void deleteProgram();
+
+	private:
+		GLuint mId;
+		bool linkStatus;
+		GLint mPositionAttribute;
+		GLint mColorAttribute;
+		GLint mTexCoordAttribute;
+		GLint mvpUniform;
+
+		GLint mSaturation;		
+		GLint mTextureSize;
+		GLint mOutputSize;
+
+		std::vector<Shader> mAttachedShaders;
+
+	private:
+		void findAttribsAndUniforms();
 	};
 
 } // Renderer::

--- a/es-core/src/resources/Font.h
+++ b/es-core/src/resources/Font.h
@@ -193,6 +193,8 @@ public:
 	} metrics;
 
 	void setColor(unsigned int color);
+	void setColors(unsigned int color, unsigned int extraColor);
+
 	void setRenderingGlow(bool glow) { renderingGlow = glow; }
 
 	friend Font;

--- a/resources/shaders/negative.glsl
+++ b/resources/shaders/negative.glsl
@@ -1,0 +1,53 @@
+#if defined(VERTEX)
+
+#if __VERSION__ >= 130
+#define COMPAT_VARYING out
+#define COMPAT_ATTRIBUTE in
+#define COMPAT_TEXTURE texture
+#else
+#define COMPAT_VARYING varying 
+#define COMPAT_ATTRIBUTE attribute 
+#define COMPAT_TEXTURE texture2D
+#endif
+
+#ifdef GL_ES
+#define COMPAT_PRECISION mediump
+#else
+#define COMPAT_PRECISION
+#endif
+
+uniform   mat4 MVPMatrix;
+COMPAT_ATTRIBUTE vec2 VertexCoord;
+COMPAT_ATTRIBUTE vec2 TexCoord;
+COMPAT_ATTRIBUTE vec4 COLOR;
+COMPAT_VARYING   vec2 v_tex;
+COMPAT_VARYING   vec4 v_col;
+void main(void)                                    
+{                                                  
+	gl_Position = MVPMatrix * vec4(VertexCoord.xy, 0.0, 1.0);
+	v_tex       = TexCoord;                           
+	v_col       = COLOR;                           
+}
+
+#elif defined(FRAGMENT)
+			
+varying   vec4      v_col;
+varying   vec2      v_tex;
+uniform   sampler2D u_tex;
+uniform   float saturation;
+
+void main(void)                                    
+{                                                  
+	vec4 clr = texture2D(u_tex, v_tex) * v_col;
+	
+	clr = vec4(1.0 - clr.r, 1.0 - clr.g, 1.0 - clr.b, clr.a);
+	
+	if (saturation != 1.0) {
+		vec3 gray = vec3(dot(clr.rgb, vec3(0.34, 0.55, 0.11)));
+		vec3 blend = mix(gray, clr.rgb, saturation);
+		clr = vec4(blend, clr.a);
+	}
+
+	gl_FragColor = clr;
+}
+#endif

--- a/resources/shaders/scanlines.glsl
+++ b/resources/shaders/scanlines.glsl
@@ -1,0 +1,55 @@
+#if defined(VERTEX)
+
+#if __VERSION__ >= 130
+#define COMPAT_VARYING out
+#define COMPAT_ATTRIBUTE in
+#define COMPAT_TEXTURE texture
+#else
+#define COMPAT_VARYING varying 
+#define COMPAT_ATTRIBUTE attribute 
+#define COMPAT_TEXTURE texture2D
+#endif
+
+#ifdef GL_ES
+#define COMPAT_PRECISION mediump
+#else
+#define COMPAT_PRECISION
+#endif
+
+uniform   mat4 MVPMatrix;
+COMPAT_ATTRIBUTE vec2 VertexCoord;
+COMPAT_ATTRIBUTE vec2 TexCoord;
+COMPAT_ATTRIBUTE vec4 COLOR;
+COMPAT_VARYING   vec2 v_tex;
+COMPAT_VARYING   vec4 v_col;
+void main(void)                                    
+{                                                  
+	gl_Position = MVPMatrix * vec4(VertexCoord.xy, 0.0, 1.0);
+	v_tex       = TexCoord;                           
+	v_col       = COLOR;                           
+}
+
+#elif defined(FRAGMENT)
+			
+varying   vec4      v_col;
+varying   vec2      v_tex;
+uniform   sampler2D u_tex;
+uniform   float saturation;
+
+void main(void)                                    
+{                                                  
+	vec4 clr = texture2D(u_tex, v_tex) * v_col;
+	
+	if (mod(gl_FragCoord.y, 2.0) < 1.0) {
+		clr = vec4(clr.rgb / 2.0, clr.a);
+	}
+	
+	if (saturation != 1.0) {
+		vec3 gray = vec3(dot(clr.rgb, vec3(0.34, 0.55, 0.11)));
+		vec3 blend = mix(gray, clr.rgb, saturation);
+		clr = vec4(blend, clr.a);
+	}
+
+	gl_FragColor = clr;
+}
+#endif


### PR DESCRIPTION
+ Add Theme support for image.saturation & video.saturation ( 0.0 -> grayscale to 1.0 -> normal )
+ Add Theme support for image.shader & video.shader : Allow use of external shaders in Themes.
+ Add custom scanlines shader in resources/shaders ( could be used to display a video or image with scanlines - see sample image )
+ Add Theme support for textlist.extraTextColor & textlist.extraTextSelectedColor ( extraText color is for texts located between [] or () which can now be displayed with a different color )
+ Add Gun icon on games supporting lightgun

![image](https://user-images.githubusercontent.com/51082152/171299328-f5bcac7d-7e26-41af-b3e6-830c8ba39e0e.png)
