### PR TITLE
Fix crash in std::stof reading battery level 

### DIFF
--- a/es-core/src/utils/Platform.cpp
+++ b/es-core/src/utils/Platform.cpp
@@ -462,9 +462,12 @@ namespace Utils
 				// If reading from fuel gauge, we have to calculate remaining charge
 				if (batteryCapacityPath.length() <= 1)
 				{
-					float now = std::stof(Utils::FileSystem::readAllText(batteryCurrChargePath).c_str());
-					float full = std::stof(Utils::FileSystem::readAllText(batteryMaxChargePath).c_str());
-					ret.level = int(round((now / full) * 100));
+					if ((!batteryCurrChargePath.empty()) && (!batteryMaxChargePath.empty()))
+					{
+						float now = std::stof(Utils::FileSystem::readAllText(batteryCurrChargePath).c_str());
+						float full = std::stof(Utils::FileSystem::readAllText(batteryMaxChargePath).c_str());
+						ret.level = int(round((now / full) * 100));
+					}
 				}
 				else
 					ret.level = Utils::String::toInteger(Utils::FileSystem::readAllText(batteryCapacityPath).c_str());


### PR DESCRIPTION
Bug triggered on Gameforce ACE.
Both batteryCurrChargePath and batteryMaxChargePath are empty, and trigger glibc crash in std::stof call.
Protect the call the make sure we have a valid string (and we should also make sure the path exists).
