### PR TITLE
Fix RetroAchievements for Arduboy and WASM4

### DIFF
--- a/es-app/src/SystemData.cpp
+++ b/es-app/src/SystemData.cpp
@@ -1617,7 +1617,7 @@ bool SystemData::isCheevosSupported()
 				"atarilynx", "lynx", "ngp", "gamegear", "pokemini", "atari2600", "fbneo", "fbn", "virtualboy", "pcfx", "tg16", "famicom", "msx1",
 				"psx", "sg-1000", "sg1000", "coleco", "colecovision", "atari7800", "wonderswan", "pc88", "saturn", "3do", "apple2", "neogeo", "arcade", "mame",
 				"nds", "arcade", "megadrive-japan", "pcenginecd", "supergrafx", "supervision", "snes-msu1", "amstradcpc",
-				"dreamcast", "psp", "jaguar", "intellivision", "vectrex" };
+				"dreamcast", "psp", "jaguar", "intellivision", "vectrex", "megaduck", "arduboy", "wasm4" };
 
 			if (cheevosSystems.find(getName()) != cheevosSystems.cend())
 				mIsCheevosSupported = 1;

--- a/es-core/src/components/BatteryIndicatorComponent.cpp
+++ b/es-core/src/components/BatteryIndicatorComponent.cpp
@@ -46,9 +46,6 @@ void BatteryIndicatorComponent::init()
 	if (ResourceManager::getInstance()->fileExists(":/battery/empty.svg"))
 		mEmpty = ResourceManager::getInstance()->getResourcePath(":/battery/empty.svg");	
 
-	if (ResourceManager::getInstance()->fileExists(":/battery/empty.svg"))
-		mEmpty = ResourceManager::getInstance()->getResourcePath(":/battery/empty.svg");
-
 	if (ResourceManager::getInstance()->fileExists(":/network.svg"))
 	{
 		mView |= ActivityView::NETWORK;


### PR DESCRIPTION
- Fix RetroAchievements indexing for Arduboy and WASM4
- For the future, add RetroAchievements for Megaduck
- Tiny fix (duplicate lines on empty battery icon)