### PR TITLE
[Suggestion] web frontend can look ES capability

### DIFF
--- a/es-app/src/services/HttpApi.cpp
+++ b/es-app/src/services/HttpApi.cpp
@@ -317,3 +317,23 @@ std::string HttpApi::getRunnningGameInfo()
 	return ToJson(file);
 }
 
+std::string HttpApi::getCaps()
+{
+	rapidjson::StringBuffer s;
+	rapidjson::PrettyWriter<rapidjson::StringBuffer> writer(s);
+
+	writer.StartObject();
+
+	writer.Key("Version"); writer.String(ApiSystem::getInstance()->getVersion().c_str());
+
+	// MetaDataId::SortName is disabled in this EmulationStation 
+	writer.Key("SortName"); writer.Bool(false);
+
+	//	:
+	// add capability info for web client 
+	//	:
+
+	writer.EndObject();
+
+	return s.GetString();
+}

--- a/es-app/src/services/HttpApi.cpp
+++ b/es-app/src/services/HttpApi.cpp
@@ -5,6 +5,7 @@
 #endif
 
 #include "platform.h"
+#include "ApiSystem.h"
 #include "Gamelist.h"
 #include "SystemData.h"
 #include "FileData.h"

--- a/es-app/src/services/HttpApi.h
+++ b/es-app/src/services/HttpApi.h
@@ -12,6 +12,7 @@ class FileData;
 class HttpApi
 {
 public:
+	static std::string getCaps();
 	static std::string getSystemList();
 	static std::string getSystemGames(SystemData* system);
 

--- a/es-app/src/services/HttpServerThread.cpp
+++ b/es-app/src/services/HttpServerThread.cpp
@@ -29,6 +29,7 @@
 
 Misc APIS
 -----------------
+GET  /caps                                                      -> capability info
 GET  /restart
 GET  /quit
 GET  /emukill
@@ -248,6 +249,14 @@ void HttpServerThread::run()
 			return;
 
 		ApiSystem::getInstance()->emuKill();
+	});
+
+	mHttpServer->Get("/caps", [](const httplib::Request& req, httplib::Response& res)
+	{
+		if (!isAllowed(req, res))
+			return;
+
+		res.set_content(HttpApi::getCaps(), "application/json");
 	});
 
 	mHttpServer->Get("/systems", [](const httplib::Request& req, httplib::Response& res)


### PR DESCRIPTION
add web API /caps
returns ES capability info in JSON

frontend can understand (customised) ES features
and switch correctly.
