### PR TITLE
Support for new hardcore/softcore points in RetroAchievements

### DIFF
--- a/es-app/src/RetroAchievements.cpp
+++ b/es-app/src/RetroAchievements.cpp
@@ -382,6 +382,7 @@ RetroAchievementInfo RetroAchievements::toRetroAchivementInfo(UserSummary& ret)
 
 	info.points = ret.TotalPoints;
 	info.totalpoints = ret.TotalTruePoints;
+	info.softpoints = std::to_string(std::stoi(info.totalpoints) - std::stoi(info.points));
 	info.username = ret.Username;
 	info.registered = ret.MemberSince;
 

--- a/es-app/src/RetroAchievements.h
+++ b/es-app/src/RetroAchievements.h
@@ -180,6 +180,7 @@ struct RetroAchievementInfo
 	std::string username;
 	std::string points;
 	std::string totalpoints;
+	std::string softpoints;
 	std::string rank;
 	std::string userpic;
 	std::string registered;

--- a/es-app/src/guis/GuiRetroAchievements.cpp
+++ b/es-app/src/guis/GuiRetroAchievements.cpp
@@ -195,7 +195,7 @@ GuiRetroAchievements::GuiRetroAchievements(Window* window, RetroAchievementInfo 
 		setTitleImage(image);
 	}
 
-	setSubTitle(_("Points") + ":\t" + ra.points + "\r\n"+ _("Rank") + ":\t" + ra.rank);
+	setSubTitle(_("Points (hardcore)") + ":\t" + ra.points + "\r\n" +_("Softcore points") + ":\t" + ra.softpoints + "\r\n"+ _("Rank") + ":\t" + ra.rank);
 
 	for (auto game : ra.games)
 	{


### PR DESCRIPTION
By default, if you don't enable hardcore mode or use the save states like many users, points will always be accrued to "softcore points", not "points" any more, as RetroAchievements has now changed "points" to be hardcore-only. 

That means that without that PR, users will unlock cheevos, get the badges and so on, but their "points" would be stuck to 0. Now, we have a new line for softcore points to show progress.