### PR TITLE
modified es-app/src/FileData.cpp and es-app/src/SystemData.cpp

### DIFF
--- a/es-app/src/FileData.cpp
+++ b/es-app/src/FileData.cpp
@@ -1733,12 +1733,15 @@ std::string FileData::getProperty(const std::string& name)
 		if (seconds == 0)
 			return "";
 		
-		int h = 0, m = 0, s = 0;
+		int d = 0, h = 0, m = 0, s = 0;
+		d = seconds / 86400;
 		h = (seconds / 3600) % 24;
 		m = (seconds / 60) % 60;
 		s = seconds % 60;
-
-		if (h > 0)
+		
+		if (d > 0)
+			return Utils::String::format("%02d %02d:%02d:%02d", d, h, m, s);
+		else if (h > 0)
 			return Utils::String::format("%02d:%02d:%02d", h, m, s);
 
 		return Utils::String::format("%02d:%02d", m, s);		

--- a/es-app/src/SystemData.cpp
+++ b/es-app/src/SystemData.cpp
@@ -2045,13 +2045,16 @@ std::string SystemData::getProperty(const std::string& name)
 	{
 		auto seconds = info->playTime;
 
-		int h = 0, m = 0, s = 0;
+		int d = 0, h = 0, m = 0, s = 0;
+		d = seconds / 86400;
 		h = (seconds / 3600) % 24;
 		m = (seconds / 60) % 60;
 		s = seconds % 60;
 
 		std::string timeText;
-		if (h > 0)
+		if (d > 0)
+			timeText = Utils::String::format("%02d:%02d:%02d:%02d", d, h, m, s);
+		else if (h > 0)
 			timeText = Utils::String::format("%02d:%02d:%02d", h, m, s);
 		else
 			timeText = Utils::String::format("%02d:%02d", m, s);

--- a/es-core/src/utils/TimeUtil.cpp
+++ b/es-core/src/utils/TimeUtil.cpp
@@ -318,11 +318,27 @@ namespace Utils
 
 			char buf[256];
 
-			int h = 0, m = 0, s = 0;
+			int d =0, h = 0, m = 0, s = 0;
+			d = seconds / 86400;
 			h = (seconds / 3600) % 24;
 			m = (seconds / 60) % 60;
 			s = seconds % 60;
-			
+			if (d > 0)
+			{
+				snprintf(buf, 256, _("%d d").c_str(), d);
+				if (h > 0)
+				{
+					std::string days(buf);
+					snprintf(buf, 256, _("%d h").c_str(), h);
+					if(m > 0)
+					{
+						std::string hours(buf);
+						snprintf(buf, 256, _("%d mn").c_str(), m);
+						return days + " " + hours + " " + std::string(buf);
+					}
+					return days + " " + std::string(buf);
+				}
+			}
 			if (h > 0)
 			{
 				snprintf(buf, 256, _("%d h").c_str(), h);


### PR DESCRIPTION
modified es-app/src/FileData.cpp and es-app/src/SystemData.cpp
to include a resolve for the gametime metadata ticking over 24 hours.

Following on from the issue I raised here, https://github.com/batocera-linux/batocera-emulationstation/issues/1357