### PR TITLE
Silence TextToSpeech when launching a game

### DIFF
--- a/es-app/src/views/ViewController.cpp
+++ b/es-app/src/views/ViewController.cpp
@@ -461,6 +461,9 @@ bool ViewController::doLaunchGame(FileData* game, LaunchGameOptions options)
 {
 	if (mCurrentView) mCurrentView->onHide();
 
+	// Silence TTS when launching a game
+	TextToSpeech::getInstance()->say(" ");
+
 	if (game->launchGame(mWindow, options))
 		if (game->getSourceFileData()->getSystemName() == "windows_installers")
 			return true;


### PR DESCRIPTION
Otherwise, when there's a game description, it plays back over the launched game itself (with its own sounds and music...).