### PR TITLE
[Carousel/Theming] Add "scaledLogoSpacing" element to define how the active scaled logo should be padded from other logos

### DIFF
--- a/es-app/src/components/CarouselComponent.cpp
+++ b/es-app/src/components/CarouselComponent.cpp
@@ -49,6 +49,7 @@ CarouselComponent::CarouselComponent(Window* window) :
 	mDefaultTransition = "";
 	mTransitionSpeed = 500;
 	mMinLogoOpacity = 0.5f;
+	mScaledSpacing = 0.0f;
 
 	mAnyLogoHasScaleStoryboard = false;
 	mAnyLogoHasOpacityStoryboard = false;
@@ -436,7 +437,20 @@ void CarouselComponent::renderCarousel(const Transform4x4f& trans)
 			index += (int)mEntries.size();
 
 		Transform4x4f logoTrans = carouselTrans;
-		logoTrans.translate(Vector3f(i * logoSpacing[0] + xOff, i * logoSpacing[1] + yOff, 0));
+
+		if (mType == HORIZONTAL && mLogoScale != 1.0f && mScaledSpacing != 0.0f)
+		{
+			auto logoDiffX = ((logoSpacing[0] * mLogoScale) - logoSpacing[0]) / 2.0f * mScaledSpacing;
+
+			if (index == mCursor)
+				logoTrans.translate(Vector3f(i * logoSpacing[0] + xOff, i * logoSpacing[1] + yOff, 0));
+			else if (i < mCursor || (mCursor == 0 && index > mMaxLogoCount))
+				logoTrans.translate(Vector3f(i * logoSpacing[0] + xOff - logoDiffX, i * logoSpacing[1] + yOff, 0));
+			else
+				logoTrans.translate(Vector3f(i * logoSpacing[0] + xOff + logoDiffX, i * logoSpacing[1] + yOff, 0));
+		}
+		else
+			logoTrans.translate(Vector3f(i * logoSpacing[0] + xOff, i * logoSpacing[1] + yOff, 0));
 
 		float distance = i - mCamOffset;
 
@@ -536,6 +550,9 @@ void CarouselComponent::getCarouselFromTheme(const ThemeData::ThemeElement* elem
 	if (elem->has("minLogoOpacity"))
 		mMinLogoOpacity = elem->get<float>("minLogoOpacity");
 	
+	if (elem->has("scaledLogoSpacing"))
+		mScaledSpacing = elem->get<float>("scaledLogoSpacing");	
+
 	if (elem->has("imageSource"))
 	{
 		auto direction = elem->get<std::string>("imageSource");

--- a/es-app/src/components/CarouselComponent.h
+++ b/es-app/src/components/CarouselComponent.h
@@ -156,9 +156,12 @@ private:
 	bool			mAnyLogoHasScaleStoryboard;
 	bool			mAnyLogoHasOpacityStoryboard;
 
+	float			mScaledSpacing;
+
 	// Mouse support
 	int				mPressedCursor;
 	Vector2i		mPressedPoint;	
+
 
 public:
 	bool isHorizontalCarousel() { return mType == HORIZONTAL || mType == HORIZONTAL_WHEEL; }

--- a/es-app/src/views/SystemView.cpp
+++ b/es-app/src/views/SystemView.cpp
@@ -1121,6 +1121,8 @@ void  SystemView::getViewElements(const std::shared_ptr<ThemeData>& theme)
 	mViewNeedsReload = false;
 }
 
+#include "Log.h"
+
 //  Render system carousel
 void SystemView::renderCarousel(const Transform4x4f& trans)
 {
@@ -1212,7 +1214,20 @@ void SystemView::renderCarousel(const Transform4x4f& trans)
 			index += (int)mEntries.size();
 
 		Transform4x4f logoTrans = carouselTrans;
-		logoTrans.translate(Vector3f(i * logoSpacing[0] + xOff, i * logoSpacing[1] + yOff, 0));
+
+		if (mCarousel.type == HORIZONTAL && mCarousel.logoScale != 1.0f && mCarousel.scaledSpacing != 0.0f)
+		{
+			auto logoDiffX = ((logoSpacing[0] * mCarousel.logoScale) - logoSpacing[0]) / 2.0f * mCarousel.scaledSpacing;
+
+			if (index == mCursor)
+				logoTrans.translate(Vector3f(i * logoSpacing[0] + xOff, i * logoSpacing[1] + yOff, 0));
+			else if (i < mCursor || (mCursor == 0 && index > mCarousel.maxLogoCount))
+				logoTrans.translate(Vector3f(i * logoSpacing[0] + xOff - logoDiffX, i * logoSpacing[1] + yOff, 0));
+			else 
+				logoTrans.translate(Vector3f(i * logoSpacing[0] + xOff + logoDiffX, i * logoSpacing[1] + yOff, 0));
+		}
+		else
+			logoTrans.translate(Vector3f(i * logoSpacing[0] + xOff, i * logoSpacing[1] + yOff, 0));
 
 		float distance = i - mCamOffset;
 
@@ -1613,6 +1628,7 @@ void  SystemView::getDefaultElements(void)
 	mCarousel.logoSize.y() = 0.155f * mSize.y();
 	mCarousel.logoPos = Vector2f(-1, -1);
 	mCarousel.maxLogoCount = 3;
+	mCarousel.scaledSpacing = 0.0f;
 	mCarousel.zIndex = 40;
 	mCarousel.systemInfoDelay = 2000;
 	mCarousel.systemInfoCountOnly = false;
@@ -1673,6 +1689,8 @@ void SystemView::getCarouselFromTheme(const ThemeData::ThemeElement* elem)
 		mCarousel.logoPos = elem->get<Vector2f>("logoPos") * mSize;
 	if (elem->has("maxLogoCount"))
 		mCarousel.maxLogoCount = (int)Math::round(elem->get<float>("maxLogoCount"));
+	if (elem->has("scaledLogoSpacing"))
+		mCarousel.scaledSpacing = elem->get<float>("scaledLogoSpacing");	
 	if (elem->has("zIndex"))
 		mCarousel.zIndex = elem->get<float>("zIndex");
 	if (elem->has("logoRotation"))

--- a/es-app/src/views/SystemView.h
+++ b/es-app/src/views/SystemView.h
@@ -55,6 +55,8 @@ struct SystemViewCarousel
 
 	bool anyLogoHasOpacityStoryboard;
 	bool anyLogoHasScaleStoryboard;
+
+	float			scaledSpacing;
 };
 
 class SystemView : public IList<SystemViewData, SystemData*>

--- a/es-core/src/ThemeData.cpp
+++ b/es-core/src/ThemeData.cpp
@@ -571,6 +571,7 @@ std::map<std::string, std::map<std::string, ThemeData::ElementPropertyType>> The
 		{ "defaultTransition", STRING },		// auto, instant, fade, slide, fade & slide
 		{ "minLogoOpacity", FLOAT },
 		{ "transitionSpeed", FLOAT },
+		{ "scaledLogoSpacing", FLOAT },
 		{ "scrollSound", PATH },
 		{ "zIndex", FLOAT } } },
 
@@ -590,6 +591,7 @@ std::map<std::string, std::map<std::string, ThemeData::ElementPropertyType>> The
 		{ "defaultTransition", STRING },	// auto, instant, fade, slide, fade & slide
 		{ "minLogoOpacity", FLOAT },
 		{ "transitionSpeed", FLOAT },
+		{ "scaledLogoSpacing", FLOAT },
 		{ "scrollSound", PATH },
 		{ "zIndex", FLOAT } } },
 


### PR DESCRIPTION
default is 0 : No space
1 -> apply the same space that exist between 2 inactive logos 2 -> apply the double
0.5 -> apply half...