### PR TITLE
mapper input labels to be homogenuous

### DIFF
--- a/es-app/src/guis/GuiKeyMappingEditor.cpp
+++ b/es-app/src/guis/GuiKeyMappingEditor.cpp
@@ -34,8 +34,8 @@ void GuiKeyMappingEditor::initMappingNames()
 		{ "start",   "START",        ":/help/button_start.svg" },
 		{ "select",  "SELECT",       ":/help/button_select.svg" },
 
-		{ "a",				 InputConfig::buttonLabel("a"),    InputConfig::buttonImage("a") },
-		{ "b",				 InputConfig::buttonLabel("b"),    InputConfig::buttonImage("b") },
+		{ "a",               "EAST",    ":/help/buttons_east.svg" },
+		{ "b",               "SOUTH",    ":/help/buttons_south.svg" },
 
 		{ "x",               "NORTH",   ":/help/buttons_north.svg" },
 		{ "y",               "WEST",    ":/help/buttons_west.svg" },
@@ -60,8 +60,8 @@ void GuiKeyMappingEditor::initMappingNames()
 
 		{ "hotkey + start",          "HOTKEY + START",      ":/help/button_hotkey.svg", ":/help/button_start.svg" },
 
-		{ "hotkey + a",       "HOTKEY + " + InputConfig::buttonLabel("a"),    ":/help/button_hotkey.svg", InputConfig::buttonImage("a") },
-		{ "hotkey + b",       "HOTKEY + " + InputConfig::buttonLabel("b"),   ":/help/button_hotkey.svg", InputConfig::buttonImage("b") },
+		{ "hotkey + a",       "HOTKEY + EAST",    ":/help/button_hotkey.svg", ":/help/buttons_east.svg" },
+		{ "hotkey + b",       "HOTKEY + SOUTH",   ":/help/button_hotkey.svg", ":/help/buttons_south.svg" },
 		{ "hotkey + x",       "HOTKEY + NORTH",    ":/help/button_hotkey.svg", ":/help/buttons_north.svg" },
 		{ "hotkey + y",       "HOTKEY + WEST",   ":/help/button_hotkey.svg", ":/help/buttons_west.svg" }
 	};

--- a/es-app/src/guis/GuiKeyMappingEditor.cpp
+++ b/es-app/src/guis/GuiKeyMappingEditor.cpp
@@ -37,8 +37,8 @@ void GuiKeyMappingEditor::initMappingNames()
 		{ "a",				 InputConfig::buttonLabel("a"),    InputConfig::buttonImage("a") },
 		{ "b",				 InputConfig::buttonLabel("b"),    InputConfig::buttonImage("b") },
 
-		{ "x",               "NORTH (X ON SNES)",   ":/help/buttons_north.svg" },
-		{ "y",               "WEST (Y ON SNES)",    ":/help/buttons_west.svg" },
+		{ "x",               "NORTH",   ":/help/buttons_north.svg" },
+		{ "y",               "WEST",    ":/help/buttons_west.svg" },
 
 		{ "joystick1up",     "LEFT ANALOG UP",     ":/help/analog_up.svg" },
 		{ "joystick1down",   "LEFT ANALOG DOWN",     ":/help/analog_down.svg" },
@@ -62,8 +62,8 @@ void GuiKeyMappingEditor::initMappingNames()
 
 		{ "hotkey + a",       "HOTKEY + " + InputConfig::buttonLabel("a"),    ":/help/button_hotkey.svg", InputConfig::buttonImage("a") },
 		{ "hotkey + b",       "HOTKEY + " + InputConfig::buttonLabel("b"),   ":/help/button_hotkey.svg", InputConfig::buttonImage("b") },
-		{ "hotkey + x",       "HOTKEY + NORTH (X ON SNES)",    ":/help/button_hotkey.svg", ":/help/buttons_north.svg" },
-		{ "hotkey + y",       "HOTKEY + WEST (Y ON SNES)",   ":/help/button_hotkey.svg", ":/help/buttons_west.svg" }
+		{ "hotkey + x",       "HOTKEY + NORTH",    ":/help/button_hotkey.svg", ":/help/buttons_north.svg" },
+		{ "hotkey + y",       "HOTKEY + WEST",   ":/help/button_hotkey.svg", ":/help/buttons_west.svg" }
 	};
 }
 

--- a/es-app/src/guis/GuiKeyMappingEditor.cpp
+++ b/es-app/src/guis/GuiKeyMappingEditor.cpp
@@ -27,18 +27,18 @@ void GuiKeyMappingEditor::initMappingNames()
 {
 	mMappingNames =
 	{
-		{ "up",      "UP",           ":/help/dpad_up.svg" },
-		{ "down",    "DOWN",         ":/help/dpad_down.svg" },
-		{ "left",    "LEFT",         ":/help/dpad_left.svg" },
-		{ "right",   "RIGHT",        ":/help/dpad_right.svg" },
+		{ "up",      "D-PAD UP",           ":/help/dpad_up.svg" },
+		{ "down",    "D-PAD DOWN",         ":/help/dpad_down.svg" },
+		{ "left",    "D-PAD LEFT",         ":/help/dpad_left.svg" },
+		{ "right",   "D-PAD RIGHT",        ":/help/dpad_right.svg" },
 		{ "start",   "START",        ":/help/button_start.svg" },
 		{ "select",  "SELECT",       ":/help/button_select.svg" },
 
 		{ "a",				 InputConfig::buttonLabel("a"),    InputConfig::buttonImage("a") },
 		{ "b",				 InputConfig::buttonLabel("b"),    InputConfig::buttonImage("b") },
 
-		{ "x",               "X",   ":/help/buttons_north.svg" },
-		{ "y",               "Y",    ":/help/buttons_west.svg" },
+		{ "x",               "NORTH (X ON SNES)",   ":/help/buttons_north.svg" },
+		{ "y",               "WEST (Y ON SNES)",    ":/help/buttons_west.svg" },
 
 		{ "joystick1up",     "LEFT ANALOG UP",     ":/help/analog_up.svg" },
 		{ "joystick1down",   "LEFT ANALOG DOWN",     ":/help/analog_down.svg" },
@@ -49,12 +49,12 @@ void GuiKeyMappingEditor::initMappingNames()
 		{ "joystick2down",   "RIGHT ANALOG DOWN",     ":/help/analog_down.svg" },
 		{ "joystick2left",   "RIGHT ANALOG LEFT",   ":/help/analog_left.svg" },
 		{ "joystick2right",  "RIGHT ANALOG RIGHT",   ":/help/analog_right.svg" },
-		{ "pageup",          "L1",      ":/help/button_l.svg" },
-		{ "pagedown",        "R1",     ":/help/button_r.svg" },
-		{ "l2",              "L2",       ":/help/button_lt.svg" },
-		{ "r2",              "R2",      ":/help/button_rt.svg" },
-		{ "l3",              "L3",       ":/help/analog_thumb.svg" },
-		{ "r3",              "R3",      ":/help/analog_thumb.svg" },
+		{ "pageup",          "LEFT SHOULDER",      ":/help/button_l.svg" },
+		{ "pagedown",        "RIGHT SHOULDER",     ":/help/button_r.svg" },
+		{ "l2",              "LEFT TRIGGER",       ":/help/button_lt.svg" },
+		{ "r2",              "RIGHT TRIGGER",      ":/help/button_rt.svg" },
+		{ "l3",              "LEFT STICK PRESS",       ":/help/analog_thumb.svg" },
+		{ "r3",              "RIGHT STICK PRESS",      ":/help/analog_thumb.svg" },
 
 		//{ "hotkey",          "HOTKEY",      ":/help/button_hotkey.svg" },
 
@@ -62,8 +62,8 @@ void GuiKeyMappingEditor::initMappingNames()
 
 		{ "hotkey + a",       "HOTKEY + " + InputConfig::buttonLabel("a"),    ":/help/button_hotkey.svg", InputConfig::buttonImage("a") },
 		{ "hotkey + b",       "HOTKEY + " + InputConfig::buttonLabel("b"),   ":/help/button_hotkey.svg", InputConfig::buttonImage("b") },
-		{ "hotkey + x",       "HOTKEY + X",    ":/help/button_hotkey.svg", ":/help/buttons_north.svg" },
-		{ "hotkey + y",       "HOTKEY + Y",   ":/help/button_hotkey.svg", ":/help/buttons_west.svg" }
+		{ "hotkey + x",       "HOTKEY + NORTH (X ON SNES)",    ":/help/button_hotkey.svg", ":/help/buttons_north.svg" },
+		{ "hotkey + y",       "HOTKEY + WEST (Y ON SNES)",   ":/help/button_hotkey.svg", ":/help/buttons_west.svg" }
 	};
 }
 

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -2347,11 +2347,10 @@ void GuiMenu::openControllersSettings(int autoSel)
 	s->addEntry(_("CONTROLLER MAPPING"), false, [window, this, s]
 	{
 		window->pushGui(new GuiMsgBox(window,
-			_("YOU ARE GOING TO MAP A CONTROLLER. MAP BASED ON THE BUTTON'S POSITION "
-				"RELATIVE TO ITS EQUIVALENT ON A SNES CONTROLLER, NOT ITS PHYSICAL LABEL. "
-				"IF YOU DO NOT HAVE A SPECIAL KEY FOR HOTKEY, USE THE SELECT BUTTON. SKIP "
-				"ALL BUTTONS/STICKS YOU DO NOT HAVE BY HOLDING ANY KEY. PRESS THE "
-				"SOUTH BUTTON TO CONFIRM WHEN DONE."), 
+			_("YOU ARE GOING TO MAP A CONTROLLER. MAP BASED ON THE BUTTON'S POSITION, "
+				"NOT ITS PHYSICAL LABEL. IF YOU DO NOT HAVE A SPECIAL BUTTON FOR HOTKEY, "
+				"USE THE SELECT BUTTON. SKIP ALL BUTTONS/STICKS YOU DO NOT HAVE BY "
+				"HOLDING ANY BUTTON. PRESS THE SOUTH BUTTON TO CONFIRM WHEN DONE."),
 			_("OK"), [window, this, s] { window->pushGui(new GuiDetectDevice(window, false, [this, s] { s->setSave(false); delete s; this->openControllersSettings(); })); },
 			_("CANCEL"), nullptr,
 			GuiMsgBoxIcon::ICON_INFORMATION));

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -730,7 +730,7 @@ void GuiMenu::openDeveloperSettings()
 
 	auto invertJoy = std::make_shared<SwitchComponent>(mWindow);
 	invertJoy->setState(Settings::getInstance()->getBool("InvertButtons"));
-	s->addWithLabel(_("SWITCH A & B BUTTONS IN EMULATIONSTATION"), invertJoy);
+	s->addWithDescription(_("SWITCH CONFIRM & CANCEL BUTTONS IN EMULATIONSTATION"), _("Switches the South and East buttons' functionality"), invertJoy);
 	s->addSaveFunc([this, s, invertJoy]
 	{
 		if (Settings::getInstance()->setBool("InvertButtons", invertJoy->getState()))

--- a/es-core/src/InputConfig.cpp
+++ b/es-core/src/InputConfig.cpp
@@ -240,11 +240,16 @@ std::string InputConfig::buttonLabel(const std::string& button)
 	if (!Settings::getInstance()->getBool("InvertButtons"))
 	{
 		if (button == "a")
-			return "b";
+			return "SOUTH (B ON SNES)";
 		else if (button == "b")
-			return "a";
+			return "EAST (A ON SNES)";
 	}
 #endif
+
+	if (button == "a")
+		return "EAST (A ON SNES)";
+	else if (button == "b")
+		return "SOUTH (B ON SNES)";
 
 	return button;
 }

--- a/es-core/src/InputConfig.cpp
+++ b/es-core/src/InputConfig.cpp
@@ -240,16 +240,11 @@ std::string InputConfig::buttonLabel(const std::string& button)
 	if (!Settings::getInstance()->getBool("InvertButtons"))
 	{
 		if (button == "a")
-			return "SOUTH (B ON SNES)";
+			return "b";
 		else if (button == "b")
-			return "EAST (A ON SNES)";
+			return "a";
 	}
 #endif
-
-	if (button == "a")
-		return "EAST (A ON SNES)";
-	else if (button == "b")
-		return "SOUTH (B ON SNES)";
 
 	return button;
 }

--- a/es-core/src/guis/GuiInputConfig.cpp
+++ b/es-core/src/guis/GuiInputConfig.cpp
@@ -33,8 +33,8 @@ void GuiInputConfig::initInputConfigStructure()
 {
 	GUI_INPUT_CONFIG_LIST =
 	{
-		{ "a",                false, InputConfig::buttonLabel("a"),    InputConfig::buttonImage("a") },
-		{ "b",                true,  InputConfig::buttonLabel("b"),    InputConfig::buttonImage("b") },
+		{ "a",                false, "EAST",               ":/help/buttons_east.svg" },
+		{ "b",                true,  "SOUTH",              ":/help/buttons_south.svg" },
 		{ "x",                true,  "NORTH",              ":/help/buttons_north.svg" },
 		{ "y",                true,  "WEST",               ":/help/buttons_west.svg" },
 

--- a/es-core/src/guis/GuiInputConfig.cpp
+++ b/es-core/src/guis/GuiInputConfig.cpp
@@ -35,29 +35,29 @@ void GuiInputConfig::initInputConfigStructure()
 	{
 		{ "a",                false, InputConfig::buttonLabel("a"),    InputConfig::buttonImage("a") },
 		{ "b",                true,  InputConfig::buttonLabel("b"),    InputConfig::buttonImage("b") },
-		{ "x",                true,  "X",    ":/help/buttons_north.svg" },
-		{ "y",                true,  "Y",    ":/help/buttons_west.svg" },
+		{ "x",                true,  "NORTH (X ON SNES)",  ":/help/buttons_north.svg" },
+		{ "y",                true,  "WEST (Y ON SNES)",   ":/help/buttons_west.svg" },
 
 		{ "start",            true,  "START",              ":/help/button_start.svg" },
 		{ "select",           true,  "SELECT",             ":/help/button_select.svg" },
 
-		{ "up",               false, "UP",           ":/help/dpad_up.svg" },
-		{ "down",             false, "DOWN",         ":/help/dpad_down.svg" },
-		{ "left",             false, "LEFT",         ":/help/dpad_left.svg" },
-		{ "right",            false, "RIGHT",        ":/help/dpad_right.svg" },
+		{ "up",               false, "D-PAD UP",           ":/help/dpad_up.svg" },
+		{ "down",             false, "D-PAD DOWN",         ":/help/dpad_down.svg" },
+		{ "left",             false, "D-PAD LEFT",         ":/help/dpad_left.svg" },
+		{ "right",            false, "D-PAD RIGHT",        ":/help/dpad_right.svg" },
 
-		{ "pageup",          true,  "L1",      ":/help/button_l.svg" },
-		{ "pagedown",        true,  "R1",     ":/help/button_r.svg" },
+		{ "pageup",          true,  "LEFT SHOULDER",      ":/help/button_l.svg" },
+		{ "pagedown",        true,  "RIGHT SHOULDER",     ":/help/button_r.svg" },
 
 		{ "joystick1up",     true,  "LEFT ANALOG UP",     ":/help/analog_up.svg" },
 		{ "joystick1left",   true,  "LEFT ANALOG LEFT",   ":/help/analog_left.svg" },
 		{ "joystick2up",     true,  "RIGHT ANALOG UP",     ":/help/analog_up.svg" },
 		{ "joystick2left",   true,  "RIGHT ANALOG LEFT",   ":/help/analog_left.svg" },
 
-		{ "l2",              true,  "L2",       ":/help/button_lt.svg" },
-		{ "r2",              true,  "R2",      ":/help/button_rt.svg" },
-		{ "l3",              true,  "L3",       ":/help/analog_thumb.svg" },
-		{ "r3",              true,  "R3",      ":/help/analog_thumb.svg" },
+		{ "l2",              true,  "LEFT TRIGGER",       ":/help/button_lt.svg" },
+		{ "r2",              true,  "RIGHT TRIGGER",      ":/help/button_rt.svg" },
+		{ "l3",              true,  "LEFT STICK PRESS",       ":/help/analog_thumb.svg" },
+		{ "r3",              true,  "RIGHT STICK PRESS",      ":/help/analog_thumb.svg" },
 
 		{ "hotkey",          true,  "HOTKEY",      ":/help/button_hotkey.svg" }
 	};

--- a/es-core/src/guis/GuiInputConfig.cpp
+++ b/es-core/src/guis/GuiInputConfig.cpp
@@ -35,8 +35,8 @@ void GuiInputConfig::initInputConfigStructure()
 	{
 		{ "a",                false, InputConfig::buttonLabel("a"),    InputConfig::buttonImage("a") },
 		{ "b",                true,  InputConfig::buttonLabel("b"),    InputConfig::buttonImage("b") },
-		{ "x",                true,  "NORTH (X ON SNES)",  ":/help/buttons_north.svg" },
-		{ "y",                true,  "WEST (Y ON SNES)",   ":/help/buttons_west.svg" },
+		{ "x",                true,  "NORTH",              ":/help/buttons_north.svg" },
+		{ "y",                true,  "WEST",               ":/help/buttons_west.svg" },
 
 		{ "start",            true,  "START",              ":/help/button_start.svg" },
 		{ "select",           true,  "SELECT",             ":/help/button_select.svg" },


### PR DESCRIPTION
Less dependent on the user knowing the layout of both the SNES and PS3/4 controller.

Uses the same co-ordinate system for face buttons as used throughout the rest of Batocera:
![screenshot-2022 08 26-21h45 38](https://user-images.githubusercontent.com/67527064/187159422-872df6b9-4053-4c00-8f55-7b1073865eb3.png)

Replaces L1/R1 with Left shoulder/Right shoulder and L2/R2 with Left trigger/Right trigger.

Replaces L3/R3 with Left stick press/Right stick press.

Specifies the "up/down/left/right" are for the D-pad.