### PR TITLE
[v40] Save only changed config

### DIFF
--- a/es-core/src/SystemConf.h
+++ b/es-core/src/SystemConf.h
@@ -4,6 +4,7 @@
 
 #include <string>
 #include <map>
+#include <set>
 
 class SystemConf 
 {
@@ -27,7 +28,7 @@ private:
 	static SystemConf* sInstance;
 
 	std::map<std::string, std::string> confMap;
-	bool mWasChanged;
+	std::set<std::string> changedConf;
 
 
 	std::string mSystemConfFile;


### PR DESCRIPTION
Currently whenever a `batocera.conf` setting is changed in ES all `batocera.conf` settings **modified outside ES** are reverted to the values they had when ES was started.

This PR prevents overwriting all config in `batocera.conf` wheneven one or more config values are changed in ES. With this PR ES updates in `batocera.conf` only those settings that were changed in ES.

Although this is a bugfix I think it would be better to test it for a while (to review and merge it when development of Batocera v40 will start).