### PR TITLE
Support battery readings from standalone fuel gauge and charger

### DIFF
--- a/es-core/src/platform.cpp
+++ b/es-core/src/platform.cpp
@@ -367,6 +367,12 @@ BatteryInformation queryBatteryInformation()
 				batteryCurrChargePath = fuelgaugeRootPath + "/charge_now";
 				batteryMaxChargePath = fuelgaugeRootPath + "/charge_full";
 				batteryCapacityPath = ".";
+				// If there's a fuel gauge without "charge_now" or "charge_full" property, don't poll it
+				if ((!Utils::FileSystem::exists(batteryCurrChargePath)) || (!Utils::FileSystem::exists(batteryMaxChargePath)))
+				{
+					batteryCurrChargePath = ".";
+					batteryMaxChargePath = ".";
+				}
 			}
 			if (!chargerRootPath.empty())
                                 batteryStatusPath = chargerRootPath + "/status";
@@ -378,10 +384,9 @@ BatteryInformation queryBatteryInformation()
 			batteryStatusPath = batteryRootPath + "/status";
 			batteryCapacityPath = batteryRootPath + "/capacity";
 		}
-
 	}
 
-	if (batteryStatusPath.length() <= 1)
+	if ((batteryStatusPath.length() <= 1) || (batteryCurrChargePath.length() <= 1))
 	{
 		ret.hasBattery = false;
 		ret.isCharging = false;
@@ -401,7 +406,7 @@ BatteryInformation queryBatteryInformation()
 			ret.level = int(round((now/full)*100));
 		}
 		else
-			ret.level = atoi(Utils::FileSystem::readAllText(batteryCapacityPath).c_str());
+			ret.level = Utils::String::toInteger(Utils::FileSystem::readAllText(batteryCapacityPath).c_str());
 	}
 
 	return ret;


### PR DESCRIPTION
The Linux kernel has drivers for standalone battery-monitoring hardware that does not show up in /sys/class/power_supply as a discrete battery device with "status" and "capacity" properties. For example, in my use case, I am using the LTC2941 fuel gauge and the generic "gpio-charger" driver to detect the presence of +5V on the USB charging port. The LTC2941 does not report "capacity" but it does report the current charge level and the max charge level of the battery. Meanwhile, the gpio-charger driver does report the charging status via a "status" property, but it's a separate device from the fuel gauge.

This PR adds support for such devices so that the battery status overlay works as intended. If I did it right, existing functionality is preserved for users without such hardware, or with a standard battery device. ES first checks for a battery device and if it finds one, it is read as before. If it does not find one, it instead looks for devices in /sys/class/power_supply/ that contain "fuel" or "charger" in the device name. If it finds them, it calculates the remaining battery capacity from the "charge_now" and "charge_max" properties, and it determines the charging state from the charger's "status" property.