### PR TITLE
[WatchersManager] Use a unified thread to perform all watches 

### DIFF
--- a/es-app/src/ApiSystem.cpp
+++ b/es-app/src/ApiSystem.cpp
@@ -1476,7 +1476,8 @@ bool ApiSystem::isScriptingSupported(ScriptId script)
 	case ApiSystem::VERSIONINFO:
 		executables.push_back("batocera-version");
 		break;
-	case ApiSystem::PLANEMODE:
+	case ApiSystem::READPLANEMODE:
+	case ApiSystem::WRITEPLANEMODE:
 		executables.push_back("batocera-planemode");
 		break;
 	case ApiSystem::SERVICES:
@@ -2007,6 +2008,11 @@ bool ApiSystem::isPlaneMode()
 		return res[0] == "on";
 
 	return false;
+}
+
+bool ApiSystem::isReadPlaneModeSupported()
+{
+	return isScriptingSupported(READPLANEMODE);
 }
 
 bool ApiSystem::setPlaneMode(bool enable)

--- a/es-app/src/ApiSystem.h
+++ b/es-app/src/ApiSystem.h
@@ -120,9 +120,10 @@ public:
 		UPGRADE = 24,
 		SUSPEND = 25,
 		VERSIONINFO = 26,
-		PLANEMODE = 27,
-		VIDEOFILTERS = 28,
-		SERVICES = 29
+		VIDEOFILTERS = 27,
+		SERVICES = 28,
+		READPLANEMODE = 29,
+		WRITEPLANEMODE = 30,
 	};
 
 	virtual bool isScriptingSupported(ScriptId script);
@@ -265,14 +266,15 @@ public:
 	virtual void suspend();
 
   	virtual void replugControllers_sindenguns();
-    	virtual void replugControllers_wiimotes();
-    	virtual void replugControllers_steamdeckguns();
+    virtual void replugControllers_wiimotes();
+    virtual void replugControllers_steamdeckguns();
 
-    	virtual bool isPlaneMode();
-    	virtual bool setPlaneMode(bool enable);
+    virtual bool isPlaneMode();
+    virtual bool setPlaneMode(bool enable);
+	virtual bool isReadPlaneModeSupported();
 
-    	virtual std::vector<Service> getServices();
-    	virtual bool enableService(std::string name, bool enable);
+    virtual std::vector<Service> getServices();
+    virtual bool enableService(std::string name, bool enable);
 
 protected:
 	ApiSystem();

--- a/es-app/src/NetworkThread.cpp
+++ b/es-app/src/NetworkThread.cpp
@@ -91,6 +91,8 @@ bool CheckUpdatesComponent::check()
 	}
 	else
 		LOG(LogDebug) << "NetworkThread : No update found";
+
+	return false;
 }
 
 void NetworkThread::onJoystickChanged()

--- a/es-app/src/NetworkThread.h
+++ b/es-app/src/NetworkThread.h
@@ -4,31 +4,62 @@
 #include <thread>
 #include <condition_variable>
 #include <mutex>
+#include <list>
 
 #include "InputManager.h"
+#include "ApiSystem.h"
+#include "watchers/WatchersManager.h"
 
-class NetworkThread : public IJoystickChangedEvent
+class CheckPadsBatteryLevelComponent : public IWatcher
+{
+public:
+	CheckPadsBatteryLevelComponent();
+
+	std::vector<PadInfo>& getPadsInfo() { return mPadsInfo; }
+
+protected:
+	bool enabled() override { return mEnabled; };
+	int  updateTime() override { return 15 * 1000; } // 15 seconds
+
+	bool check() override;
+
+private:
+	std::vector<PadInfo> mPadsInfo;
+	bool mEnabled;
+};
+
+class CheckUpdatesComponent : public IWatcher
+{
+public:
+	CheckUpdatesComponent() { mEnabled = true; }
+
+	std::string& getLastUpdateMessage() { return mLastUpdateMessage; }
+
+protected:
+	bool enabled() override;
+	int  updateTime() override { return 60 * 60 * 1000; } // 60 minutes
+	bool check() override;
+
+private:
+	std::string mLastUpdateMessage;
+	bool mEnabled;
+};
+
+class NetworkThread : public IJoystickChangedEvent, public IWatcherNotify
 {
 public:
 	NetworkThread(Window * window);
-	virtual ~NetworkThread();
 
+public:
 	void onJoystickChanged() override;
 
 private:
-	void	checkPadsBatteryLevel();
+	void OnWatcherChanged(IWatcher* component) override;
 
-	Window*			mWindow;
-	bool			mRunning;
-	bool			mFirstRun;
-	std::thread*	mThread;
+	CheckPadsBatteryLevelComponent					mCheckPadsBatteryLevelComponent;
+	CheckUpdatesComponent							mCheckUpdatesComponent;
 
-	void run();
-
-	std::mutex					mLock;
-	std::condition_variable		mEvent;
-
-	int				mCheckUpdateTimer;
+	Window* mWindow;
 };
 
 

--- a/es-app/src/Win32ApiSystem.cpp
+++ b/es-app/src/Win32ApiSystem.cpp
@@ -146,8 +146,8 @@ bool Win32ApiSystem::isScriptingSupported(ScriptId script)
 	case ApiSystem::SERVICES:
 		executables.push_back("batocera-services");
 		break;
-	// case ApiSystem::PLANEMODE:
-		// return true;
+	 case ApiSystem::READPLANEMODE:
+		return true;	 
 	}
 
 	if (executables.size() == 0)

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -3486,7 +3486,7 @@ void GuiMenu::openQuitMenu_static(Window *window, bool quickAccessMenu, bool ani
 				}, "iconManual");
 		}
 
-		if (ApiSystem::getInstance()->isScriptingSupported(ApiSystem::PLANEMODE))
+		if (ApiSystem::getInstance()->isScriptingSupported(ApiSystem::WRITEPLANEMODE))
 		{
 			if (ApiSystem::getInstance()->isPlaneMode())
 			{

--- a/es-app/src/views/gamelist/DetailedContainer.cpp
+++ b/es-app/src/views/gamelist/DetailedContainer.cpp
@@ -463,6 +463,9 @@ void DetailedContainer::onThemeChanged(const std::shared_ptr<ThemeData>& theme)
 	loadIfThemed(&mNoMap, theme, "md_nomap", false, true);
 	loadIfThemed(&mSaveState, theme, "md_savestate", false, true);
 	loadIfThemed(&mNoSaveState, theme, "md_nosavestate", false, true);		
+	
+	for (auto comp : getComponents())
+		disableComponent(comp);
 
 	for (auto ctrl : getMetaComponents())
 	{
@@ -1153,6 +1156,9 @@ bool DetailedContainer::anyComponentHasStoryBoard()
 
 void DetailedContainer::disableComponent(GuiComponent* comp)
 {
+	if (comp == nullptr)
+		return;
+
 	if (mVideo == comp) { mVideo->setImage(""); mVideo->setVideo(""); }
 	if (mImage == comp) mImage->setImage("");
 	if (mThumbnail == comp) mThumbnail->setImage("");

--- a/es-core/CMakeLists.txt
+++ b/es-core/CMakeLists.txt
@@ -1,6 +1,6 @@
 project("core")
 
-set(CORE_HEADERS
+set(CORE_HEADERS	
 	${CMAKE_CURRENT_SOURCE_DIR}/src/AsyncHandle.h
 	${CMAKE_CURRENT_SOURCE_DIR}/src/AudioManager.h
 	${CMAKE_CURRENT_SOURCE_DIR}/src/CECInput.h
@@ -126,9 +126,14 @@ set(CORE_HEADERS
 	${CMAKE_CURRENT_SOURCE_DIR}/src/utils/Randomizer.h
 	${CMAKE_CURRENT_SOURCE_DIR}/src/utils/VectorEx.h
 	${CMAKE_CURRENT_SOURCE_DIR}/src/utils/HtmlColor.h
+
+	# Watchers
+	${CMAKE_CURRENT_SOURCE_DIR}/src/watchers/WatchersManager.h
+	${CMAKE_CURRENT_SOURCE_DIR}/src/watchers/BatteryLevelWatcher.h
+	${CMAKE_CURRENT_SOURCE_DIR}/src/watchers/NetworkStateWatcher.h
 )
 
-set(CORE_SOURCES
+set(CORE_SOURCES	
 	${CMAKE_CURRENT_SOURCE_DIR}/src/AudioManager.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/CECInput.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/GuiComponent.cpp
@@ -245,6 +250,11 @@ set(CORE_SOURCES
 	${CMAKE_CURRENT_SOURCE_DIR}/src/utils/md5.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/utils/Randomizer.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/utils/HtmlColor.cpp
+
+	# Watchers
+	${CMAKE_CURRENT_SOURCE_DIR}/src/watchers/WatchersManager.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/src/watchers/BatteryLevelWatcher.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/src/watchers/NetworkStateWatcher.cpp
 )
 
 # Keep Directory structure in Visual Studio

--- a/es-core/src/Window.cpp
+++ b/es-core/src/Window.cpp
@@ -779,7 +779,7 @@ void Window::render()
 
 	// Render guns aims
 	auto guns = InputManager::getInstance()->getGuns();
-	if (guns.size())
+	if (!mRenderScreenSaver && guns.size())
 	{
 		auto margin = Renderer::setScreenMargin(0, 0);
 		Renderer::setMatrix(Transform4x4f::Identity());

--- a/es-core/src/components/BatteryIconComponent.h
+++ b/es-core/src/components/BatteryIconComponent.h
@@ -6,22 +6,26 @@
 #include "GuiComponent.h"
 #include "components/ImageComponent.h"
 #include "utils/Platform.h"
+#include "watchers/WatchersManager.h"
 
 class Window;
 
-class BatteryIconComponent : public ImageComponent
+class BatteryIconComponent : public ImageComponent, IWatcherNotify
 {
 public:
 	BatteryIconComponent(Window* window);
+	~BatteryIconComponent();
 
 	std::string getThemeTypeName() override { return "batteryIcon"; }
 
 	void update(int deltaTime) override;
 	void applyTheme(const std::shared_ptr<ThemeData>& theme, const std::string& view, const std::string& element, unsigned int properties) override;
 
+	void OnWatcherChanged(IWatcher* component) override;
+
 private:
-	int mBatteryInfoCheckTime;
 	Utils::Platform::BatteryInformation mBatteryInfo;
+	bool mDirty;
 
 	std::string mIncharge;
 	std::string mFull;

--- a/es-core/src/components/BatteryTextComponent.cpp
+++ b/es-core/src/components/BatteryTextComponent.cpp
@@ -1,44 +1,64 @@
 #include "components/BatteryTextComponent.h"
 #include "Settings.h"
 #include <time.h>
+#include "watchers/BatteryLevelWatcher.h"
 
 #define UPDATE_NETWORK_DELAY	2000
 
-BatteryTextComponent::BatteryTextComponent(Window* window) : TextComponent(window)
-{	
-	mBatteryInfoCheckTime = UPDATE_NETWORK_DELAY;
+BatteryTextComponent::BatteryTextComponent(Window* window) : TextComponent(window), mDirty(true)
+{		
 	mBatteryInfo = Utils::Platform::BatteryInformation();
+
+	WatchersManager::getInstance()->RegisterNotify(this);
+
+	BatteryLevelWatcher* watcher = WatchersManager::GetComponent<BatteryLevelWatcher>();
+	if (watcher != nullptr)
+		mBatteryInfo = watcher->getBatteryInfo();
+}
+
+BatteryTextComponent::~BatteryTextComponent()
+{
+	WatchersManager::getInstance()->UnregisterNotify(this);
+}
+
+void BatteryTextComponent::OnWatcherChanged(IWatcher* component)
+{
+	BatteryLevelWatcher* watcher = dynamic_cast<BatteryLevelWatcher*>(component);
+	if (watcher != nullptr)
+	{
+		mBatteryInfo = watcher->getBatteryInfo();
+		mDirty = true;
+	}
 }
 
 void BatteryTextComponent::update(int deltaTime)
 {
 	TextComponent::update(deltaTime);
+		
+	if (!mDirty)
+		return;
 	
-	mBatteryInfoCheckTime += deltaTime;
-	if (mBatteryInfoCheckTime >= UPDATE_NETWORK_DELAY)
+	if (Settings::getInstance()->getString("ShowBattery") != "text")
+		mBatteryInfo.hasBattery = false;
+	else 
+		mBatteryInfo = Utils::Platform::queryBatteryInformation();
+
+	setVisible(mBatteryInfo.hasBattery && mBatteryInfo.level >= 0);
+
+	auto batteryText = std::to_string(mBatteryInfo.level) + "%";
+
+	float sx = mSize.x();
+
+	mAutoCalcExtent.x() = 1;
+
+	setText(batteryText);
+
+	if (mSize.x() != sx)
 	{
-		if (Settings::getInstance()->getString("ShowBattery") != "text")
-			mBatteryInfo.hasBattery = false;
-		else 
-			mBatteryInfo = Utils::Platform::queryBatteryInformation();
-
-		setVisible(mBatteryInfo.hasBattery && mBatteryInfo.level >= 0);
-
-		auto batteryText = std::to_string(mBatteryInfo.level) + "%";
-
-		float sx = mSize.x();
-
-		mAutoCalcExtent.x() = 1;
-
-		setText(batteryText);
-
-		if (mSize.x() != sx)
-		{
-			auto sz = mSize;
-			mSize.x() = sx;
-			setSize(sz);
-		}
-
-		mBatteryInfoCheckTime = 0;
+		auto sz = mSize;
+		mSize.x() = sx;
+		setSize(sz);
 	}
+
+	mDirty = false;
 }

--- a/es-core/src/components/BatteryTextComponent.h
+++ b/es-core/src/components/BatteryTextComponent.h
@@ -6,21 +6,25 @@
 #include "GuiComponent.h"
 #include "components/TextComponent.h"
 #include "utils/Platform.h"
+#include "watchers/WatchersManager.h"
 
 class Window;
 
-class BatteryTextComponent : public TextComponent
+class BatteryTextComponent : public TextComponent, IWatcherNotify
 {
 public:
 	BatteryTextComponent(Window* window);
+	~BatteryTextComponent();
 
 	std::string getThemeTypeName() override { return "batteryText"; }
 
 	virtual void update(int deltaTime);
 
+	void OnWatcherChanged(IWatcher* component) override;
+
 private:
-	int mBatteryInfoCheckTime;
 	Utils::Platform::BatteryInformation mBatteryInfo;
+	bool mDirty;
 };
 
 #endif // ES_CORE_COMPONENTS_BATTTEXT_COMPONENT_H

--- a/es-core/src/components/ControllerActivityComponent.h
+++ b/es-core/src/components/ControllerActivityComponent.h
@@ -6,10 +6,11 @@
 #include "GuiComponent.h"
 #include "resources/Font.h"
 #include "utils/Platform.h"
+#include "watchers/WatchersManager.h"
 
 class TextureResource;
 
-class ControllerActivityComponent : public GuiComponent
+class ControllerActivityComponent : public GuiComponent, IWatcherNotify
 {
 public:
 	enum ActivityView : unsigned int
@@ -21,6 +22,7 @@ public:
 	};
 
 	ControllerActivityComponent(Window* window);
+	~ControllerActivityComponent();
 
 	std::string getThemeTypeName() override { return "controllerActivity"; }
 
@@ -43,6 +45,8 @@ public:
 	void setHotkeyColor(unsigned int color) { mHotkeyColor = color; }
 	
 	bool hasBattery() { return mBatteryInfo.hasBattery; }
+
+	void OnWatcherChanged(IWatcher* component) override;
 
 protected:
 	virtual void	init();
@@ -99,19 +103,18 @@ protected:
 
 protected:
 	// Network info
-	void updateNetworkInfo();
-	std::shared_ptr<TextureResource> mNetworkImage;
+	std::shared_ptr<TextureResource> mNetworkImage;	
+    std::shared_ptr<TextureResource> mPlanemodeImage;
 	bool mNetworkConnected;
-	int mNetworkCheckTime;
-    	std::shared_ptr<TextureResource> mPlanemodeImage;
   	bool mPlanemodeEnabled;
 
 protected:
 	// Battery info
-	int mBatteryCheckTime;
 	int mBatteryTextX;
 
 	Utils::Platform::BatteryInformation mBatteryInfo;
+	Utils::Platform::BatteryInformation mWatchedBatteryInfo;
+	bool mBatteryInfoChanged;
 
 	std::shared_ptr<TextureResource> mBatteryImage;
 	std::shared_ptr<Font>			 mBatteryFont;

--- a/es-core/src/components/GridTileComponent.cpp
+++ b/es-core/src/components/GridTileComponent.cpp
@@ -583,6 +583,8 @@ bool GridImageProperties::applyTheme(const ThemeData::ThemeElement* elem)
 	if (elem && elem->has("roundCorners"))
 		roundCorners = elem->get<float>("roundCorners");
 
+	ThemeData::parseCustomShader(elem, &customShader);
+
 	return true;
 }
 
@@ -1206,6 +1208,8 @@ void GridImageProperties::mixProperties(GridImageProperties& def, GridImagePrope
 	colorEnd = mixColors(def.colorEnd, sel.colorEnd, percent);
 	reflexion = mixVectors(def.reflexion, sel.reflexion, percent);
 	roundCorners = mixFloat(def.roundCorners, sel.roundCorners, percent);
+
+	customShader = percent >= 0.02f ? sel.customShader : def.customShader;
 }
 
 void GridTextProperties::mixProperties(GridTextProperties& def, GridTextProperties& sel, float percent)

--- a/es-core/src/components/GridTileComponent.h
+++ b/es-core/src/components/GridTileComponent.h
@@ -7,6 +7,7 @@
 #include "TextComponent.h"
 #include "ThemeData.h"
 #include "resources/TextureResource.h"
+#include "renderers/Renderer.h"
 
 class VideoComponent;
 
@@ -49,6 +50,7 @@ public:
 		image->setColorShiftEnd(colorEnd);
 		image->setMirroring(reflexion);
 		image->setRoundCorners(roundCorners);
+		image->setCustomShader(customShader);
 	}
 
 	bool Loaded;
@@ -63,6 +65,8 @@ public:
 	unsigned int colorEnd;
 
 	std::string  sizeMode;
+
+	Renderer::ShaderInfo customShader;
 
 	float roundCorners;
 };

--- a/es-core/src/components/IExternalActivity.h
+++ b/es-core/src/components/IExternalActivity.h
@@ -9,5 +9,6 @@ public:
 
 public:
 	virtual bool isPlaneMode() = 0;
+	virtual bool isReadPlaneModeSupported() = 0;
 };
 #endif // ES_APP_COMPONENTS_EXTERNALACTIVITY_COMPONENT_H

--- a/es-core/src/components/NetworkIconComponent.h
+++ b/es-core/src/components/NetworkIconComponent.h
@@ -5,22 +5,28 @@
 
 #include "GuiComponent.h"
 #include "components/ImageComponent.h"
+#include "watchers/WatchersManager.h"
 
 class Window;
 
-class NetworkIconComponent : public ImageComponent
+class NetworkIconComponent : public ImageComponent, IWatcherNotify
 {
 public:
 	NetworkIconComponent(Window* window);
+	~NetworkIconComponent();
 
 	std::string getThemeTypeName() override { return "networkIcon"; }
 
 	void update(int deltaTime) override;
 	void applyTheme(const std::shared_ptr<ThemeData>& theme, const std::string& view, const std::string& element, unsigned int properties) override;
 
+	void OnWatcherChanged(IWatcher* component) override;
+	
 private:
-	int mNetworkCheckTime;
-
+	bool mConnected;
+	bool mPlaneMode;
+	bool mDirty;
+	
 	std::string mNetworkIcon;
 	std::string mPlanemodeIcon;
 };

--- a/es-core/src/watchers/BatteryLevelWatcher.cpp
+++ b/es-core/src/watchers/BatteryLevelWatcher.cpp
@@ -1,0 +1,9 @@
+#include "BatteryLevelWatcher.h"
+
+bool BatteryLevelWatcher::check()
+{
+	auto batteryInfo = Utils::Platform::queryBatteryInformation();
+	bool changed = batteryInfo.hasBattery != mBatteryInfo.hasBattery || batteryInfo.isCharging != mBatteryInfo.isCharging || batteryInfo.level != mBatteryInfo.level;
+	mBatteryInfo = batteryInfo;
+	return changed;
+}

--- a/es-core/src/watchers/BatteryLevelWatcher.h
+++ b/es-core/src/watchers/BatteryLevelWatcher.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "WatchersManager.h"
+#include "utils/Platform.h"
+
+class BatteryLevelWatcher : public IWatcher
+{
+public:
+	Utils::Platform::BatteryInformation& getBatteryInfo() { return mBatteryInfo; }
+
+protected:
+	bool enabled() override { return true; };
+
+	int  initialUpdateTime() override { return 0; }		// Immediate
+	int  updateTime() override { return 5 * 1000; }		// 5 seconds
+
+	bool check() override;
+
+private:
+	Utils::Platform::BatteryInformation mBatteryInfo;	
+};

--- a/es-core/src/watchers/NetworkStateWatcher.cpp
+++ b/es-core/src/watchers/NetworkStateWatcher.cpp
@@ -1,0 +1,21 @@
+#include "NetworkStateWatcher.h"
+#include "components/IExternalActivity.h"
+#include "utils/Platform.h"
+
+NetworkStateWatcher::NetworkStateWatcher() : mIsConnected(false), mIsPlaneMode(false)
+{
+	mIsPlaneModeSupported = IExternalActivity::Instance != nullptr && IExternalActivity::Instance->isReadPlaneModeSupported();
+}
+
+bool NetworkStateWatcher::check()
+{
+	bool networkConnected = !Utils::Platform::queryIPAdress().empty();
+	bool planemodeEnabled = mIsPlaneModeSupported && IExternalActivity::Instance != nullptr && IExternalActivity::Instance->isPlaneMode();
+
+	bool changed = networkConnected != mIsConnected || mIsPlaneMode != planemodeEnabled;
+
+	mIsConnected = networkConnected;
+	mIsPlaneMode = planemodeEnabled;
+	
+	return changed;
+}

--- a/es-core/src/watchers/NetworkStateWatcher.h
+++ b/es-core/src/watchers/NetworkStateWatcher.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "WatchersManager.h"
+
+class NetworkStateWatcher : public IWatcher
+{
+public:
+	NetworkStateWatcher();
+
+	bool isConnected() { return mIsConnected; }
+	bool isPlaneMode() { return mIsPlaneMode; }
+
+protected:
+	bool enabled() override { return true; };
+
+	int  initialUpdateTime() override { return 0; }		// Immediate
+	int  updateTime() override { return 5 * 1000; }		// 5 seconds
+
+	bool check() override;
+
+private:
+	bool mIsConnected;
+	bool mIsPlaneMode;
+	bool mIsPlaneModeSupported;
+};

--- a/es-core/src/watchers/WatchersManager.cpp
+++ b/es-core/src/watchers/WatchersManager.cpp
@@ -1,0 +1,154 @@
+#include "WatchersManager.h"
+#include "Log.h"
+#include <chrono>
+#include <SDL.h>
+
+std::mutex											WatchersManager::mNotificationLock;
+std::list<IWatcherNotify*>							WatchersManager::mNotification;
+std::mutex											WatchersManager::mWatchersLock;
+std::list<WatchersManager::WatcherInfo*>			WatchersManager::mWatchers;
+
+WatchersManager* WatchersManager::mInstance = nullptr;
+
+WatchersManager* WatchersManager::getInstance()
+{
+	if (mInstance == nullptr)
+		mInstance = new WatchersManager();
+
+	return mInstance;
+}
+
+WatchersManager::WatchersManager()
+{
+	LOG(LogDebug) << "WatchersManager : Starting";
+
+	mRunning = true;
+	mThread = new std::thread(&WatchersManager::run, this);
+}
+
+void WatchersManager::ResetComponent(IWatcher* instance)
+{
+	std::unique_lock<std::mutex> lock(mWatchersLock);
+
+	for (auto comp : mWatchers)
+	{
+		if (comp->component == instance)
+		{
+			comp->nextCheckTime = 0;
+			return;
+		}
+	}
+}
+
+void WatchersManager::RegisterComponent(IWatcher* instance)
+{
+	std::unique_lock<std::mutex> lock(mWatchersLock);
+
+	WatcherInfo* info = new WatcherInfo();
+	info->component = instance;
+	info->nextCheckTime = SDL_GetTicks() + instance->initialUpdateTime();
+	mWatchers.push_back(info);
+}
+
+void WatchersManager::UnregisterComponent(IWatcher* instance)
+{
+	std::unique_lock<std::mutex> lock(mWatchersLock);
+
+	for (auto it = mWatchers.cbegin(); it != mWatchers.cend(); it++)
+	{
+		WatcherInfo* info = *it;
+		if (info->component == instance)
+		{
+			mWatchers.erase(it);
+			delete info;
+			return;
+		}
+	}
+}
+
+void WatchersManager::RegisterNotify(IWatcherNotify* instance)
+{
+	std::unique_lock<std::mutex> lock(mNotificationLock);
+	mNotification.push_back(instance);
+}
+
+void WatchersManager::UnregisterNotify(IWatcherNotify* instance)
+{
+	std::unique_lock<std::mutex> lock(mNotificationLock);
+
+	for (auto it = mNotification.cbegin(); it != mNotification.cend(); it++)
+	{
+		if ((*it) == instance)
+		{
+			mNotification.erase(it);
+			return;
+		}
+	}
+}
+
+void WatchersManager::NotifyComponentChanged(IWatcher* component)
+{
+	std::unique_lock<std::mutex> lock(mNotificationLock);
+
+	for (IWatcherNotify* n : mNotification)
+		n->OnWatcherChanged(component);
+}
+
+WatchersManager::~WatchersManager()
+{
+	if (mThread == nullptr)
+		return;
+	
+	LOG(LogDebug) << "WatchersManager : Exit";
+
+	mRunning = false;
+	mEvent.notify_all();
+
+	mThread->join();
+	delete mThread;
+	mThread = nullptr;	
+
+	for (auto comp : mWatchers)
+		UnregisterComponent(comp->component);
+
+	for (auto notif : mNotification)
+		UnregisterNotify(notif);
+}
+
+void WatchersManager::run()
+{
+	while (mRunning)
+	{
+		// ThreadLock
+		{			
+			std::unique_lock<std::mutex> lock(mThreadLock);
+			mEvent.wait_for(lock, std::chrono::seconds(1));
+			
+			if (!mRunning)
+				return;
+		}
+
+		// Notification Lock
+		{
+			std::unique_lock<std::mutex> lock(mWatchersLock);
+
+			int ticks = SDL_GetTicks();
+			for (auto item : mWatchers)
+			{
+				if (!mRunning)
+					return;
+
+				if (!item->component->enabled())
+					continue;
+
+				if (ticks < item->nextCheckTime)
+					continue;
+
+				if (item->component->check())
+					NotifyComponentChanged(item->component);
+
+				item->nextCheckTime = SDL_GetTicks() + item->component->updateTime();
+			}
+		}		
+	}
+}

--- a/es-core/src/watchers/WatchersManager.h
+++ b/es-core/src/watchers/WatchersManager.h
@@ -1,0 +1,88 @@
+#pragma once
+
+#include <thread>
+#include <condition_variable>
+#include <mutex>
+#include <list>
+
+class WatchersManager;
+
+class IWatcher
+{
+	friend class WatchersManager;
+
+protected:
+	virtual bool enabled() = 0;
+	virtual int  updateTime() = 0;
+	virtual bool check() = 0;
+
+	virtual int  initialUpdateTime() { return 5 * 1000; } // 15 seconds
+};
+
+class IWatcherNotify
+{
+public:
+	virtual void OnWatcherChanged(IWatcher* component) = 0;
+};
+
+class WatchersManager
+{
+public:
+	template <typename T>
+	static T* GetComponent()
+	{
+		std::unique_lock<std::mutex> lock(mWatchersLock);
+
+		for (auto cp : mWatchers)
+		{
+			T* sgview = dynamic_cast<T*>(cp->component);
+			if (sgview != nullptr)
+				return sgview;
+		}
+
+		return nullptr;
+	}
+
+	static void RegisterComponent(IWatcher* instance);
+	static void UnregisterComponent(IWatcher* instance);
+
+	static void RegisterNotify(IWatcherNotify* instance);
+	static void UnregisterNotify(IWatcherNotify* instance);
+
+	static void ResetComponent(IWatcher* instance);
+
+	static WatchersManager* getInstance();
+
+	virtual ~WatchersManager();
+
+private:
+	WatchersManager();
+
+	static WatchersManager* mInstance;
+
+	struct WatcherInfo
+	{
+		WatcherInfo() { component = nullptr; nextCheckTime = 0; }
+
+		IWatcher*	component;
+		int			nextCheckTime;
+	};
+
+	void NotifyComponentChanged(IWatcher* component);
+
+	static std::mutex								mWatchersLock;
+	static std::list<WatcherInfo*>					mWatchers;
+
+	static std::mutex								mNotificationLock;
+	static std::list<IWatcherNotify*>				mNotification;
+
+	std::mutex										mThreadLock;
+	std::condition_variable							mEvent;
+	bool											mRunning;
+	
+	std::thread*									mThread;
+
+	void run();	
+};
+
+

--- a/resources/shaders/blur.glsl
+++ b/resources/shaders/blur.glsl
@@ -70,6 +70,6 @@ void main(void)
 	blurColor /= float(total);
 
 	// Output the final blurred color
-	gl_FragColor = blurColor;
+	gl_FragColor = blurColor * v_col;
 }
 #endif


### PR DESCRIPTION
- [WatchersManager] WatchersManager checks for updates availability, machine battery level, pads battery level, network state & plane mode in a unified thread that notifies components when something changes. ( this avoids watching it in the UI thread as it works currently )
- [Lightgun] Don't show lightgun crosshairs during screensaver https://github.com/batocera-linux/batocera.linux/issues/10415
- [Win32] Fix SDL Window Styles for FullscreenBorderless
- [Shaders] Fix blur.glsl colorization