### PR TITLE
[Suggestion] defining MetaDataId::Max

### DIFF
--- a/es-app/src/MetaData.cpp
+++ b/es-app/src/MetaData.cpp
@@ -103,7 +103,7 @@ void MetaDataList::initMetadata()
 	for (int i = 0 ; i < mMetaDataDecls.size() ; i++)
 		mMetaDataIndexes[mMetaDataDecls[i].id] = i;
 
-	int maxID = mMetaDataDecls.size() + 1;
+	int maxID = MetaDataId::Max;
 
 	if (mDefaultGameMap != nullptr) 
 		delete[] mDefaultGameMap;

--- a/es-app/src/MetaData.h
+++ b/es-app/src/MetaData.h
@@ -75,7 +75,8 @@ enum MetaDataId
 	Magazine = 38,
 	GenreIds = 39,
 	Family = 40,
-	Bezel = 41
+	Bezel = 41,
+	Max
 };
 
 namespace MetaDataImportType


### PR DESCRIPTION
array size of m***Map in MetaData.cpp must be MetaDataId count.
but maxID in MetaDataList::initMetadata() is not means the count.
in the future, it makes crash, maybe.

(by the way, my custom ES have some extra MetaDataIds was crashed)
