### PR TITLE
New screensaver mode for arcade cabinets (to be reviewed)

### DIFF
--- a/es-app/src/SystemScreenSaver.cpp
+++ b/es-app/src/SystemScreenSaver.cpp
@@ -182,22 +182,15 @@ void SystemScreenSaver::startScreenSaver()
 		mVideoChangeTime = Settings::getInstance()->getInt("ScreenSaverSwapBrowsingTimeout");
 		isBrowsingScreensaver = true; 
 		
-		// Auto browsing randomly in list of games
+		// System change randomly -> to be improved : move step by step from current system to target system
+		setCursor(SystemData::getRandomSystem());
+		
+		// Game change randomly
 		auto list = getFileDataEntries();
-
 		unsigned int total = (int)list.size();
 		if (total == 0)
 		return;
-	
-		// Game List change 10% backward, 70% no change, 20% forward) : to be improved
-		int ChangeGameList = Randomizer::random(100);
-		if (ChangeGameList >= 80)
-			ViewController::goToNextGameList();
-		if (ChangeGameList <= 10)
-			ViewController::goToPrevGameList();
-		
-		// Game change
-		int target = Randomizer::random(total);
+		int gameTarget = Randomizer::random(total);
 		int gamePos = getCursorIndex();
 		if (target > gamePos && target < total) {
 			// Moving forward step by step to target game

--- a/es-app/src/SystemScreenSaver.cpp
+++ b/es-app/src/SystemScreenSaver.cpp
@@ -189,11 +189,11 @@ void SystemScreenSaver::startScreenSaver()
 		if (total == 0)
 		return;
 	
-		// Game List change (20% backward, 60% no change, 20% forward)  
+		// Game List change 10% backward, 70% no change, 20% forward) : to be improved
 		int ChangeGameList = Randomizer::random(100);
 		if (ChangeGameList >= 80)
 			ViewController::goToNextGameList();
-		if (ChangeGameList <= 20)
+		if (ChangeGameList <= 10)
 			ViewController::goToPrevGameList();
 		
 		// Game change

--- a/es-app/src/SystemScreenSaver.cpp
+++ b/es-app/src/SystemScreenSaver.cpp
@@ -190,7 +190,7 @@ void SystemScreenSaver::startScreenSaver()
 		unsigned int total = (int)list.size();
 		if (total == 0)
 		return;
-		int gameTarget = Randomizer::random(total);
+		int target = Randomizer::random(total);
 		int gamePos = getCursorIndex();
 		if (target > gamePos && target < total) {
 			// Moving forward step by step to target game

--- a/es-app/src/SystemScreenSaver.cpp
+++ b/es-app/src/SystemScreenSaver.cpp
@@ -180,8 +180,30 @@ void SystemScreenSaver::startScreenSaver()
 	{
 		mVideoChangeTime = Settings::getInstance()->getInt("ScreenSaverSwapBrowsingTimeout");
 
-		// Auto browsing randomly in lists of games
+		// Auto browsing randomly in list of games
+		auto list = getFileDataEntries();
 
+		unsigned int total = (int)list.size();
+		if (total == 0)
+		return;
+
+		int target = Randomizer::random(total);
+		int gamePos = getCursorIndex();
+		
+		if (target > gamePos && target < total) {
+			while (gamePos <= target) {
+				resetLastCursor();
+				gamePos += 1;
+				setCursor(list.at(gamePos));
+				
+			}
+		}
+		else if (gamePos > target && target > 0) {
+			while (gamePos >= target) {
+				resetLastCursor();
+				gamePos -= 1;
+				setCursor(list.at(gamePos));
+			}
 	}
 	
 	// No videos. Just use a standard screensaver

--- a/es-app/src/SystemScreenSaver.cpp
+++ b/es-app/src/SystemScreenSaver.cpp
@@ -180,7 +180,7 @@ void SystemScreenSaver::startScreenSaver()
 	{
 		mVideoChangeTime = Settings::getInstance()->getInt("ScreenSaverSwapBrowsingTimeout");
 
-		// Auto browsing randomly in games lists
+		// Auto browsing randomly in lists of games
 
 	}
 	

--- a/es-app/src/SystemScreenSaver.cpp
+++ b/es-app/src/SystemScreenSaver.cpp
@@ -176,7 +176,14 @@ void SystemScreenSaver::startScreenSaver()
 			return;
 		}	
 	}
+	else if (screensaver_behavior == "autobrowsing")
+	{
+		mVideoChangeTime = Settings::getInstance()->getInt("ScreenSaverSwapBrowsingTimeout");
 
+		// Auto browsing randomly in games lists
+
+	}
+	
 	// No videos. Just use a standard screensaver
 	mState = STATE_SCREENSAVER_ACTIVE;
 	mCurrentGame = NULL;

--- a/es-app/src/SystemScreenSaver.h
+++ b/es-app/src/SystemScreenSaver.h
@@ -112,7 +112,7 @@ private:
 
 	std::shared_ptr<ImageScreenSaver>		mFadingImageScreensaver;
 	std::shared_ptr<ImageScreenSaver>		mImageScreensaver;
-
+	bool			isBrowsingScreensaver;
 	Window*			mWindow;
 	STATE			mState;
 	float			mOpacity;

--- a/es-app/src/guis/GuiGeneralScreensaverOptions.cpp
+++ b/es-app/src/guis/GuiGeneralScreensaverOptions.cpp
@@ -15,6 +15,7 @@
 #define fake_gettext_black			_("black")
 #define fake_gettext_randomvideo	_("random video")
 #define fake_gettext_slideshow		_("slideshow")
+#define fake_gettext_autobrowsing	_("autobrowsing")
 
 #define fake_gettext_always			_("always")
 #define fake_gettext_start_end		_("start & end")
@@ -42,7 +43,7 @@ GuiGeneralScreensaverOptions::GuiGeneralScreensaverOptions(Window* window, int s
 	
 	// Screensaver behavior
 	auto ctlBehavior = std::make_shared< OptionListComponent<std::string> >(mWindow, _("SCREENSAVER TYPE"), false);
-	ctlBehavior->addRange({ "dim", "black", "random video", "slideshow" }, ssBehavior);
+	ctlBehavior->addRange({ "dim", "black", "random video", "slideshow", "autobrowsing" }, ssBehavior);
 	addWithLabel(_("SCREENSAVER TYPE"), ctlBehavior, selectItem == 1);
 	ctlBehavior->setSelectedChangedCallback([this](const std::string& name)
 	{
@@ -69,6 +70,8 @@ GuiGeneralScreensaverOptions::GuiGeneralScreensaverOptions(Window* window, int s
 		addVideoScreensaverOptions(selectItem);
 	else if (ssBehavior == "slideshow")
 		addSlideShowScreensaverOptions(selectItem);
+	else if (ssBehavior == "autobrowsing")
+		addAutoBrowsingScreensaverOptions(selectItem);
 }
 
 void GuiGeneralScreensaverOptions::addVideoScreensaverOptions(int selectItem)
@@ -276,6 +279,23 @@ void GuiGeneralScreensaverOptions::addSlideShowScreensaverOptions(int selectItem
 		auto sss_image_filter = addEditableTextComponent(_("CUSTOM IMAGE FILE EXTENSIONS"), Settings::getInstance()->getString("SlideshowScreenSaverImageFilter"));
 		addSaveFunc([sss_image_filter] { Settings::getInstance()->setString("SlideshowScreenSaverImageFilter", sss_image_filter->getValue()); });
 	}
+}
+
+void GuiGeneralScreensaverOptions::addAutoBrowsingScreensaverOptions(int selectItem)
+{
+	mMenu.addGroup(_("AUTO BROWSING SCREENSAVER SETTINGS"));
+
+	auto theme = ThemeData::getMenuTheme();
+
+	// timeout to swap browsing
+	auto swap_browsing = std::make_shared<SliderComponent>(mWindow, 10.f, 1000.f, 1.f, "s");
+	swap_browsing->setValue((float)(Settings::getInstance()->getInt("ScreenSaverSwapBrowsingTimeout") / (1000)));
+	addWithLabel(_("BROWSING DURATION (SECS)"), swap_browsing);
+	addSaveFunc([swap_browsing] {
+		int playNextTimeout = (int)Math::round(swap_browsing->getValue()) * (1000);
+		Settings::getInstance()->setInt("ScreenSaverSwapBrowsingTimeout", playNextTimeout);
+		PowerSaver::updateTimeouts();
+	});
 }
 
 std::shared_ptr<TextComponent> GuiGeneralScreensaverOptions::addEditableTextComponent(const std::string label, std::string value)

--- a/es-app/src/guis/GuiGeneralScreensaverOptions.h
+++ b/es-app/src/guis/GuiGeneralScreensaverOptions.h
@@ -14,6 +14,7 @@ public:
 private:
 	void addVideoScreensaverOptions(int selectItem);
 	void addSlideShowScreensaverOptions(int selectItem);	
+	void addAutoBrowsingScreensaverOptions(int selectItem);
 
 	std::shared_ptr<TextComponent> addEditableTextComponent(const std::string label, std::string value);
 	std::shared_ptr<TextComponent> addBrowsablePath(const std::string label, std::string value);

--- a/es-core/src/PowerSaver.cpp
+++ b/es-core/src/PowerSaver.cpp
@@ -56,6 +56,8 @@ void PowerSaver::loadWakeupTime()
 		mWakeupTimeout = Settings::getInstance()->getInt("ScreenSaverSwapVideoTimeout") - getMode();
 	else if (behaviour == "slideshow")
 		mWakeupTimeout = Settings::getInstance()->getInt("ScreenSaverSwapImageTimeout") - getMode();
+	else if (behaviour == "autobrowsing")
+		mWakeupTimeout = Settings::getInstance()->getInt("ScreenSaverSwapBrowsingTimeout") - getMode();
 	else // Dim and Blank
 		mWakeupTimeout = -1;
 }

--- a/es-core/src/Settings.cpp
+++ b/es-core/src/Settings.cpp
@@ -240,6 +240,7 @@ void Settings::setDefaults()
 	#endif
 
 	mIntMap["ScreenSaverSwapVideoTimeout"] = 30000;
+	mIntMap["ScreenSaverSwapBrowsingTimeout"] = 30000;
 
 	mBoolMap["VideoAudio"] = true;
 	mBoolMap["ScreenSaverVideoMute"] = false;


### PR DESCRIPTION
Creation of a new screensaver mode dedicated to arcade cabinets.

The idea is to cycle through the games in the EmulationStation interface randomly like in HyperSpin by moving and spinning quickly and randomly through the list or the wheel of games and systems and stopping on a game to view marquee, image, video, information available then switch to another game.

I am not a computer scientist. I did my best to write the code but I need help to write the code cleanly and make it work properly. @fabricecaruso: I hope you can provide your help and expertise to set up this new screensaver. Thanks a lot