### PR TITLE
[TextComponent] Fix Y AutoCalcExtent when TextComponent is MultiLineType::SINGLELINE

### DIFF
--- a/es-core/src/components/MultiLineMenuEntry.cpp
+++ b/es-core/src/components/MultiLineMenuEntry.cpp
@@ -15,6 +15,7 @@ MultiLineMenuEntry::MultiLineMenuEntry(Window* window, const std::string& text, 
 	auto theme = ThemeData::getMenuTheme();
 
 	mText = std::make_shared<TextComponent>(mWindow, text.c_str(), theme->Text.font, theme->Text.color);
+	mText->setMultiLine(TextComponent::MultiLineType::SINGLELINE);
 	mText->setVerticalAlignment(ALIGN_TOP);
 
 	mSubstring = std::make_shared<TextComponent>(mWindow, substring.c_str(), theme->TextSmall.font, theme->Text.color);		

--- a/es-core/src/components/TextComponent.cpp
+++ b/es-core/src/components/TextComponent.cpp
@@ -274,8 +274,13 @@ void TextComponent::onTextChanged()
 		mSize = mFont->sizeText(text, mLineSpacing);
 		mSize[0] += mPadding.x() + mPadding.z();
 	}
-	else if(mAutoCalcExtent.y())
-		mSize[1] = mFont->sizeWrappedText(mUppercase ? Utils::String::toUpper(mText) : mText, getSize().x(), mLineSpacing).y() + mPadding.y() + mPadding.w();
+	else if (mAutoCalcExtent.y())
+	{
+		if (mMultiline == MultiLineType::SINGLELINE)
+			mSize[1] = mFont->getHeight() + mPadding.y() + mPadding.w();
+		else
+			mSize[1] = mFont->sizeWrappedText(mUppercase ? Utils::String::toUpper(mText) : mText, getSize().x(), mLineSpacing).y() + mPadding.y() + mPadding.w();
+	}
 }
 
 void TextComponent::buildTextCache()


### PR DESCRIPTION
[MultilineMenuEntry] Set main text as singleline