### PR TITLE
Fix battery detection typo

### DIFF
--- a/es-core/src/platform.cpp
+++ b/es-core/src/platform.cpp
@@ -389,7 +389,7 @@ BatteryInformation queryBatteryInformation()
 		}
 	}
 
-	if ((batteryStatusPath.length() <= 1) || (batteryCurrChargePath.length() <= 1))
+	if ((batteryStatusPath.length() <= 1) && (batteryCurrChargePath.length() <= 1))
 	{
 		ret.hasBattery = false;
 		ret.isCharging = false;


### PR DESCRIPTION
This fixes a typo that broke battery detection, as discussed here: https://github.com/batocera-linux/batocera-emulationstation/pull/1311#issuecomment-1287104364