### PR TITLE
Toggle visibility of controller notifications

### DIFF
--- a/es-app/src/guis/GuiControllersSettings.cpp
+++ b/es-app/src/guis/GuiControllersSettings.cpp
@@ -108,6 +108,19 @@ GuiControllersSettings::GuiControllersSettings(Window* wnd, int autoSel) : GuiSe
 
 	addGroup(_("DISPLAY OPTIONS"));
 
+	// CONTROLLER NOTIFICATION
+	auto notification = std::make_shared<SwitchComponent>(mWindow);
+	notification->setState(Settings::getInstance()->getBool("ShowControllerNotifications"));
+	addWithLabel(_("SHOW CONTROLLER NOTIFICATIONS"), notification, autoSel == 1);
+	notification->setOnChangedCallback([this, window, notification]
+									   {
+		if (Settings::getInstance()->setBool("ShowControllerNotifications", notification->getState()))
+		{
+			Window* parent = window;
+			delete this;
+			openControllersSettings(parent, 1);
+		} });
+		
 	// CONTROLLER ACTIVITY
 	auto activity = std::make_shared<SwitchComponent>(mWindow);
 	activity->setState(Settings::getInstance()->getBool("ShowControllerActivity"));

--- a/es-core/src/InputManager.cpp
+++ b/es-core/src/InputManager.cpp
@@ -629,7 +629,7 @@ bool InputManager::parseEvent(const SDL_Event& ev, Window* window)
 #endif
 			rebuildAllJoysticks();
 
-			if (!addedDeviceName.empty()) {
+			if (Settings::getInstance()->getBool("ShowControllerNotifications") && !addedDeviceName.empty()) {
 			  if(isWheel) {
 			    window->displayNotificationMessage(_U("\uF1B9 ") + Utils::String::format(_("%s connected").c_str(), Utils::String::trim(addedDeviceName).c_str()));
 			  } else {
@@ -642,7 +642,7 @@ bool InputManager::parseEvent(const SDL_Event& ev, Window* window)
 	case SDL_JOYDEVICEREMOVED:
 		{
 			auto it = mInputConfigs.find(ev.jdevice.which);
-			if (it != mInputConfigs.cend() && it->second != nullptr) {
+			if (Settings::getInstance()->getBool("ShowControllerNotifications") && it != mInputConfigs.cend() && it->second != nullptr) {
 			  if(it->second->isWheel()) {
 			    window->displayNotificationMessage(_U("\uF1B9 ") + Utils::String::format(_("%s disconnected").c_str(), Utils::String::trim(it->second->getDeviceName()).c_str()));
 			  } else {

--- a/es-core/src/Settings.cpp
+++ b/es-core/src/Settings.cpp
@@ -145,7 +145,8 @@ void Settings::setDefaults()
 
     mBoolMap["UseOSK"] = true; // on screen keyboard
     mBoolMap["DrawClock"] = Settings::_DrawClock;
-	mBoolMap["ClockMode12"] = Settings::_ClockMode12;	
+	mBoolMap["ClockMode12"] = Settings::_ClockMode12;
+	mBoolMap["ShowControllerNotifications"] = true;	
 	mBoolMap["ShowControllerActivity"] = Settings::_ShowControllerActivity;
 	mBoolMap["ShowControllerBattery"] = Settings::_ShowControllerBattery;
     mIntMap["SystemVolume"] = 95;

--- a/locale/emulationstation2.pot
+++ b/locale/emulationstation2.pot
@@ -872,6 +872,9 @@ msgstr ""
 msgid "DISPLAY OPTIONS"
 msgstr ""
 
+msgid "SHOW CONTROLLER NOTIFICATIONS"
+msgstr ""
+
 msgid "SHOW CONTROLLER ACTIVITY"
 msgstr ""
 


### PR DESCRIPTION
Enables the ability to turn off the controller connected/disconnected notifications.

I have scripts that dynamically create controllers via `evsieve` when games launch and exit, and the notification popups are distracting.  This setting gives users the ability to turn off those notifications if desired.