### PR TITLE
sinden guns modes

### DIFF
--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -2534,6 +2534,15 @@ void GuiMenu::openControllersSpecificSettings_sindengun()
 
 	s->addOptionList(_("BORDER SIZE"), { { _("AUTO"), "auto" },{ _("THIN") , "thin" },{ _("MEDIUM"), "medium" },{ _("BIG"), "big" } }, "controllers.guns.borderssize", false);
 
+	std::string selectedBordersMode = SystemConf::getInstance()->get("controllers.guns.bordersmode");
+	auto bordersmode_set = std::make_shared<OptionListComponent<std::string> >(mWindow, _("BORDER MODE"), false);
+	border_set->add(_("AUTO"),   "",       ""       == selectedSet);
+	border_set->add(_("NORMAL"),   "NORMAL",   "NORMAL"   == selectedSet);
+	border_set->add(_("IN GAME ONLY"), "INGAMEONLY", "INGAMEONLY" == selectedSet);
+	border_set->add(_("HIDDEN"),    "HIDDEN",    "HIDDEN"    == selectedSet);
+
+	s->addOptionList(_("BORDER MODE"), { { _("AUTO"), "auto" },{ _("NORMAL") , "normal" },{ _("INGAMEONLY"), "gameonly" },{ _("HIDDEN"), "hidden" } }, "controllers.guns.bordersmode", false);
+
 	std::string baseMode = SystemConf::getInstance()->get("controllers.guns.recoil");
 	auto sindenmode_choices = std::make_shared<OptionListComponent<std::string> >(mWindow, _("RECOIL"), false);
 	sindenmode_choices->add(_("AUTO"), "auto", baseMode.empty() || baseMode == "auto");
@@ -2549,6 +2558,7 @@ void GuiMenu::openControllersSpecificSettings_sindengun()
 	    ApiSystem::getInstance()->replugControllers_sindenguns();
 	  }
 	});
+
 	mWindow->pushGui(s);
 }
 

--- a/es-core/src/Window.cpp
+++ b/es-core/src/Window.cpp
@@ -514,9 +514,20 @@ void Window::renderSindenBorders()
 	for (auto gun : InputManager::getInstance()->getGuns())
 		if (gun->needBorders()) 
 			drawGunBorders = true;		
-	
-	if (!drawGunBorders && SystemConf::getInstance()->getBool("controllers.guns.forceborders")) // SETTING FOR DEBUGGING BORDERS
-		drawGunBorders = true; 
+
+	// normal (default) : draw borders when required
+	// hidden : the border are not displayed (assume that there are provided by an other way like bezels)
+	// force  : force even if no gun requires it (or even no gun at all)
+	// gameonly : borders are not visible in es, just in game (for boards having a sinden gun alway plugged in)
+	auto bordersMode = SystemConf::getInstance()->get("controllers.guns.bordersmode");
+	if (drawGunBorders)
+	  if(bordersMode == "hidden" || bordersMode == "gameonly")
+	    drawGunBorders = false;
+
+	if (!drawGunBorders)
+	  if(bordersMode == "force")
+	    // SETTING FOR DEBUGGING BORDERS
+	    drawGunBorders = true;
 
 	if (drawGunBorders)
 	{


### PR DESCRIPTION
- normal : draw borders when required
- hidden : the border are not displayed (assume that there are provided by an other way like bezels)
- force  : force even if no gun requires it (or even no gun at all)
- gameonly : borders are not visible in es, just in game (for boards having a sinden gun alway plugged in)

Signed-off-by: Nicolas Adenis-Lamarre <nicolas.adenis.lamarre@gmail.com>