### PR TITLE
Fixing all Wii gun mapping

### DIFF
--- a/resources/gungames.xml
+++ b/resources/gungames.xml
@@ -252,45 +252,44 @@
     <game>yoshissafari</game>
   </system>
   <system name="wii">
-    <game vertical_offset="15" yaw="18.7" pitch="18.8">arcadeshootinggallery</game>
-    <game vertical_offset="15" yaw="19" pitch="19">attackofthemovies3d</game>
+    <game vertical_offset="15" yaw="18.7" pitch="18.8" action="z">arcadeshootinggallery</game>
+    <game vertical_offset="15" yaw="19" pitch="19" action="shake" start="a">attackofthemovies3d</game>
     <game vertical_offset="7" yaw="18.7" pitch="18.9">bigbuckhunterpro</game>
-    <game vertical_offset="15" yaw="18.7" pitch="19">chickenblaster</game>
+    <game vertical_offset="15" yaw="18.7" pitch="19" action="z">chickenblaster</game>
     <game vertical_offset="14.70" yaw="18.9" pitch="19.3">chickenriot</game>
     <game vertical_offset="0" yaw="41.3" pitch="31.6">chickenshoot</game>
     <game vertical_offset="14" yaw="18.6" pitch="18.4">cocotofestival</game>
     <game vertical_offset="15.3" yaw="18.5" pitch="18.69" ir_right="(`Axis 0+`+0.01)">cocotomagiccircus</game>
-    <game vertical_offset="14.5" yaw="18.3" pitch="19.15">deadspaceextraction</game>
+    <game vertical_offset="14.5" yaw="18.3" pitch="19.15" action="z,shake" start="tiltleft" select="a" sub1="+">deadspaceextraction</game>
     <game vertical_offset="15" yaw="18.9" pitch="18.9">dinostrike</game>
-    <game vertical_offset="14.9" yaw="18.8" pitch="18.8">fastdrawshowdown</game>
+    <game vertical_offset="14.9" yaw="18.8" pitch="18.8" action="tiltforward" select="a">fastdrawshowdown</game>
     <game vertical_offset="15" yaw="18.7" pitch="19">ghostsquad</game>
     <game vertical_offset="15.2" yaw="18.6" pitch="18.9">gunbladenyandlamachineguns</game>
     <game vertical_offset="15" yaw="18.7" pitch="12">gunslingers</game>
-    <game vertical_offset="15" yaw="18.7" pitch="19" ir_down="`Axis 1+`/1.03">heavyfireafghanistan</game>
-    <game vertical_offset="14.5" yaw="22" pitch="22">heavyfireblackarms</game>
-    <game vertical_offset="14.5" yaw="22" pitch="22">heavyfirespecialoperations</game>
+    <game vertical_offset="15" yaw="18.7" pitch="19" ir_down="`Axis 1+`/1.03" action="c" start="z" select="+">heavyfireafghanistan</game>
+    <game vertical_offset="14.5" yaw="22" pitch="22" action="shake">heavyfireblackarms</game>
+    <game vertical_offset="14.5" yaw="22" pitch="22" action="shake">heavyfirespecialoperations</game>
     <game vertical_offset="15" yaw="19" pitch="19">houseofthedeadoverkill</game>
     <game vertical_offset="15" yaw="19" pitch="19">houseofthedeadtheoverkill</game>
     <game vertical_offset="15" yaw="19" pitch="19">houseofthedead2and3</game>
-    <game vertical_offset="15" yaw="18.8" pitch="19" ir_down="`Axis 1+`/1.02">maddogmccreegunslingerpack</game>
+    <game vertical_offset="15" yaw="18.8" pitch="19" ir_down="`Axis 1+`/1.02" action="tiltbackward">maddogmccreegunslingerpack</game>
     <game vertical_offset="14.7" yaw="19" pitch="19">martianpanic</game>
-    <game vertical_offset="21.3" yaw="12.35" pitch="12.3" ir_down="(`Axis 1+`+0.01)">nerfnstrikeelite</game>
+    <game vertical_offset="21.3" yaw="12.35" pitch="12.3" ir_down="(`Axis 1+`+0.01)" action="shake" start="a" select="+">nerfnstrikeelite</game>
     <game vertical_offset="15" yaw="18.6" pitch="18.9">nerfnstrike</game>
-    <game vertical_offset="14.9" yaw="18.6" pitch="18.7">pheasantsforeverwingshooter</game>
-    <game vertical_offset="14.6" yaw="19" pitch="19">pirateblast</game>
-    <game vertical_offset="15" yaw="18.75" pitch="18.75">reload</game>
+    <game vertical_offset="14.9" yaw="18.6" pitch="18.7" action="z" start="a" select="c" sub1="+">pheasantsforeverwingshooter</game>
+    <game vertical_offset="14.6" yaw="19" pitch="19" action="z" start="a" select="c">pirateblast</game>
+    <game vertical_offset="15" yaw="18.75" pitch="18.75" start="1">reload</game>
     <game vertical_offset="14.7" yaw="18.6" pitch="18.8" ir_right="(`Axis 0+`+0.02)">remingtongreatamericanbirdhunt</game>
     <game vertical_offset="14.6" yaw="30.7" pitch="18.9" ir_left="`Axis 0-`/1.22" ir_right="(`Axis 0+`+0.25)/1.23">remingtonsuperslamhuntingafrica</game>
     <game vertical_offset="14.6" yaw="30.7" pitch="18.9" ir_left="`Axis 0-`/1.22" ir_right="(`Axis 0+`+0.25)/1.23">remingtonsuperslamhuntingalaska</game>
     <game vertical_offset="14.7" yaw="18.6" pitch="18.8" ir_right="(`Axis 0+`+0.015)">remingtonsuperslamhuntingnorthamerica</game>
-    <game vertical_offset="0" yaw="20.6" pitch="15.75">residentevilthedarksidechronicles</game>
-    <game vertical_offset="15.2" yaw="15.3" pitch="11.7">residenteviltheumbrellachronicles</game>
-    <game vertical_offset="15.15" yaw="19.1" pitch="19.4">targetterror</game>
-    <game vertical_offset="14.8" yaw="16.9" pitch="17">tomclancysghostrecon</game>
-    <game vertical_offset="15" yaw="24.7" pitch="19">topshotarcade</game>
-    <game vertical_offset="15.3" yaw="18.8" pitch="19.2">topshotdinosaurhunter</game>
+    <game vertical_offset="0" yaw="20.6" pitch="15.75" action="shake" start="a" select="+" sub1="1">residentevilthedarksidechronicles</game>
+    <game vertical_offset="15.2" yaw="15.3" pitch="11.7" action="shake" start="a" select="+" sub1="-">residenteviltheumbrellachronicles</game>
+    <game vertical_offset="15.15" yaw="19.1" pitch="19.4" action="shake" start="a" select="1">targetterror</game>
+    <game vertical_offset="14.8" yaw="16.9" pitch="17" sub1="z">tomclancysghostrecon</game>
+    <game vertical_offset="15" yaw="24.7" pitch="19" trigger="z" action="b">topshotarcade</game>
     <game vertical_offset="15" yaw="18.3" pitch="18">wickedmonstersblast</game>
-    <game vertical_offset="14.7" yaw="18.9" pitch="19">wildwestguns</game>
+    <game vertical_offset="14.7" yaw="18.9" pitch="19" action="z">wildwestguns</game>
     <game vertical_offset="15" yaw="18.8" pitch="19">wildwestshootout</game>
   </system>
 </systems>


### PR DESCRIPTION
Making Wii gun games 100% playables with all controls required.

Removing Top Shot Dinosaur Hunter, not a gun game.

DO NOT MERGE YET.

Need first `tiltleft`, `tiltbackward`, `tiltforward`, duplication (one virtual gun button triggering two wii buttons at the same time) and emulated nunchuk enabled by default.