### PR TITLE
Fix crash at init when run outside of Batocera

### DIFF
--- a/es-core/src/InputManager.cpp
+++ b/es-core/src/InputManager.cpp
@@ -75,10 +75,10 @@ void InputManager::init()
 	if (initialized())
 		deinit();
 
-	rebuildAllJoysticks(false);
-
 	mKeyboardInputConfig = new InputConfig(DEVICE_KEYBOARD, -1, "Keyboard", KEYBOARD_GUID_STRING, 0, 0, 0); 
 	loadInputConfig(mKeyboardInputConfig);
+
+  rebuildAllJoysticks(false);
 
 #ifdef HAVE_LIBCEC
 	SDL_USER_CECBUTTONDOWN = SDL_RegisterEvents(2);


### PR DESCRIPTION
When starting Emulationstation with a gamepad connected and outside of Batocera this code is run: https://github.com/batocera-linux/batocera-emulationstation/blob/master/es-core/src/InputManager.cpp#L419

This will crash because `rebuildAllJoysticks` is called in [`::init`](https://github.com/batocera-linux/batocera-emulationstation/blob/master/es-core/src/InputManager.cpp#L78) before the keyboard is initialized and the called to `initialized` in [`writeDeviceConfig`](https://github.com/batocera-linux/batocera-emulationstation/blob/master/es-core/src/InputManager.cpp#L925) [checks that it is initialized](https://github.com/batocera-linux/batocera-emulationstation/blob/master/es-core/src/InputManager.cpp#L1044).