### PR TITLE
default pad sort for udev on device ports

### DIFF
--- a/es-core/src/InputConfig.h
+++ b/es-core/src/InputConfig.h
@@ -117,6 +117,7 @@ public:
         
 	inline int getDeviceIndex() const { return mDeviceIndex; }; 
 	inline const std::string& getDeviceName() { return mDeviceName; }
+	inline const std::string& getDeviceSysPath() { return mDeviceSysPath; }
 	inline const std::string& getDeviceGUIDString() { return mDeviceGUID; }
 	inline int getDeviceNbButtons() const { return mDeviceNbButtons; }; 
 	inline int getDeviceNbHats() const { return mDeviceNbHats; }; 
@@ -154,6 +155,7 @@ private:
 	const int mDeviceId;
 	const int mDeviceIndex; 
 	const std::string mDeviceName;
+	std::string mDeviceSysPath;
 	const std::string mDeviceGUID;
 	const int mDeviceNbButtons; // number of buttons of the device 
 	const int mDeviceNbHats;    // number of hats    of the device 

--- a/es-core/src/InputManager.cpp
+++ b/es-core/src/InputManager.cpp
@@ -1098,7 +1098,7 @@ std::map<int, InputConfig*> InputManager::computePlayersConfigs()
 #if WIN32
 	std::sort(availableConfigured.begin(), availableConfigured.end(), [](InputConfig * a, InputConfig * b) -> bool { return a->getSortDevicePath() < b->getSortDevicePath(); });
 #else
-	std::sort(availableConfigured.begin(), availableConfigured.end(), [](InputConfig * a, InputConfig * b) -> bool { return a->getDeviceIndex() < b->getDeviceIndex(); });
+	std::sort(availableConfigured.begin(), availableConfigured.end(), [](InputConfig * a, InputConfig * b) -> bool { return a->getDeviceSysPath() == b->getDeviceSysPath() ? a->getDeviceIndex() < b->getDeviceIndex() : a->getDeviceSysPath() < b->getDeviceSysPath(); });
 #endif
 
 	// 2. Pour chaque joueur verifier si il y a un configurated


### PR DESCRIPTION
the current default sort is random. prefer to sort according to hardware ports (mainly for cabinets having the same controllers for player 1 and 2)

device syspath for /dev/input/event7 is /sys/devices/pci0000:00/0000:00:08.1/0000:04:00.3/usb1/1-1/1-1.2/1-1.2:1.0/0003:146B:0902.0012/input/input41/event7
device syspath for /dev/input/event15 is /sys/devices/pci0000:00/0000:00:08.1/0000:04:00.4/usb3/3-3/3-3:1.2/0003:28DE:1205.0003/input/input21/event15
device syspath for /dev/input/event17 is /sys/devices/pci0000:00/0000:00:08.1/0000:04:00.3/usb1/1-1/1-1.1/1-1.1:1.0/0003:146B:0902.0011/input/input40/event17
device syspath for /dev/input/event18 is /sys/devices/pci0000:00/0000:00:08.1/0000:04:00.4/usb3/3-5/3-5:1.0/bluetooth/hci0/hci0:1/0005:2DC8:6100.0013/input/input42