### PR TITLE
Add Manufacturer & Type Sort

### DIFF
--- a/es-app/src/guis/GuiCollectionSystemsOptions.cpp
+++ b/es-app/src/guis/GuiCollectionSystemsOptions.cpp
@@ -29,7 +29,7 @@ void GuiCollectionSystemsOptions::initializeMenu()
 	auto hiddenSystems = Utils::String::split(Settings::getInstance()->getString("HiddenSystems"), ';');
 	auto displayedSystems = std::make_shared<OptionListComponent<SystemData*>>(mWindow, _("SYSTEMS DISPLAYED"), true);
 
-	if (SystemData::IsManufacturerSupported && Settings::getInstance()->getString("SortSystems") == "manufacturer")
+	if (SystemData::IsManufacturerSupported && (Settings::getInstance()->getString("SortSystems") == "manufacturer" || Settings::getInstance()->getString("SortSystems") == "subgroup"))
 	{
 		std::string man;
 		for (auto system : SystemData::sSystemVector)
@@ -222,6 +222,7 @@ void GuiCollectionSystemsOptions::initializeMenu()
 	{
 		sortType->add(_("BY MANUFACTURER"), "manufacturer", sortMode == "manufacturer");
 		sortType->add(_("BY HARDWARE TYPE"), "hardware", sortMode == "hardware");
+		sortType->add(_("BY MANUFACTURER AND TYPE"), "subgroup", sortMode == "subgroup");
 		sortType->add(_("BY RELEASE YEAR"), "releaseDate", sortMode == "releaseDate");
 	}
 
@@ -242,7 +243,7 @@ void GuiCollectionSystemsOptions::initializeMenu()
 	systemfocus_list->add(_("NONE"), "", startupSystem == "");
 	systemfocus_list->add(_("RESTORE LAST SELECTED"), "lastsystem", startupSystem == "lastsystem");
 
-	if (SystemData::IsManufacturerSupported && Settings::getInstance()->getString("SortSystems") == "manufacturer")
+	if (SystemData::IsManufacturerSupported && (Settings::getInstance()->getString("SortSystems") == "manufacturer" || Settings::getInstance()->getString("SortSystems") == "subgroup"))
 	{
 		std::string man;
 		for (auto system : SystemData::sSystemVector)

--- a/es-app/src/views/SystemView.cpp
+++ b/es-app/src/views/SystemView.cpp
@@ -576,7 +576,7 @@ bool SystemView::showNavigationBar()
 		showNavigationBar(_("GO TO LETTER"), [](SystemData* meta) { if (meta->isCollection()) return _("COLLECTIONS"); return Utils::String::toUpper(meta->getSystemMetadata().fullName.substr(0, 1)); });
 		return true;
 	}
-	else if (sortMode == "manufacturer")
+	else if (sortMode == "manufacturer" || sortMode == "subgroup")
 	{
 		showNavigationBar(_("GO TO MANUFACTURER"), [](SystemData* meta) { return meta->getSystemMetadata().manufacturer; });
 		return true;


### PR DESCRIPTION
This adds an additional sort type to the Systems list, tentatively "Manufacturer and Type," internally "subgroup."

The sort method is different than Sort by Manufacturer in that within the manufacturer's systems they get sorted by type before year. So for example, Nintendo will list all their consoles from NES to Wii U, then handhelds from Game & Watch to 3DS. Sega will list their arcade systems, then consoles, then the Game Gear. Atari is consoles, then computers, then the Lynx.

It was requested on the Batocera Discord, and it does make logical sense as a sort method as it keeps similar systems grouped together. The one outlier in Batocera is that Windows is tagged as "pc" rather than "computer," so Microsoft will go MSX - XBox - Windows. If this gets merged, I'll re-tag it as computer.