### PR TITLE
Optimizing wheels (part 3 - remake)

### DIFF
--- a/resources/wheelgames.xml
+++ b/resources/wheelgames.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <systems>
   <system name="3do">
-    <game wheel_rotation="270">needforspeed</game>
+    <game wheel_rotation_angle="270">needforspeed</game>
   </system>
   <system name="atari2600">
     <game>indy500</game>
@@ -24,48 +24,50 @@
     <game>turbo</game>
     <game>zippyrace</game>
   </system>
-  <system name="dreamcast" wheel_rotation="270" wheel="joystick1left" accelerate="rt" brake="lt">
+  <system name="dreamcast" wheel_rotation_angle="270" wheel="joystick1left" accelerate="rt" brake="lt">
     <game>18wheeler</game>
-    <game>4x4evolution</game>
+    <game wheel_deadzone="50">4x4evo</game>
     <game>alienfrontonline</game>
     <game>buggyheat</game>
     <game>crazytaxi2</game>
-    <game>crazytaxi</game>
-    <game>daytonusa</game>
-    <game>demolitionracer</game>
-    <game>exhibitionofspeed</game>
-    <game>f1racingchampionship</game>
-    <game>f1worldgrandprixii</game>
-    <game>f1worldgrandprix</game>
+    <game wheel_deadzone="10">crazytaxi</game>
+    <game wheel_deadzone="5">daytonausa</game>
+    <game wheel_deadzone="45">demolitionracer</game>
+    <game wheel_deadzone="50">exhibitionofspeed</game>
+    <game wheel_rotation_angle="200">f1racingchampionship</game>
+    <game wheel_rotation_angle="180">f1worldgrandprixii</game>
+    <game wheel_rotation_angle="180">f1worldgrandprix</game>
     <game>f355challenge</game>
     <game>flagtoflag</game>
-    <game>lemans24hours</game>
-    <game>looneytunes</game>
-    <game>magforceracing</game>
+    <game wheel_rotation_angle="180">lemans24hours</game>
+    <game wheel_rotation_angle="180" wheel_deadzone="25">looneytunes</game>
+    <game wheel_rotation_angle="180" wheel_deadzone="25">magforceracing</game>
     <game>metropolisstreetracer</game>
-    <game>monacograndprix</game>
+    <game controller="1" port1="2">monacograndprixracingsimulation2</game>
+    <game controller="1" port1="2">monacograndprix</game>
     <game>podspeedzone</game>
-    <game>racingsimulation2</game>
-    <game>roadsters</game>
+    <game controller="1" port1="2">racingsimulation2</game>
+    <game wheel_rotation_angle="180" wheel_deadzone="25">roadsters</game>
     <game>segagt</game>
-    <game>segarally2</game>
-    <game>speeddevilsonlineracing</game>
-    <game>speeddevils</game>
-    <game>spiritofspeed1937</game>
-    <game>superrunabout</game>
-    <game>taxi2</game>
+    <game wheel_deadzone="5">segarally2</game>
+    <game wheel_rotation_angle="180">speeddevilsonlineracing</game>
+    <game wheel_rotation_angle="180">speeddevils</game>
+    <game wheel_rotation_angle="180">spiritofspeed1937</game>
+    <game>stuntgp</game>
+    <game wheel_deadzone="15">superrunabout</game>
+    <game wheel_rotation_angle="180">taxi2</game>
     <game>testdrivelemans</game>
-    <game>testdrivevrally</game>
+    <game wheel_deadzone="15">testdrivevrally</game>
     <game>testdrive6</game>
-    <game>tokyoxtremeracer</game>
-    <game>toyracer</game>
-    <game>vrally2</game>
-    <game>vanishingpoint</game>
-    <game>wackyraces</game>
-    <game>waltdisneyworldquest</game>
-    <game>yusuzukigameworks</game>
+    <game wheel_rotation_angle="180" wheel_deadzone="5">tokyoxtremeracer</game>
+    <game wheel_rotation_angle="180">toyracer</game>
+    <game wheel_rotation_angle="180" wheel_deadzone="5">vrally2</game>
+    <game wheel_deadzone="40">vanishingpoint</game>
+    <game wheel_rotation_angle="180" wheel_deadzone="15">wackyraces</game>
+    <game wheel_rotation_angle="180">waltdisneyworldquest</game>
+    <game wheel_rotation_angle="180">yusuzukigameworks</game>
   </system>
-  <system name="gamecube" wheel_rotation="200" wheel="joystick1left" accelerate="a" brake="b">
+  <system name="gamecube" wheel_rotation_angle="180">
     <game>18wheeler</game>
     <game>4x4evo2</game>
     <game>americanchopper2</game>
@@ -127,111 +129,118 @@
   <system name="msx">
     <game>a1spirit</game>
   </system>
-  <system name="n64" wheel="joystick1left" wheel_rotation="150" accelerate="a" brake="b">
-    <game>aerogauge</game>
-    <game>automobililamborghini</game>
+  <system name="n64" wheel="joystick1left" wheel_rotation_angle="180" accelerate="a" brake="b">
+    <game wheel_deadzone="10">aerogauge</game>
+    <game downshift="cdown" wheel_rotation_angle="240" wheel_deadzone="10">automobililamborghini</game>
     <game>bettleadventureracing</game>
     <game>californiaspeed</game>
-    <game>carmageddon2</game>
-    <game>choroq642</game>
-    <game>cruisnexotica</game>
-    <game>cruisnusa</game>
+    <game>carmageddon64</game>
+    <game>choroq642hachamechagrandprixrace</game>
+    <game>choroq64</game>
+    <game downshift="cdown" upshift="cup" x="z" y="r" wheel_deadzone="5">cruisnexotica</game>
+    <game accelerate="z" brake="l" downshift="cdown" upshift="cup">cruisnusa</game>
     <game>cruisnworld</game>
-    <game>destructionderby64</game>
+    <game wheel_deadzone="50">destructionderby64</game>
     <game>diddykongracing</game>
-    <game>extremeg</game>
-    <game>f1worldgrandprix</game>
-    <game>fzerox</game>
-    <game>f1poleposition</game>
-    <game>f1racingchampionship</game>
-    <game>hotwheels</game>
-    <game>indyracing2000</game>
-    <game>legoracers</game>
-    <game>mariokart64</game>
+    <game accelerate="z" downshift="a">extremegxg2</game>
+    <game accelerate="z" downshift="a">extremeg</game>
+    <game wheel_deadzone="5">f1worldgrandprix</game>
+    <game brake="cdown" a="b">fzerox</game>
+    <game wheel_deadzone="10" wheel_midzone="2">f1poleposition</game>
+    <game wheel_deadzone="5">f1racingchampionship</game>
+    <game wheel_deadzone="20">hotwheels</game>
+    <game wheel_deadzone="10">indyracing2000</game>
+    <game wheel_deadzone="15" wheel_midzone="2">legoracers</game>
+    <game wheel_rotation_angle="200" wheel_deadzone="25" wheel_midzone="1">mariokart64</game>
+    <game>mickeynoracingchallengeusa</game>
     <game>mickeysspeedwayusa</game>
-    <game>monacograndprixracing</game>
-    <game>monstertruckmadness64</game>
-    <game>mrcmultiracingchampionship</game>
-    <game>nascar</game>
-    <game>offroadchallenge</game>
+    <game wheel_deadzone="5">monacograndprixracingsimulation2</game>
+    <game wheel_deadzone="5">monacograndprix</game>
+    <game wheel_deadzone="10">monstertruckmadness64</game>
+    <game downshift="l">mrcmultiracingchampionship</game>
+    <game downshift="l" wheel_deadzone="5">nascar2000</game>
+    <game downshift="l" wheel_deadzone="5">nascar99</game>
+    <game downshift="cdown" b="z" wheel_deadzone="30" wheel_midzone="1">offroadchallenge</game>
     <game>pennyracers</game>
-    <game>revolt</game>
-    <game>ridgeracer64</game>
-    <game>roadsters</game>
-    <game>rush2extremeracing</game>
-    <game>scars</game>
-    <game>sanfranciscorush</game>
-    <game>southparkrally</game>
-    <game>starwarsepisodeiracer</game>
-    <game>stuntracer64</game>
+    <game wheel_rotation_angle="240" wheel_deadzone="30" wheel_midzone="2">revolt</game>
+    <game wheel_deadzone="50">ridgeracer64</game>
+    <game>roadrash64</game>
+    <game wheel_rotation_angle="240" wheel_deadzone="10">roadsters</game>
+    <game wheel_deadzone="15">rush2extremeracing</game>
+    <game wheel_rotation_angle="240">scars</game>
+    <game wheel_deadzone="20">sanfranciscorushextremeracing</game>
+    <game downshift="cdown" b="z" wheel_deadzone="20">sanfranciscorush2049</game>
+    <game wheel_deadzone="10">southparkrally</game>
+    <game wheel_rotation_angle="200" wheel_deadzone="45">starwarsepisodeiracer</game>
+    <game downshift="cdown" upshift="z" b="l">stuntracer64</game>
     <game>topgearrally</game>
     <game>topgearoverdrive</game>
-    <game>vrally</game>
+    <game wheel_rotation_angle="200" wheel_deadzone="30">vrallyedition99</game>
     <game>wipeout64</game>
     <game>worlddriverchampionship</game>
   </system>
   <system name="ps2">
-    <game wheel_type="DrivingForce" wheel_rotation="200">18wheeler</game>
+    <game wheel_type="DrivingForce" wheel_rotation_angle="200">18wheeler</game>
     <game wheel_type="DrivingForce">4x4evo2</game>
     <game>4x4evo</game>
     <game>alarmforcobra11</game>
     <game>alfaromeoracing</game>
-    <game wheel_type="DrivingForce" wheel_rotation="270" wheel_midzone="5">automodellista</game>
+    <game wheel_type="DrivingForce" wheel_rotation_angle="270" wheel_midzone="5">automodellista</game>
     <game>bombermankart</game>
-    <game wheel_type="DrivingForce" wheel_rotation="200">burnoutdominator</game>
-    <game wheel_type="DrivingForce" wheel_rotation="200">burnoutrevenge</game>
-    <game wheel_type="GTForce" wheel_rotation="200">burnout2</game>
-    <game wheel_type="DrivingForce" wheel_rotation="200">burnout3</game>
-    <game wheel_type="GTForce" wheel_rotation="200">burnout</game>
+    <game>burnoutdominator</game>
+    <game wheel_type="DrivingForce" wheel_rotation_angle="200">burnoutrevenge</game>
+    <game wheel_type="GTForce" wheel_rotation_angle="200">burnout2</game>
+    <game wheel_type="DrivingForce" wheel_rotation_angle="200">burnout3</game>
+    <game wheel_type="GTForce" wheel_rotation_angle="200">burnout</game>
     <game>choroq</game>
     <game wheel_type="DrivingForce">cityracer</game>
-    <game wheel_type="DrivingForce" wheel_rotation="270">colinmcraerally2005</game>
-    <game wheel_type="DrivingForce" wheel_rotation="270">colinmcraerally04</game>
+    <game wheel_type="DrivingForce" wheel_rotation_angle="270">colinmcraerally2005</game>
+    <game wheel_type="DrivingForce" wheel_rotation_angle="270">colinmcraerally04</game>
     <game wheel_type="DrivingForce">colinmcraerally3</game>
     <game>colinmcraerally2</game>
     <game>colinmcraerally</game>
     <game wheel_type="DrivingForcePro">corvetteevolutionGT</game>
-    <game wheel_type="DrivingForce" wheel_rotation="200">corvette</game>
+    <game wheel_type="DrivingForce" wheel_rotation_angle="200">corvette</game>
     <game>crashed</game>
     <game>crashnitrokart</game>
     <game>crazytaxi</game>
     <game wheel_type="DrivingForcePro">criticalvelocity</game>
-    <game wheel_type="DrivingForce" wheel_rotation="200">dakar2</game>
+    <game wheel_type="DrivingForce" wheel_rotation_angle="200">dakar2</game>
     <game>destructionderby</game>
     <game>dirttrackdevils</game>
     <game>disneypixarcars</game>
     <game>downforce</game>
-    <game wheel_type="DrivingForce" wheel_rotation="200" wheel_deadzone="15">downtownrun</game>
+    <game wheel_type="DrivingForce" wheel_rotation_angle="200" wheel_deadzone="15">downtownrun</game>
+    <game wheel_type="DrivingForce" wheel_rotation_angle="200">driven</game>
     <game>dromeracers</game>
-    <game wheel_type="DrivingForce" wheel_rotation="200">driven</game>
     <game>dtcarnage</game>
     <game>dtracer</game>
-    <game wheel_type="DrivingForce">eighteenwheeler</game>
+    <game wheel_type="DrivingForce" wheel_rotation_angle="200">eighteenwheeler</game>
     <game wheel_type="DrivingForcePro">enthusia</game>
     <game wheel_type="DrivingForcePro">evolutiongt</game>
     <game wheel_type="DrivingForcePro">f106</game>
     <game>f12001</game>
-    <game wheel_type="DrivingForce" wheel_rotation="200">f12002</game>
+    <game wheel_type="DrivingForce" wheel_rotation_angle="200">f12002</game>
     <game wheel_type="DrivingForce" controller="1">f1careerchallenge</game>
     <game>f1championship</game>
     <game>f1racingchampionship</game>
     <game wheel_type="DrivingForce">f355challenge</game>
-    <game wheel_type="DrivingForce" wheel_rotation="270" wheel_deadzone="15">ferrarichallenge</game>
+    <game wheel_type="DrivingForce" wheel_rotation_angle="270" wheel_deadzone="15">ferrarichallenge</game>
     <game wheel_type="DrivingForcePro" controller="1">flatout2</game>
     <game wheel_type="DrivingForcePro">flatout</game>
-    <game wheel_type="DrivingForcePro" wheel_rotation="270">fordboldmovesstreetracing</game>
+    <game wheel_type="DrivingForcePro" wheel_rotation_angle="270">fordboldmovesstreetracing</game>
     <game>fordmustang</game>
     <game wheel_type="DrivingForce">fordracing2</game>
     <game wheel_type="DrivingForcePro" controller="1">fordracing3</game>
-    <game wheel_type="DrivingForcePro" wheel_rotation="360">fordvschevy</game>
+    <game wheel_type="DrivingForcePro" wheel_rotation_angle="360">fordvschevy</game>
     <game>formulachallenge</game>
-    <game wheel_type="DrivingForce" wheel_rotation="200">formulaone2001</game>
-    <game wheel_type="DrivingForce" wheel_rotation="200">formulaone2002</game>
-    <game wheel_type="DrivingForce" wheel_rotation="200">formulaone2003</game>
-    <game wheel_type="DrivingForce" wheel_rotation="200">formulaone04</game>
+    <game wheel_type="DrivingForce" wheel_rotation_angle="200">formulaone2001</game>
+    <game wheel_type="DrivingForce" wheel_rotation_angle="200">formulaone2002</game>
+    <game wheel_type="DrivingForce" wheel_rotation_angle="200">formulaone2003</game>
+    <game wheel_type="DrivingForce" wheel_rotation_angle="200">formulaone04</game>
     <game wheel_type="DrivingForcePro">formulaone05</game>
     <game wheel_type="DrivingForcePro">formulaone06</game>
-    <game wheel_type="DrivingForce" wheel_rotation="270">granturismo3</game>
+    <game wheel_type="DrivingForce" wheel_rotation_angle="270">granturismo3</game>
     <game wheel_type="DrivingForcePro">granturismo4</game>
     <game>grandprixchallenge</game>
     <game>gtcafrica</game>
@@ -239,103 +248,103 @@
     <game>ihradragracing</game>
     <game>ihraprofessionaldragracing</game>	
     <game>italianjob</game>
-    <game wheel_type="DrivingForce" wheel_rotation="200">indycarseries2005</game>
+    <game wheel_type="DrivingForce" wheel_rotation_angle="200">indycarseries2005</game>
     <game>indycarseries</game>
-    <game wheel_type="DrivingForce" wheel_rotation="360">initiald</game>
+    <game wheel_type="DrivingForce" wheel_rotation_angle="360">initiald</game>
     <game wheel_type="DrivingForcePro">juiced2</game>
     <game wheel_type="DrivingForcePro">juiced</game>
     <game wheel_type="DrivingForcePro">kaidoracer2</game>
-    <game wheel_type="DrivingForce" wheel_rotation="270">kaidoracer</game>
+    <game wheel_type="DrivingForce" wheel_rotation_angle="270">kaidoracer</game>
     <game wheel_type="DrivingForce">kaidoutougenodensetsu</game>
-    <game wheel_type="DrivingForce" wheel_rotation="200">kaidoubattle</game>
+    <game wheel_type="DrivingForce" wheel_rotation_angle="200">kaidoubattle</game>
     <game>kartracer</game>
-    <game wheel_type="DrivingForce" wheel_rotation="200">kingofroute66</game>
+    <game wheel_type="DrivingForce" wheel_rotation_angle="200">kingofroute66</game>
     <game>knightrider2</game>
-    <game wheel_type="DrivingForce" wheel_rotation="200">knightrider</game>
+    <game wheel_type="DrivingForce" wheel_rotation_angle="200">knightrider</game>
     <game>lemans24hours</game>
     <game>legoracers2</game>
     <game>londonracer</game>
     <game>looneytunesspacerace</game>
-    <game wheel_type="DrivingForce" wheel_rotation="200">lotuschallenge</game>
+    <game wheel_type="DrivingForce" wheel_rotation_angle="200">lotuschallenge</game>
     <game>masterrallye</game>
     <game>megarace3</game>
     <game wheel_type="DrivingForce">midnightclubii</game>
     <game wheel_type="DrivingForcePro">midnightclub3</game>
     <game>midnightclub</game>
-    <game wheel_type="DrivingForce" wheel_rotation="200">nascar06totalcontrol</game>
-    <game wheel_type="DrivingForce" wheel_rotation="200">nascarheat2002</game>
-    <game wheel_type="DrivingForce" wheel_rotation="200">nascarheat2003</game>
-    <game wheel_type="DrivingForce" wheel_rotation="200">nascarheat2004</game>
-    <game wheel_type="DrivingForce" wheel_rotation="200">nascar07</game>
-    <game wheel_type="DrivingForcePro" wheel_rotation="360">nascar08</game>
-    <game wheel_type="DrivingForcePro" wheel_rotation="360">nascar09</game>
-    <game wheel_type="DrivingForce" wheel_rotation="200">nascar2005</game>
+    <game wheel_type="DrivingForce" wheel_rotation_angle="200">nascar06totalcontrol</game>
+    <game wheel_type="DrivingForce" wheel_rotation_angle="200">nascarheat2002</game>
+    <game wheel_type="DrivingForce" wheel_rotation_angle="200">nascarheat2003</game>
+    <game wheel_type="DrivingForce" wheel_rotation_angle="200">nascarheat2004</game>
+    <game wheel_type="DrivingForce" wheel_rotation_angle="200">nascar07</game>
+    <game wheel_type="DrivingForcePro" wheel_rotation_angle="360">nascar08</game>
+    <game wheel_type="DrivingForcePro" wheel_rotation_angle="360">nascar09</game>
+    <game wheel_type="DrivingForce" wheel_rotation_angle="200">nascar2005</game>
     <game wheel_type="DrivingForce">nascar</game>
-    <game wheel_type="DrivingForcePro" wheel_rotation="360">needforspeedcarbon</game>
-    <game wheel_type="DrivingForce" wheel_rotation="200">needforspeedhotpursuit2</game>
+    <game wheel_type="DrivingForcePro" wheel_rotation_angle="360">needforspeedcarbon</game>
+    <game wheel_type="DrivingForce" wheel_rotation_angle="200">needforspeedhotpursuit2</game>
     <game wheel_type="DrivingForcePro">needforspeedmostwanted</game>
-    <game wheel_type="DrivingForcePro" wheel_rotation="360">needforspeedprostreet</game>
+    <game wheel_type="DrivingForcePro" wheel_rotation_angle="360">needforspeedprostreet</game>
     <game wheel_type="DrivingForcePro">needforspeedundercover</game>
     <game wheel_type="DrivingForcePro">needforspeedunderground2</game>
-    <game wheel_type="DrivingForce" wheel_rotation="200">needforspeedunderground</game>
-    <game wheel_type="DrivingForce" wheel_rotation="200">nhrachampionshipcountdown</game>
-    <game wheel_type="DrivingForce" wheel_rotation="200">nhradragracing</game>
+    <game wheel_type="DrivingForce" wheel_rotation_angle="200">needforspeedunderground</game>
+    <game wheel_type="DrivingForce" wheel_rotation_angle="200">nhrachampionshipcountdown</game>
+    <game wheel_type="DrivingForce" wheel_rotation_angle="200">nhradragracing</game>
     <game>outrun2006</game>
-    <game wheel_type="DrivingForce" wheel_rotation="200">outrun2</game>
+    <game wheel_type="DrivingForce" wheel_rotation_angle="200">outrun2</game>
     <game>parisdakar</game>
     <game>parismarseille</game>
     <game wheel_type="DrivingForcePro">professionaldriftd1grandprixseries</game>
     <game wheel_type="DrivingForce" controller="1">proracedriver</game>
     <game>prorally</game>
-    <game wheel_type="DrivingForce" wheel_rotation="200">racingsimulation</game>
+    <game wheel_type="DrivingForce" wheel_rotation_angle="200">racingsimulation</game>
     <game wheel_type="DrivingForce">rracing</game>
-    <game wheel_type="DrivingForce" wheel_rotation="200" controller="1">wrcworldrallychampionship</game>
+    <game wheel_type="DrivingForce" wheel_rotation_angle="200" controller="1">wrcworldrallychampionship</game>
     <game wheel_type="GTForce">worldrallychampionship</game>
-    <game wheel_type="DrivingForcePro" wheel_rotation="270">segarallychampionship</game>
-    <game wheel_type="DrivingForce" wheel_rotation="200">rallychampionship</game>
+    <game wheel_type="DrivingForcePro" wheel_rotation_angle="270">segarallychampionship</game>
+    <game wheel_type="DrivingForce" wheel_rotation_angle="200">rallychampionship</game>
     <game wheel_type="DrivingForcePro" controller="1">richardburnsrally</game>
     <game>ridgeracerv</game>
     <game>roadrage3</game>
     <game>rpmtuning</game>
     <game wheel_type="DrivingForce" controller="1">saturdaynightspeedway</game>
-    <game wheel_type="DrivingForce" wheel_rotation="200">segarally</game>
+    <game wheel_type="DrivingForce" wheel_rotation_angle="200">segarally</game>
     <game wheel_type="DrivingForce">shoxrallyreinvented</game>
-    <game wheel_type="DrivingForce" controller="1" wheel_rotation="200">shox</game>
-    <game wheel_type="DrivingForce" wheel_rotation="270">simpsonsthehitrun</game>
+    <game wheel_type="DrivingForce" controller="1" wheel_rotation_angle="200">shox</game>
+    <game wheel_type="DrivingForce" wheel_rotation_angle="270">simpsonsthehitrun</game>
     <game>simpsonsroadrage</game>
     <game>smashcars</game>
     <game>speedchallenge</game>
     <game>sprintcars</game>
     <game>spyhunter</game>
-    <game wheel_type="DrivingForce" wheel_rotation="200">srsstreetracingsyndicate</game>
-    <game wheel_type="DrivingForce" wheel_rotation="200">streetracingsyndicate</game>
+    <game wheel_type="DrivingForce" wheel_rotation_angle="200">srsstreetracingsyndicate</game>
+    <game wheel_type="DrivingForce" wheel_rotation_angle="200">streetracingsyndicate</game>
     <game wheel_type="DrivingForce" controller="1">starskyhutch</game>
     <game>stuntgp</game>
-    <game wheel_type="DrivingForce" wheel_rotation="200">stuntmanignition</game>
+    <game wheel_type="DrivingForce" wheel_rotation_angle="200">stuntmanignition</game>
     <game>stuntman</game>
     <game>supertrucks</game>
-    <game wheel_type="DrivingForce" wheel_rotation="270">testdriveeveofdestruction</game>
-    <game wheel_type="DrivingForce" wheel_rotation="270">testdrive</game>
+    <game wheel_type="DrivingForce" wheel_rotation_angle="270">testdriveeveofdestruction</game>
+    <game wheel_type="DrivingForce" wheel_rotation_angle="270">testdrive</game>
     <game wheel_type="DrivingForcePro">tocaracedriver2</game>
     <game wheel_type="DrivingForcePro">tocaracedriver3</game>
-    <game wheel_type="DrivingForce" wheel_rotation="200">tocaracedriver</game>
+    <game wheel_type="DrivingForce" wheel_rotation_angle="200">tocaracedriver</game>
     <game>tokyobusguide</game>
     <game>tokyoroadrace</game>
-    <game wheel_type="DrivingForce" wheel_rotation="200">tokyoxtremeracer3</game>
+    <game wheel_type="DrivingForce" wheel_rotation_angle="200">tokyoxtremeracer3</game>
     <game wheel_type="DrivingForcePro">tokyoxtremeracerdrift2</game>
-    <game wheel_type="DrivingForce" wheel_rotation="200">tokyoxtremeracerdrift</game>
+    <game wheel_type="DrivingForce" wheel_rotation_angle="200">tokyoxtremeracerdrift</game>
     <game>tokyoxtremeracerzero</game>
     <game>topgear</game>
-    <game wheel_type="DrivingForce" wheel_rotation="200" port1="2">totalimmersionracing</game>
+    <game wheel_type="DrivingForce" wheel_rotation_angle="200" port1="2">totalimmersionracing</game>
     <game>twistedmetalblack</game>
-    <game wheel_type="DrivingForce" wheel_rotation="200" controller="1" port1="2">vrally3</game>
+    <game wheel_type="DrivingForce" wheel_rotation_angle="200" controller="1" port1="2">vrally3</game>
     <game>wackyraces</game>
-    <game wheel_type="DrivingForce" wheel_rotation="200">wanganmidnight</game>
-    <game wheel_type="DrivingForce" wheel_rotation="200" port1="2">worldofoutlaws</game>
+    <game wheel_type="DrivingForce" wheel_rotation_angle="200">wanganmidnight</game>
+    <game wheel_type="DrivingForce" wheel_rotation_angle="200" port1="2">worldofoutlaws</game>
     <game>worldracing</game>
     <game wheel_type="DrivingForcePro">wrcrallyevolved</game>
-    <game wheel_type="DrivingForce" wheel_rotation="200">wrcii</game>
-    <game wheel_type="DrivingForce" wheel_rotation="200">wrc3</game>
+    <game wheel_type="DrivingForce" wheel_rotation_angle="200">wrcii</game>
+    <game wheel_type="DrivingForce" wheel_rotation_angle="200">wrc3</game>
     <game wheel_type="DrivingForcePro">wrc4</game>
   </system>
   <system name="ps3">
@@ -444,46 +453,46 @@
     <game>warmup</game>
     <game type="negcon">wipeout</game>
   </system>
-  <system name="saturn" wheel_rotation="180" wheel="joystick1left" accelerate="b" brake="y">
-    <game>andrettiracing</game>
-    <game>chronoqpark</game>
-    <game>coder</game>
-    <game>crimewave</game>
-    <game>cyberspeedway</game>
-    <game>daytonausachampionship</game>
-    <game>daytonausacircuit</game>
-    <game>daytonausa</game>
-    <game>destructionderby</game>
-    <game>f1challenge</game>
-    <game>galeracer</game>
-    <game>gt24</game>
-    <game>hangongp</game>
-    <game>hardcore4x4</game>
-    <game>highvelocity</game>
-    <game>highway2000</game>
-    <game>initiald</game>
-    <game>manxttsuperbike</game>
-    <game>nissanpresentsoverdrivin</game>
-    <game>segaagesoutrun</game>
-    <game>outrun</game>
-    <game>racedrivin</game>
-    <game>roadtrackpresentstheneedforspeed</game>
-    <game>segaagespowerdrift</game>
-    <game>segarallychampionshipplus</game>
-    <game>segarallychampionship</game>
-    <game>segatouringcarchampionship</game>
-    <game>shutokoubattle97</game>
-    <game>taitochasehq</game>
-    <game>tnnmotorsportshardcore</game>
-    <game>tougekingthespirits2</game>
-    <game>tougekingthespirits</game>
+  <system name="saturn" wheel_rotation_angle="180" wheel="joystick1left" downshift="l" upshift="r">
+    <game accelerate="c" brake="z" wheel_rotation_angle="240">andrettiracing</game>
+    <game accelerate="b" brake="a" wheel_rotation_angle="240" wheel_deadzone="20">choroqpark</game>
+    <game accelerate="c" brake="z" wheel_rotation_angle="240">coder</game>
+    <game accelerate="c" brake="b" a="z">crimewave</game>
+    <game accelerate="b" brake="a" a="c" b="z">cyberspeedway</game>
+    <game accelerate="c" brake="z" wheel_rotation_angle="240" wheel_deadzone="5" wheel_midzone="1">daytonausachampionship</game>
+    <game accelerate="c" brake="z" wheel_rotation_angle="240" wheel_deadzone="5" wheel_midzone="1">daytonausacircuit</game>
+    <game accelerate="c" brake="z" wheel_rotation_angle="240" wheel_deadzone="5" wheel_midzone="1">daytonausa</game>
+    <game accelerate="b" brake="c" a="z" wheel_rotation_angle="270">destructionderby</game>
+    <game accelerate="b" brake="c" a="z" wheel_rotation_angle="240" wheel_midzone="1">f1challenge</game>
+    <game accelerate="b" brake="c">galeracer</game>
+    <game accelerate="c" brake="b" a="z">gt24</game>
+    <game accelerate="b" brake="a" a="c" b="z" wheel_rotation_angle="240">hangongp</game>
+    <game accelerate="c" brake="b" a="z">hardcore4x4</game>
+    <game accelerate="c" brake="b" a="z">highvelocity</game>
+    <game accelerate="c" brake="x" y="z" wheel_rotation_angle="200">highway2000</game>
+    <game accelerate="c" brake="z" wheel_rotation_angle="200">initiald</game>
+    <game accelerate="c" brake="z">manxttsuperbike</game>
+    <game accelerate="c" brake="b">nascar98</game>
+    <game accelerate="c" brake="b" a="z">nissanpresentsoverdrivin</game>
+    <game accelerate="a" brake="b" y="c">racedrivin</game>
+    <game accelerate="c" brake="b" a="z">roadtrackpresentstheneedforspeed</game>
+    <game accelerate="c" brake="x">segaagespowerdrift</game>
+    <game accelerate="b" brake="c">segaagesoutrun</game>
+    <game accelerate="c" brake="z" wheel_rotation_angle="270" wheel_midzone="2">segarallychampionshipplus</game>
+    <game accelerate="c" brake="z" wheel_rotation_angle="270" wheel_midzone="2">segarallychampionship</game>
+    <game accelerate="c" brake="z" wheel_rotation_angle="270" wheel_midzone="1">segatouringcarchampionship</game>
+    <game accelerate="a" brake="b">shutokoubattle97</game>
+    <game accelerate="a" brake="b">taitochasehq</game>
+    <game accelerate="c" brake="b" a="z">tnnmotorsportshardcore</game>
+    <game accelerate="c" brake="b" a="z" wheel_rotation_angle="240">tougekingthespirits2</game>
+    <game accelerate="c" brake="b" a="z">tougekingthespirits</game>
     <game>vatlva</game>
-    <game>virtuaracing</game>
-    <game>wangandeadheatrealarrange</game>
-    <game>wangandeadheat</game>
+    <game accelerate="c" brake="b"  wheel_rotation_angle="200">virtuaracing</game>
+    <game accelerate="c" brake="z">wangandeadheatrealarrange</game>
+    <game accelerate="c" brake="z"  wheel_rotation_angle="240">wangandeadheat</game>
     <game>wangantriallove</game>
-    <game>wipeout2097</game>
-    <game>wipeout</game>
+    <game accelerate="b" downshift="x" upshift="a" a="c" b="z">wipeout2097</game>
+    <game accelerate="b" downshift="x" upshift="a" a="c">wipeout</game>
   </system>
   <system name="sg1000">
     <game>monacogp</game>


### PR DESCRIPTION
`controller="1"` means a controller must be set to port 1 
`port1="2"` means the wheel (on port 1) must be set to port 2 
Default N64 and Saturn mapping need to be redone.
Naomi/Naomi2/Atomiswave mapping need to be done in configgen.