### PR TITLE
Adding Namco 2x6 gun games

### DIFF
--- a/resources/gungames.xml
+++ b/resources/gungames.xml
@@ -124,6 +124,12 @@
     <game>maddogii</game>
     <game>whoshotjohnnyrock</game> 
   </system>
+  <system name="namco2x6">
+    <game>cobra</game>
+    <game>timecrisis3</game>
+    <game>timecrisis4</game>
+    <game>vampirenight</game>
+  </system>
   <system name="nes">
     <game>3in1supergun</game>
     <game>babyboomer</game>


### PR DESCRIPTION
They work with Play! emulator in a separate collection named `namco2x6` (tested on v38 butterfly). The scraper doesn't work for that collection at the moment. But this is futureproof. Merge once the scraper works with the Namco 2x6 collection.