### PR TITLE
Add fast game launch animations / update controller activity color

### DIFF
--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -65,9 +65,11 @@
 #endif
 
 #define fake_gettext_fade _("fade")
+#define fake_gettext_fastfade _("fast fade")
 #define fake_gettext_slide _("slide")
-#define fake_gettext_instant _("instant")
+#define fake_gettext_fastslide _("fast slide")
 #define fake_gettext_fadeslide _("fade & slide")
+#define fake_gettext_instant _("instant")
 
 #define fake_gettext_system       _("System")
 #define fake_gettext_architecture _("Architecture")
@@ -3708,8 +3710,8 @@ void GuiMenu::openUISettings()
 
 	s->addGroup(_("DISPLAY OPTIONS"));
 	s->addEntry(_("SCREENSAVER SETTINGS"), true, std::bind(&GuiMenu::openScreensaverOptions, this));
-	s->addOptionList(_("LIST TRANSITION"), { { _("auto"), "auto" },{ _("fade") , "fade" },{ _("slide"), "slide" },{ _("fade & slide"), "fade & slide" },{ _("instant"), "instant" } }, "TransitionStyle", true);
-	s->addOptionList(_("GAME LAUNCH TRANSITION"), { { _("auto"), "auto" },{ _("fade") , "fade" },{ _("slide"), "slide" },{ _("instant"), "instant" } }, "GameTransitionStyle", true);
+	s->addOptionList(_("LIST TRANSITION"), { { _("auto"), "auto" },{ _("fade"), "fade" },{ _("slide"), "slide" },{ _("fade & slide"), "fade & slide" },{ _("instant"), "instant" } }, "TransitionStyle", true);
+	s->addOptionList(_("GAME LAUNCH TRANSITION"), { { _("auto"), "auto" },{ _("fade"), "fade" },{ _("fast fade"), "fast fade" },{ _("slide"), "slide" },{ _("fast slide"), "fast slide" },{ _("instant"), "instant" } }, "GameTransitionStyle", true);
 
 	s->addSwitch(_("GAME MEDIAS DURING FAST SCROLLING"), "ScrollLoadMedias", false); 
 

--- a/es-app/src/views/ViewController.cpp
+++ b/es-app/src/views/ViewController.cpp
@@ -585,12 +585,13 @@ void ViewController::launch(FileData* game, LaunchGameOptions options, Vector3f 
 	//if (transition_style == "slide" && mCurrentView->isKindOf<GridGameListView>())
 		//transition_style = "fade";
 
-	if(transition_style == "fade")
+	if (transition_style == "fade" || transition_style == "fast fade")
 	{
+		int fadeDuration = (transition_style == "fast fade") ? 400 : 800; // Halve the duration for fast fade
 		// fade out, launch game, fade back in
 		auto fadeFunc = [this](float t) { mFadeOpacity = Math::lerp(0.0f, 1.0f, t); };
 
-		setAnimation(new LambdaAnimation(fadeFunc, 800), 0, [this, game, fadeFunc, options]
+		setAnimation(new LambdaAnimation(fadeFunc, fadeDuration), 0, [this, game, fadeFunc, options]
 		{
 			if (doLaunchGame(game, options))
 			{
@@ -606,10 +607,11 @@ void ViewController::launch(FileData* game, LaunchGameOptions options, Vector3f 
 			}
 		});
 	} 
-	else if (transition_style == "slide")
+	else if (transition_style == "slide" || transition_style == "fast slide")
 	{
+		int slideDuration = (transition_style == "fast slide") ? 750 : 1500; // Halve the duration for fast slide
 		// move camera to zoom in on center + fade out, launch game, come back in
-		setAnimation(new LaunchAnimation(mCamera, mFadeOpacity, center, 1500), 0, [this, origCamera, center, game, options]
+		setAnimation(new LaunchAnimation(mCamera, mFadeOpacity, center, slideDuration), 0, [this, origCamera, center, game, options]
 		{			
 			if (doLaunchGame(game, options))
 			{

--- a/es-core/src/components/ControllerActivityComponent.cpp
+++ b/es-core/src/components/ControllerActivityComponent.cpp
@@ -52,7 +52,7 @@ void ControllerActivityComponent::init()
 	mView = CONTROLLERS;
 
 	mColorShift = 0xFFFFFF99;
-	mActivityColor = 0xFF000066;
+	mActivityColor = 0xFF3675CA;
 	mHotkeyColor = 0x0000FF66;
 
 	mPadTexture = nullptr;


### PR DESCRIPTION
Add new game launch animations fast fade and fast slide which are twice as fast as the normal fade and slide.

Also changes the controller activity color to a different shade of blue that matches the other blue colors in the default carbon theme, as well as having a better contrast in mostly white and black backgrounds. Examples seen here: 

new color: https://convertingcolors.com/hex-color-3675CA.html?search=Hex(3675CA)

original color: https://convertingcolors.com/hex-color-000066.html?search=Hex(000066)