### PR TITLE
[Win32] Port Win32 High CPU Usage fix from GL21 renderer to GLES20 renderer

### DIFF
--- a/es-app/src/main.cpp
+++ b/es-app/src/main.cpp
@@ -710,6 +710,7 @@ int main(int argc, char* argv[])
 		TRYCATCH("Window.update" ,window.update(deltaTime))	
 		TRYCATCH("Window.render", window.render())
 
+/*
 #ifdef WIN32		
 		int processDuration = SDL_GetTicks() - processStart;
 		if (processDuration < timeLimit)
@@ -719,6 +720,7 @@ int main(int argc, char* argv[])
 				Sleep(timeToWait);
 		}
 #endif
+*/
 
 		Renderer::swapBuffers();
 

--- a/es-core/src/renderers/Renderer_GLES20.cpp
+++ b/es-core/src/renderers/Renderer_GLES20.cpp
@@ -935,6 +935,12 @@ namespace Renderer
 	void GLES20Renderer::swapBuffers()
 	{
 		useProgram(nullptr);
+
+#ifdef WIN32		
+		glFlush();
+		glFinish();
+		Sleep(0);
+#endif
 		SDL_GL_SwapWindow(getSDLWindow());
 		GL_CHECK_ERROR(glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT));
 	} // swapBuffers


### PR DESCRIPTION
+ Remove sleep from main loop