### PR TITLE
[v40] Add settings for disabling BT and PS3 controllers

### DIFF
--- a/es-app/src/ApiSystem.cpp
+++ b/es-app/src/ApiSystem.cpp
@@ -490,6 +490,16 @@ std::string ApiSystem::getIpAdress()
 	return result;
 }
 
+bool ApiSystem::enableBluetooth()
+{
+	return executeScript("batocera-bluetooth enable 2>&1 >/dev/null");
+}
+
+bool ApiSystem::disableBluetooth()
+{
+	return executeScript("batocera-bluetooth disable");
+}
+
 void ApiSystem::startBluetoothLiveDevices(const std::function<void(const std::string)>& func)
 {
 	executeScript("batocera-bluetooth live_devices", func);

--- a/es-app/src/ApiSystem.h
+++ b/es-app/src/ApiSystem.h
@@ -167,6 +167,8 @@ public:
 
 	virtual std::string getIpAdress();
 
+	bool enableBluetooth();
+	bool disableBluetooth();
 	void startBluetoothLiveDevices(const std::function<void(const std::string)>& func);
 	void stopBluetoothLiveDevices();
 	bool pairBluetoothDevice(const std::string& deviceName);

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -815,6 +815,23 @@ void GuiMenu::openDeveloperSettings()
 	}
 //#endif
 
+#if defined(BATOCERA)
+	// PS3 controller enable
+	auto enable_ps3 = std::make_shared<SwitchComponent>(mWindow);
+	enable_ps3->setState(SystemConf::getInstance()->getBool("controllers.ps3.enabled"));
+	s->addWithDescription(_("ENABLE PS3 CONTROLLER SUPPORT"), _("Might have negative impact on security."), enable_ps3);
+	s->addSaveFunc([enable_ps3] {
+		bool ps3Enabled = enable_ps3->getState();
+		if (ps3Enabled != SystemConf::getInstance()->getBool("controllers.ps3.enabled"))
+		{
+			SystemConf::getInstance()->setBool("controllers.ps3.enabled", ps3Enabled);
+			SystemConf::getInstance()->saveSystemConf();
+			if(SystemConf::getInstance()->getBool("controllers.bluetooth.enabled"))
+				ApiSystem::getInstance()->enableBluetooth();
+		}
+	});
+#endif
+
 #if defined(WIN32)
 
 	auto hidJoysticks = std::make_shared<SwitchComponent>(mWindow);


### PR DESCRIPTION
Add settings "ENABLE BLUETOOTH" and "ENABLE PS3 CONTROLLER SUPPORT" to "CONTROLLER & BLUETOOTH SETTINGS".

This requires https://github.com/batocera-linux/batocera.linux/pull/11003