### PR TITLE
Select running board as default installation target

### DIFF
--- a/es-app/src/ApiSystem.cpp
+++ b/es-app/src/ApiSystem.cpp
@@ -1961,6 +1961,15 @@ std::string ApiSystem::getRunningArchitecture()
 	return "";
 }
 
+std::string ApiSystem::getRunningBoard()
+{
+	auto res = executeEnumerationScript("cat /boot/boot/batocera.board");
+	if (res.size() > 0)
+		return res[0];
+
+	return "";
+}
+
 std::string ApiSystem::getHostsName()
 {
 	auto hostName = SystemConf::getInstance()->get("system.hostname");

--- a/es-app/src/ApiSystem.h
+++ b/es-app/src/ApiSystem.h
@@ -228,6 +228,7 @@ public:
 	virtual std::vector<std::string> extractPdfImages(const std::string& fileName, int pageIndex = -1, int pageCount = 1, int quality = 0);
 
 	virtual std::string getRunningArchitecture();
+	virtual std::string getRunningBoard();
 
 	std::vector<PacmanPackage> getBatoceraStorePackages();
 	std::pair<std::string, int> installBatoceraStorePackage(std::string name, const std::function<void(const std::string)>& func = nullptr);

--- a/es-app/src/guis/GuiInstallStart.cpp
+++ b/es-app/src/guis/GuiInstallStart.cpp
@@ -16,6 +16,7 @@ mMenu(window, _("INSTALL ON A NEW DISK").c_str())
 
 	std::vector<std::string> availableStorage = ApiSystem::getInstance()->getAvailableInstallDevices();
 	std::vector<std::string> availableArchitecture = ApiSystem::getInstance()->getAvailableInstallArchitectures();
+	std::string runningBoard = ApiSystem::getInstance()->getRunningBoard();
 
 	bool installationPossible = (availableArchitecture.size() != 0);
 
@@ -44,11 +45,13 @@ mMenu(window, _("INSTALL ON A NEW DISK").c_str())
 	
 		// available install architecture
 		moptionsArchitecture = std::make_shared<OptionListComponent<std::string> >(window, _("TARGET ARCHITECTURE"), false);
-		moptionsArchitecture->add(_("SELECT"), "", true);
+		moptionsArchitecture->add(_("SELECT"), "", false);
 
 		for (auto it = availableArchitecture.begin(); it != availableArchitecture.end(); it++)
-			moptionsArchitecture->add((*it), (*it), false);
-		
+			moptionsArchitecture->add(*it, *it, *it == runningBoard);
+		if (!(moptionsArchitecture->hasSelection()))
+			moptionsArchitecture->selectFirstItem();
+
 		mMenu.addWithLabel(_("TARGET ARCHITECTURE"), moptionsArchitecture);
 
 		moptionsValidation = std::make_shared<SwitchComponent>(mWindow);


### PR DESCRIPTION
    A common source of user error when using the "INSTALL ON A NEW DISK"
    feature is that the user guesses their architecture incorrectly.

    With this change, if an installation architecture matches the
    currently running board, it will be selected as default.

    If no match is found, the previous behavior is retained.
