### PR TITLE
[Win32 only] Update controllers battery levels using new SDL_JOYBATTERYUPDATED event

### DIFF
--- a/es-app/src/NetworkThread.cpp
+++ b/es-app/src/NetworkThread.cpp
@@ -5,6 +5,7 @@
 #include "LocaleES.h"
 #include "Log.h"
 #include <chrono>
+#include <SDL.h>
 
 #define CHECKUPDATE_MINUTES 60
 
@@ -46,6 +47,16 @@ NetworkThread::~NetworkThread()
 
 void NetworkThread::checkPadsBatteryLevel()
 {
+#if WIN32
+	SDL_version ver;
+	SDL_GetVersion(&ver);
+	if (ver.major >= 2 && ver.minor >= 24)
+	{
+		// use SDL_JOYBATTERYUPDATED event instead starting with SDL 2.24+
+		return;
+	}
+#endif
+
 	if (!ApiSystem::getInstance()->isScriptingSupported(ApiSystem::PADSINFO))
 		return;
 

--- a/es-app/src/Win32ApiSystem.cpp
+++ b/es-app/src/Win32ApiSystem.cpp
@@ -13,6 +13,7 @@
 #include <thread>
 #include <direct.h>
 #include <algorithm>
+#include <SDL.h>
 #include "LocaleES.h"
 #include "Paths.h"
 #include "utils/VectorEx.h"
@@ -120,7 +121,17 @@ bool Win32ApiSystem::isScriptingSupported(ScriptId script)
 		executables.push_back("emulatorLauncher");
 		break;
 	case ApiSystem::PADSINFO:
-		executables.push_back("batocera-padsinfo");
+		{
+			SDL_version ver;
+			SDL_GetVersion(&ver);
+			if (ver.major >= 2 && ver.minor >= 24)
+			{
+				// PADSINFO is managed with SDL_JOYBATTERYUPDATED event starting with SDL 2.24+
+				return true;
+			}
+			else
+				executables.push_back("batocera-padsinfo");
+		}
 		break;
 	case ApiSystem::UPGRADE:
 		return true;


### PR DESCRIPTION
When SDL2.dll is at least 2.24 - instead of "batocera-padsinfo" script