### PR TITLE
[Storyboard] Add support for <sound path="XXX" at="1000"/> element in storyboards

### DIFF
--- a/es-core/src/GuiComponent.cpp
+++ b/es-core/src/GuiComponent.cpp
@@ -11,6 +11,7 @@
 #include "anim/StoryboardAnimator.h"
 #include "components/ScrollableContainer.h"
 #include "math/Vector2i.h"
+#include "Sound.h"
 
 bool GuiComponent::isLaunchTransitionRunning = false;
 
@@ -958,6 +959,9 @@ ThemeData::ThemeElement::Property GuiComponent::getProperty(const std::string na
 	if (name == "clipRect")
 		return Vector4f(mClipRect.x() / screenScale.x(), mClipRect.y() / screenScale.y(), mClipRect.z() /screenScale.x(), mClipRect.w() / screenScale.y());
 
+	if (name == "sound")
+		return mStoryBoardSound;
+
 	return "";
 }
 
@@ -1025,6 +1029,14 @@ void GuiComponent::setProperty(const std::string name, const ThemeData::ThemeEle
 
 	if (name == "clipRect" && value.type == ThemeData::ThemeElement::Property::PropertyType::Rect)
 		setClipRect(Vector4f(value.r.x() * screenScale.x(), value.r.y() * screenScale.y(), value.r.z() * screenScale.x(), value.r.w() * screenScale.y()));
+
+	if (name == "sound" && value.type == ThemeData::ThemeElement::Property::PropertyType::String && mStoryBoardSound != value.s)
+	{
+		mStoryBoardSound = value.s;
+
+		if (!mStoryBoardSound.empty())
+			Sound::get(mStoryBoardSound)->play();
+	}
 
 	mTransformDirty = true;
 }

--- a/es-core/src/GuiComponent.h
+++ b/es-core/src/GuiComponent.h
@@ -236,6 +236,8 @@ protected:
 
 	Vector2f mScreenOffset;
 
+	std::string mStoryBoardSound;
+
 	float mRotation = 0.0;
 	float mScale = 1.0;
 	float mDefaultZIndex = 0;

--- a/es-core/src/ThemeData.cpp
+++ b/es-core/src/ThemeData.cpp
@@ -1665,7 +1665,8 @@ void ThemeData::parseElement(const pugi::xml_node& root, const std::map<std::str
 				else
 				{
 					auto storyBoard = new ThemeStoryboard();
-					if (!storyBoard->fromXmlNode(node, typeMap))
+
+					if (!storyBoard->fromXmlNode(node, typeMap, mPaths.size() ? Utils::FileSystem::getParent(mPaths.back()) : ""))
 					{
 						auto sb = element.mStoryBoards.find(storyBoard->eventName);
 						if (sb != element.mStoryBoards.cend())

--- a/es-core/src/anim/ThemeAnimation.h
+++ b/es-core/src/anim/ThemeAnimation.h
@@ -115,3 +115,14 @@ class ThemePathAnimation : public ThemeAnimation
 		return from.s;
 	}
 };
+
+class ThemeSoundAnimation : public ThemeAnimation
+{
+	ThemeData::ThemeElement::Property computeValue(float value) override
+	{
+		if (value >= 0.9999)
+			return to.s;
+
+		return from.s;
+	}
+};

--- a/es-core/src/anim/ThemeStoryboard.h
+++ b/es-core/src/anim/ThemeStoryboard.h
@@ -23,5 +23,5 @@ public:
 
 	std::vector<ThemeAnimation*> animations;
 
-	bool fromXmlNode(const pugi::xml_node& root, const std::map<std::string, ThemeData::ElementPropertyType>& typeMap);
+	bool fromXmlNode(const pugi::xml_node& root, const std::map<std::string, ThemeData::ElementPropertyType>& typeMap, const std::string& relativePath);
 };


### PR DESCRIPTION
Warning : if you set sound to multiple controls ( `<control name="md_description, md_name [...]">` ) it will be played for every control at the same time... -> So use it on one control only !

```
    <control name="md_description">
      <storyboard>
        <sound path="./../art/sounds/scroll.wav" at="1000"/> <!-- repeat, duration & autoreverse attributes are supported -->
      </storyboard>
    </control>
```