### PR TITLE
Make "a" (EAST) button skippable in controller config gui

### DIFF
--- a/es-core/src/guis/GuiInputConfig.cpp
+++ b/es-core/src/guis/GuiInputConfig.cpp
@@ -48,7 +48,7 @@ void GuiInputConfig::initInputConfigStructure()
 {
 	GUI_INPUT_CONFIG_LIST =
 	{
-		{ "a",                false, InputConfig::buttonDisplayName("a"),    InputConfig::buttonImage("a") },
+		{ "a",                true,  InputConfig::buttonDisplayName("a"),    InputConfig::buttonImage("a") },
 		{ "b",                true,  InputConfig::buttonDisplayName("b"),    InputConfig::buttonImage("b") },
 		{ "x",                true,  "NORTH",              ":/help/buttons_north.svg" },
 		{ "y",                true,  "WEST",               ":/help/buttons_west.svg" },


### PR DESCRIPTION
Currently, the EAST button is not skippable in the controller config gui.  This leads to an awkward and unpleasant user experience when configuring minimal controllers with few buttons.  In these situations, as a user, I want to be able to skip a mapping for EAST and provide a mapping for SOUTH.
