### PR TITLE
1563 - Audio volume sets to 100% after reboot

### DIFF
--- a/es-core/src/VolumeControl.cpp
+++ b/es-core/src/VolumeControl.cpp
@@ -12,6 +12,8 @@
 #include <thread>
 #include <condition_variable>
 #include <pulse/pulseaudio.h>
+#include "utils/StringUtil.h"
+#include "SystemConf.h"
 
 class PulseAudioControl
 {
@@ -25,7 +27,9 @@ public:
 
 	  	mReady   = 0;
 		mMute    = 0;
-		mVolume  = 100;
+
+		std::string volume = SystemConf::getInstance()->get("audio.volume");
+		mVolume = !volume.empty() ? Utils::String::toInteger(volume) : 100;
 
 		mThread = new std::thread(&PulseAudioControl::run, this);
 		WaitEvent();


### PR DESCRIPTION
Should fix this one https://github.com/batocera-linux/batocera-emulationstation/issues/1563 v38 - Audio volume sets to 100% after reboot