### PR TITLE
[HFSDB] Abandon manual search if the server's reponse is 429, if delay to wait is > 5 seconds

### DIFF
--- a/es-app/src/components/ScraperSearchComponent.cpp
+++ b/es-app/src/components/ScraperSearchComponent.cpp
@@ -254,7 +254,8 @@ void ScraperSearchComponent::search(const ScraperSearchParams& params)
 			ScraperSearch* ss = new ScraperSearch();
 			ss->name = scraperName;
 			ss->params = params;
-			ss->searchHandle = scraper->search(params);
+			ss->params.isManualScrape = true;
+			ss->searchHandle = scraper->search(ss->params);
 			mScrapEngines.push_back(ss);
 		}
 	}

--- a/es-app/src/scrapers/HfsDBScraper.cpp
+++ b/es-app/src/scrapers/HfsDBScraper.cpp
@@ -258,7 +258,7 @@ void HfsDBScraper::generateRequests(const ScraperSearchParams& params, std::queu
 	tokenAuth.customHeaders.push_back("Authorization: Token " + mToken);
 	
 	for (auto url : urls)
-		requests.push(std::unique_ptr<ScraperRequest>(new HfsDBRequest(results, url, &tokenAuth, params.system->hasPlatformId(PlatformIds::ARCADE))));
+		requests.push(std::unique_ptr<ScraperRequest>(new HfsDBRequest(results, url, &tokenAuth, params.system->hasPlatformId(PlatformIds::ARCADE), params.isManualScrape)));
 }
 
 bool HfsDBScraper::isSupportedPlatform(SystemData* system)

--- a/es-app/src/scrapers/HfsDBScraper.h
+++ b/es-app/src/scrapers/HfsDBScraper.h
@@ -33,25 +33,28 @@ class HfsDBRequest : public ScraperHttpRequest
 {
   public:
 	// ctor for a GetGameList request
-	HfsDBRequest(std::queue<std::unique_ptr<ScraperRequest>>& requestsWrite, std::vector<ScraperSearchResult>& resultsWrite, const std::string& url, HttpReqOptions* options, bool isArcade)
+	HfsDBRequest(std::queue<std::unique_ptr<ScraperRequest>>& requestsWrite, std::vector<ScraperSearchResult>& resultsWrite, const std::string& url, HttpReqOptions* options, bool isArcade, bool isManualScrape)
 		: ScraperHttpRequest(resultsWrite, url, options), mRequestQueue(&requestsWrite)
 	{
+		  mIsManualScrape = isManualScrape;
 		  mIsArcade = isArcade;
 	}
 
 	// ctor for a GetGame request
-	HfsDBRequest(std::vector<ScraperSearchResult>& resultsWrite, const std::string& url, HttpReqOptions* options, bool isArcade)
+	HfsDBRequest(std::vector<ScraperSearchResult>& resultsWrite, const std::string& url, HttpReqOptions* options, bool isArcade, bool isManualScrape)
 		: ScraperHttpRequest(resultsWrite, url, options), mRequestQueue(nullptr)
 	{		
+		  mIsManualScrape = isManualScrape;
 		  mIsArcade = isArcade;
 	}
 
-	virtual bool retryOn249() { return false; }
+	virtual bool retryOn249() { return !mIsManualScrape; }
 
   protected:
 	bool process(HttpReq* request, std::vector<ScraperSearchResult>& results) override;
 	bool isGameRequest() { return !mRequestQueue; }
 
+	bool mIsManualScrape;
 	bool mIsArcade;
 	std::queue<std::unique_ptr<ScraperRequest>>* mRequestQueue;
 };

--- a/es-app/src/scrapers/Scraper.h
+++ b/es-app/src/scrapers/Scraper.h
@@ -22,11 +22,13 @@ struct ScraperSearchParams
 	ScraperSearchParams()
 	{ 
 		overWriteMedias = true; 
+		isManualScrape = false;
 	}
 
 	SystemData* system;
 	FileData* game;
 
+	bool isManualScrape;
 	bool overWriteMedias;
 	std::string nameOverride;
 


### PR DESCRIPTION
With HFSDB, as we can perform only 2 request per minute, abandon search if the server's reponse is 429, if delay to wait is > 5 seconds when scrapping manually. If we don't do that, the screen can remain open 1 minute without doing anything