### PR TITLE
update ping utility

### DIFF
--- a/es-app/src/ApiSystem.cpp
+++ b/es-app/src/ApiSystem.cpp
@@ -332,8 +332,16 @@ std::pair<std::string, int> ApiSystem::scrape(BusyComponent* ui)
 
 bool ApiSystem::ping() 
 {
-	if (!executeScript("timeout 1 ping -c 1 -t 1000 8.8.8.8")) // ping Google DNS
-		return executeScript("timeout 2 ping -c 1 -t 2000 8.8.4.4"); // ping Google secondary DNS & give 2 seconds
+	// ping Google, if it fails then move on, if succeeds exit loop and return "true"
+	if (!executeScript("timeout 1 ping -c 1 -t 1000 google.com"))
+	{
+		// ping Google DNS
+		if (!executeScript("timeout 1 ping -c 1 -t 1000 8.8.4.4"))
+		{
+			// ping Google secondary DNS & give 2 seconds, return this one's status
+			return executeScript("timeout 2 ping -c 1 -t 2000 8.8.4.4");
+		}
+	}
 
 	return true;
 }

--- a/es-app/src/ApiSystem.cpp
+++ b/es-app/src/ApiSystem.cpp
@@ -336,7 +336,7 @@ bool ApiSystem::ping()
 	if (!executeScript("timeout 1 ping -c 1 -t 1000 google.com"))
 	{
 		// ping Google DNS
-		if (!executeScript("timeout 1 ping -c 1 -t 1000 8.8.4.4"))
+		if (!executeScript("timeout 1 ping -c 1 -t 1000 8.8.8.8"))
 		{
 			// ping Google secondary DNS & give 2 seconds, return this one's status
 			return executeScript("timeout 2 ping -c 1 -t 2000 8.8.4.4");


### PR DESCRIPTION
Check for the HTTP URL of Google instead of only relying on its DNS. This will improve the robustness of the tool and also how quickly it resolves (in my personal testing at least, pinging the http domain is 2ms quicker).

Related issue: https://github.com/batocera-linux/batocera-emulationstation/issues/1102

Also made the structure of the code more consistent with the rest of the file.