### PR TITLE
Logarithmic calculation for music volume

### DIFF
--- a/es-core/src/AudioManager.cpp
+++ b/es-core/src/AudioManager.cpp
@@ -549,7 +549,9 @@ void AudioManager::setVideoPlaying(bool state)
 
 int AudioManager::getMaxMusicVolume()
 {
-	int ret = (Settings::getInstance()->getInt("MusicVolume") * MIX_MAX_VOLUME) / 100;
+	int linearVolume = Settings::getInstance()->getInt("MusicVolume");
+	double logarithmicVolume = (linearVolume == 0) ? 0 : std::pow(10.0, (linearVolume - 100) / 20.0) * MIX_MAX_VOLUME;
+	int ret = static_cast<int>(logarithmicVolume);
 	if (ret > MIX_MAX_VOLUME)
 		return MIX_MAX_VOLUME;
 


### PR DESCRIPTION
Calculation for changing the music volume slider scale from LINEAR to LOGARITHMIC. 

Human hearing works on a logarithmic scale, so for example, 50% of perceived volume reduction in a numeric percentage would be roughly 66-67% of 100 on the music volume slider. I believe this is how the master volume slider works currently.

Currently the master slider and the volume slider's do NOT scale volume in the same manner. This should resolve that.