### PR TITLE
add calibration to menu

### DIFF
--- a/es-app/src/ApiSystem.cpp
+++ b/es-app/src/ApiSystem.cpp
@@ -1717,3 +1717,7 @@ void ApiSystem::replugControllers_wiimotes() {
   LOG(LogDebug) << "ApiSystem::replugControllers_wiimotes";
   executeScript("/usr/bin/virtual-wii-mouse-bar-remap");
 }
+
+bool ApiSystem::wiigun_calibrate() {
+	return executeScript("/usr/bin/batocera-gun-calibrator-daemon $env{DEVNAME} 260");
+}

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -2568,6 +2568,12 @@ void GuiMenu::openControllersSpecificSettings_wiigun()
 	    ApiSystem::getInstance()->replugControllers_wiimotes();
 	  }
 	});
+
+	s->addEntry(_("RECALIBRATE WIIMOTE GUN"), false, [this, s]
+	{
+		wiigun_calibrate();
+	});
+
 	mWindow->pushGui(s);
 }
 


### PR DESCRIPTION
Adds recalibration function to the Wiimote gun menu.

Need to wait on confirmation that this will work before merging.