### PR TITLE
allow user to select 0 degrees for screen rotation

### DIFF
--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -1235,7 +1235,8 @@ void GuiMenu::openSystemSettings()
 	if (selectedRotation.empty())
 		selectedRotation = "auto";
 
-	optionsRotation->add(_("0 DEGREES (AUTO)"),              "auto", selectedRotation == "auto");
+	optionsRotation->add(_("AUTO"),              "auto", selectedRotation == "auto");
+	optionsRotation->add(_("0 DEGREES"),        "0", selectedRotation == "0");
 	optionsRotation->add(_("90 DEGREES"),       "1", selectedRotation == "1");
 	optionsRotation->add(_("180 DEGREES"),    "2", selectedRotation == "2");
 	optionsRotation->add(_("270 DEGREES"),        "3", selectedRotation == "3");


### PR DESCRIPTION
In Batocera, the 0 degrees and auto setting functionality is different. This allows the user to not have to manually edit `batocera.conf` to access this functionality.

This also makes it more in line with the way other options function, showing "auto" as the default followed by all the options.