### PR TITLE
[PostProcess Shaders] Optimisations : Don't render bottom view if we have a Shader Texture Cache

### DIFF
--- a/es-app/src/EmulationStation.h
+++ b/es-app/src/EmulationStation.h
@@ -4,14 +4,14 @@
 
 // These numbers and strings need to be manually updated for a new version.
 // Do this version number update as the very last commit for the new release version.
-#define PROGRAM_VERSION_MAJOR        34
+#define PROGRAM_VERSION_MAJOR        39
 #define PROGRAM_VERSION_MINOR        0
 #define PROGRAM_VERSION_MAINTENANCE  0
-#define PROGRAM_VERSION_STRING		"34"
+#define PROGRAM_VERSION_STRING		"39"
 
 #define PROGRAM_BUILT_STRING __DATE__ " - " __TIME__
 
-#define RESOURCE_VERSION_STRING "34,0,0\0"
+#define RESOURCE_VERSION_STRING "39,0,0\0"
 #define RESOURCE_VERSION PROGRAM_VERSION_MAJOR,PROGRAM_VERSION_MINOR,PROGRAM_VERSION_MAINTENANCE
 
 #ifndef SCREENSCRAPER_SOFTNAME

--- a/es-core/src/Window.cpp
+++ b/es-core/src/Window.cpp
@@ -630,7 +630,7 @@ void Window::renderMenuBackgroundShader()
 			vertices[2] = { { (float)0 + w, (float)0       }, { 1.0f, 1.0f }, 0xFFFFFFFF };
 			vertices[3] = { { (float)0 + w, (float)0 + h   }, { 1.0f, 0.0f }, 0xFFFFFFFF };
 
-			Renderer::drawTriangleStrips(&vertices[0], 4);
+			Renderer::drawTriangleStrips(&vertices[0], 4, Renderer::Blend::ONE, Renderer::Blend::ONE);
 			Renderer::bindTexture(0);
 		}
 	}
@@ -661,7 +661,10 @@ void Window::render()
 
 		auto menuBackground = ThemeData::getMenuTheme()->Background;
 
-		bottom->render(transform);
+		// Don't render bottom if we have a MenuBackgroundShaderTextureCache
+		if (mMenuBackgroundShaderTextureCache == -1)
+			bottom->render(transform);
+
 		if (bottom != top)
 		{
 			if ((top->getTag() == "GuiLoading") && mGuiStack.size() > 2)

--- a/es-core/src/components/PostProcessShaderComponent.cpp
+++ b/es-core/src/components/PostProcessShaderComponent.cpp
@@ -40,7 +40,7 @@ void PostProcessShaderComponent::render(const Transform4x4f& parentTrans)
 			Renderer::bindTexture(textureId);
 
 			beginCustomClipRect();
-			Renderer::drawTriangleStrips(&vertices[0], 4);
+			Renderer::drawTriangleStrips(&vertices[0], 4, Renderer::Blend::ONE, Renderer::Blend::ONE);
 			GuiComponent::renderChildren(trans);
 			endCustomClipRect();
 


### PR DESCRIPTION
+ use Blend::ONE to render postprocess shaders ( as we don't need transparency )