### PR TITLE
Misc improvements & fixes

### DIFF
--- a/es-app/src/SystemData.cpp
+++ b/es-app/src/SystemData.cpp
@@ -719,6 +719,7 @@ bool SystemData::loadConfig(Window* window)
 {
 	deleteSystems();
 	ThemeData::setDefaultTheme(nullptr);
+	UIModeController::getInstance(); // Init UIModeController before loading systems
 
 	std::string path = getConfigPath();
 
@@ -1415,11 +1416,17 @@ void SystemData::loadTheme()
 		sysData["global.netplay"] = SystemConf::getInstance()->getBool("global.netplay") ? "true" : "false";
 		sysData["global.netplay.username"] = SystemConf::getInstance()->getBool("global.netplay") ? SystemConf::getInstance()->get("global.netplay.nickname") : "";
 
+		// Screen
+		sysData["screen.width"] = std::to_string(Renderer::getScreenWidth());
+		sysData["screen.height"] = std::to_string(Renderer::getScreenHeight());
+		sysData["screen.ratio"] = Renderer::getAspectRatio();
+		sysData["screen.vertical"] = Renderer::isVerticalScreen() ? "true" : "false";
+
 		// Retrocompatibility
 		sysData["cheevos.username"] = SystemConf::getInstance()->getBool("global.retroachievements") ? SystemConf::getInstance()->get("global.retroachievements.username") : "";
 
 		// System variables
-		sysData["system.cheevos"] = SystemConf::getInstance()->getBool("global.retroachievements") && (isCheevosSupported() || isCollection() || isGroupSystem()) ? "true" : "false";
+		sysData["system.cheevos"] = SystemConf::getInstance()->getBool("global.retroachievements") && (isCheevosSupported() || isCollection() || isGameSystem()) ? "true" : "false";
 		sysData["system.netplay"] = isNetplaySupported() ? "true" : "false";
 		sysData["system.savestates"] = isCurrentFeatureSupported(EmulatorFeatures::autosave) ? "true" : "false";
 
@@ -1452,6 +1459,11 @@ void SystemData::loadTheme()
 		global.cheevos.username
 		global.netplay				( bool )
 		global.netplay.username
+		global.language
+		screen.width				( float )
+		screen.height				( float ) 
+		screen.ratio
+		screen.vertical             ( bool )
 		system.cheevos				( bool )
 		system.netplay				( bool )
 		system.savestates			( bool )
@@ -1465,6 +1477,9 @@ void SystemData::loadTheme()
 		system.sortedBy
 		system.theme
 		system.command
+
+		lang					
+		cheevos.username		-> retrocompat
 		*/
 
 		mTheme->loadFile(getThemeFolder(), sysData, path);

--- a/es-app/src/views/SystemView.cpp
+++ b/es-app/src/views/SystemView.cpp
@@ -25,6 +25,7 @@
 #include "guis/GuiTextEditPopupKeyboard.h"
 #include "TextToSpeech.h"
 #include "Binding.h"
+#include "guis/GuiRetroAchievements.h"
 
 // buffer values for scrolling velocity (left, stopped, right)
 const int logoBuffersLeft[] = { -5, -2, -1 };
@@ -1976,7 +1977,20 @@ bool SystemView::onAction(const std::string& action)
 	{
 		listInput(1);
 		return true;
-	}	
+	}
 
+	if (action == "cheevos")
+	{
+		if (SystemConf::getInstance()->getBool("global.retroachievements") && !Settings::getInstance()->getBool("RetroachievementsMenuitem") && SystemConf::getInstance()->get("global.retroachievements.username") != "")
+		{
+			if (ApiSystem::getInstance()->getIpAdress() == "NOT CONNECTED")
+				mWindow->pushGui(new GuiMsgBox(mWindow, _("YOU ARE NOT CONNECTED TO A NETWORK"), _("OK"), nullptr));				
+			else
+				GuiRetroAchievements::show(mWindow);
+		}
+
+		return true;
+	}
+	
 	return false;
 }

--- a/es-app/src/views/gamelist/ISimpleGameListView.cpp
+++ b/es-app/src/views/gamelist/ISimpleGameListView.cpp
@@ -24,6 +24,8 @@
 #include "BasicGameListView.h"
 #include "utils/Randomizer.h"
 #include "views/Binding.h"
+#include "guis/GuiImageViewer.h"
+#include "guis/GuiGameAchievements.h"
 
 ISimpleGameListView::ISimpleGameListView(Window* window, FolderData* root, bool temporary) : IGameListView(window, root),
 	mHeaderText(window), mHeaderImage(window), mBackground(window), mFolderPath(window), mOnExitPopup(nullptr),
@@ -669,6 +671,68 @@ bool ISimpleGameListView::onAction(const std::string& action)
 		return true;
 	}
 	
+	if (action == "video")
+	{
+		FileData* game = getCursor();
+		if (game != nullptr)
+		{
+			auto path = game->getMetadata(MetaDataId::Video);
+			if (!path.empty())
+				GuiVideoViewer::playVideo(mWindow, path);
+		}
+		return true;
+	}
 
+	if (action == "manual")
+	{
+		FileData* game = getCursor();
+		if (game != nullptr)
+		{
+			auto path = game->getMetadata(MetaDataId::Manual);
+			if (!path.empty())
+				GuiImageViewer::showPdf(mWindow, path);
+		}
+		return true;
+	}
+
+	if (action == "map")
+	{
+		FileData* game = getCursor();
+		if (game != nullptr)
+		{
+			auto path = game->getMetadata(MetaDataId::Map);
+			if (!path.empty())
+				GuiImageViewer::showImage(mWindow, path, Utils::String::toLower(Utils::FileSystem::getExtension(path)) != ".pdf");
+		}
+		return true;
+	}
+
+	if (action == "medias")
+	{
+		FileData* game = getCursor();
+		if (game != nullptr)
+		{
+			auto imageList = game->getSourceFileData()->getFileMedias();
+			if (imageList.size())
+				GuiImageViewer::showImages(mWindow, imageList);
+		}
+
+		return true;
+	}
+
+	if (action == "cheevos")
+	{
+		FileData* game = getCursor();
+		if (game != nullptr)
+		{
+			auto path = Utils::String::toInteger(game->getMetadata(MetaDataId::CheevosId));
+			if (path != 0)
+				GuiGameAchievements::show(mWindow, path);
+		}
+
+		return true;
+	}
+
+	
 	return false;
 }

--- a/es-core/src/GuiComponent.cpp
+++ b/es-core/src/GuiComponent.cpp
@@ -16,8 +16,8 @@ bool GuiComponent::isLaunchTransitionRunning = false;
 
 GuiComponent::GuiComponent(Window* window) : mWindow(window), mParent(NULL), mOpacity(255),
 	mPosition(Vector3f::Zero()), mOrigin(Vector2f::Zero()), mRotationOrigin(0.5, 0.5), mScaleOrigin(0.5f, 0.5f),
-	mSize(Vector2f::Zero()), mTransform(Transform4x4f::Identity()), mIsProcessing(false), mVisible(true), mShowing(false),
-	mStaticExtra(false), mStoryboardAnimator(nullptr), mScreenOffset(0.0f), mTransformDirty(true), mIsMouseOver(false)
+	mSize(Vector2f::Zero()), mTransform(Transform4x4f::Identity()), mVisible(true), mShowing(false),
+	mStaticExtra(false), mStoryboardAnimator(nullptr), mScreenOffset(0.0f), mTransformDirty(true), mIsMouseOver(false), mChildZIndexDirty(false)
 {
 	mClipRect = Vector4f();
 }
@@ -69,6 +69,12 @@ void GuiComponent::updateSelf(int deltaTime)
 
 void GuiComponent::updateChildren(int deltaTime)
 {
+	if (mChildZIndexDirty)
+	{
+		mChildZIndexDirty = false;
+		sortChildren();
+	}
+
 	for (auto it = mChildren.cbegin(), next_it = it; it != mChildren.cend(); it = next_it)
 	{
 		++next_it;
@@ -231,7 +237,13 @@ float GuiComponent::getZIndex() const
 
 void GuiComponent::setZIndex(float z)
 {
+	if (mZIndex == z)
+		return;
+
 	mZIndex = z;
+
+	if (mParent != nullptr)
+		mParent->mChildZIndexDirty = true;
 }
 
 float GuiComponent::getDefaultZIndex() const
@@ -769,11 +781,6 @@ HelpStyle GuiComponent::getHelpStyle()
 	}
 
 	return style;
-}
-
-bool GuiComponent::isProcessing() const
-{
-	return mIsProcessing;
 }
 
 void GuiComponent::onShow()

--- a/es-core/src/GuiComponent.h
+++ b/es-core/src/GuiComponent.h
@@ -166,9 +166,6 @@ public:
 
 	virtual HelpStyle getHelpStyle();
 
-	// Returns true if the component is busy doing background processing (e.g. HTTP downloads)
-	bool isProcessing() const;
-
 	void animateTo(Vector2f from, Vector2f to, unsigned int flags = 0xFFFFFFFF, int delay = 350);
 	void animateTo(Vector2f from, unsigned int flags = AnimateFlags::OPACITY | AnimateFlags::SCALE, int delay = 350) { animateTo(from, from, flags, delay); }
 
@@ -244,12 +241,12 @@ protected:
 	float mDefaultZIndex = 0;
 	float mZIndex = 0;
 
-	bool mIsProcessing;
 	bool mVisible;
 	bool mShowing;
 	bool mStaticExtra;
 
 	bool mTransformDirty;
+	bool mChildZIndexDirty;
 
 	bool mIsMouseOver;
 

--- a/es-core/src/Window.cpp
+++ b/es-core/src/Window.cpp
@@ -650,7 +650,7 @@ void Window::render()
 
 	if (mTimeSinceLastInput >= screensaverTime && screensaverTime != 0)
 	{
-		if (!isProcessing() && mAllowSleep && (!mScreenSaver || mScreenSaver->allowSleep()))
+		if (mAllowSleep && (!mScreenSaver || mScreenSaver->allowSleep()))
 		{
 			// go to sleep
 			if (mSleeping == false) {
@@ -853,11 +853,6 @@ void Window::onSleep()
 void Window::onWake()
 {
 	Scripting::fireEvent("wake");
-}
-
-bool Window::isProcessing()
-{
-	return count_if(mGuiStack.cbegin(), mGuiStack.cend(), [](GuiComponent* c) { return c->isProcessing(); }) > 0;
 }
 
 void Window::startScreenSaver()

--- a/es-core/src/Window.h
+++ b/es-core/src/Window.h
@@ -136,9 +136,6 @@ private:
 	void onSleep();
 	void onWake();
 
-	// Returns true if at least one component on the stack is processing
-	bool isProcessing();
-
 	HelpComponent*	mHelp;
 	ImageComponent* mBackgroundOverlay;
 	ScreenSaver*	mScreenSaver;	

--- a/es-core/src/components/IList.h
+++ b/es-core/src/components/IList.h
@@ -146,7 +146,7 @@ public:
 		return mCursor;
 	}
 
-	void clear()
+	virtual void clear()
 	{
 		mEntries.clear();
 		mCursor = 0;

--- a/es-core/src/components/ImageGridComponent.h
+++ b/es-core/src/components/ImageGridComponent.h
@@ -86,6 +86,7 @@ public:
 	ImageGridComponent(Window* window);
 
 	void add(const std::string& name, const std::string& imagePath, const std::string& videoPath, const std::string& marqueePath, bool favorite, bool cheevos, bool folder, bool virtualFolder, const T& obj);
+	virtual void clear();
 
 	void setImage(const std::string& imagePath, const T& obj);
 	std::string getImage(const T& obj);
@@ -407,6 +408,13 @@ void ImageGridComponent<T>::add(const std::string& name, const std::string& imag
 	static_cast<IList< ImageGridData, T >*>(this)->add(entry);
 
 	mEntriesDirty = true;
+}
+
+template<typename T>
+void ImageGridComponent<T>::clear()
+{
+	mCameraOffset = 0;
+	IList<ImageGridData, T>::clear();
 }
 
 template<typename T>

--- a/es-core/src/components/VideoComponent.cpp
+++ b/es-core/src/components/VideoComponent.cpp
@@ -385,6 +385,11 @@ void VideoComponent::applyTheme(const std::shared_ptr<ThemeData>& theme, const s
 	else
 		setClipRect(Vector4f());
 
+	if (elem->has("onclick"))
+		setClickAction(elem->get<std::string>("onclick"));
+	else
+		setClickAction("");
+
 	if (elem->has("defaultSnapshot"))
 		mStaticImage.setDefaultImage(elem->get<std::string>("defaultSnapshot"));
 }

--- a/es-core/src/renderers/Renderer.cpp
+++ b/es-core/src/renderers/Renderer.cpp
@@ -480,6 +480,50 @@ namespace Renderer
 		return (float) screenWidth / (float) screenHeight;
 	}
 
+	std::map<std::string, float> ratios =
+	{
+		{ "4/3",		   4.0f / 3.0f },
+		{ "16/9",          16.0f / 9.0f },
+		{ "16/10",         16.0f / 10.0f },
+		{ "16/15",         16.0f / 15.0f },
+		{ "21/9",          21.0f / 9.0f },
+		{ "1/1",           1 / 1 },
+		{ "2/1",           2.0f / 1.0f },
+		{ "3/2",           3.0f / 2.0f },
+		{ "3/4",           3.0f / 4.0f },
+		{ "4/1",           4.0f / 1.0f },
+		{ "9/16",          9.0f / 16.0f },
+		{ "5/4",           5.0f / 4.0f },
+		{ "6/5",           6.0f / 5.0f },
+		{ "7/9",           7.0f / 9.0f },
+		{ "8/3",           8.0f / 3.0f },
+		{ "8/7",           8.0f / 7.0f },
+		{ "19/12",         19.0f / 12.0f },
+		{ "19/14",         19.0f / 14.0f },
+		{ "30/17",         30.0f / 17.0f },
+		{ "32/9",          32.0f / 9.0f }
+	};
+
+	std::string  getAspectRatio()
+	{
+		float nearDist = 9999999;
+		std::string nearName = "";
+
+		float prop = Renderer::getScreenProportion();
+
+		for (auto ratio : ratios)
+		{
+			float dist = abs(prop - ratio.second);
+			if (dist < nearDist)
+			{
+				nearDist = dist;
+				nearName = ratio.first;
+			}
+		}
+
+		return nearName;
+	}
+
 	bool        isSmallScreen()    
 	{ 		
 		return screenWidth <= 480 || screenHeight <= 480; 

--- a/es-core/src/renderers/Renderer.h
+++ b/es-core/src/renderers/Renderer.h
@@ -137,6 +137,7 @@ namespace Renderer
 	int         getScreenOffsetY();
 	int         getScreenRotate ();
 	float		getScreenProportion();
+	std::string getAspectRatio();
 	bool		isVerticalScreen();
 
 	// API specific

--- a/es-core/src/utils/MathExpr.cpp
+++ b/es-core/src/utils/MathExpr.cpp
@@ -78,7 +78,7 @@ namespace Utils
 				expr = nextChar;
 				lastTokenWasOp = false;
 			}
-			else if (isvariablechar(*expr) || *expr == '{')
+			else if (isvariablechar(*expr) || *expr == '{' || *expr == '$')
 			{
 				// If the function is a variable, resolve it and
 				// add the parsed number to the output queue.
@@ -86,6 +86,9 @@ namespace Utils
 					throw std::domain_error("Detected variable, but the variable map is null.");
 
 				std::stringstream ss;
+
+				if (*expr == '$' && *(expr+1) == '{')
+					expr++;
 
 				if (*expr == '{')
 				{


### PR DESCRIPTION
- zIndex : Reorder parent's children when zIndex change ( due to storyboard animations )

- Add new Themes variables : 
screen.width, screen.height, screen.vertical (bool), screen.ratio (string, format 16/9, 4/3... see libretro ratio list )

- onclick : add new events :
Gamelist -> video, manual, map, cheevos, medias
SystemView -> cheevos

- ImageGrid : fix scroll pos when returning back from a child folder
