### PR TITLE
Enable ES to save unique config entries based on relative path

### DIFF
--- a/es-app/src/FileData.cpp
+++ b/es-app/src/FileData.cpp
@@ -110,7 +110,13 @@ const std::string FileData::getBreadCrumbPath()
 
 const std::string FileData::getConfigurationName()
 {
-	std::string gameConf = Utils::FileSystem::getFileName(getPath());
+	// "EDIT METADATA" displays subtitle: `cas/zonx.zip` (code from guis/GuiMetaDataEd.cpp near verbatim)
+	std::string gameConf = Utils::FileSystem::createRelativePath(getPath(), getSourceFileData()->getSystem()->getRootFolder()->getPath(), true);
+	if (Utils::String::startsWith(gameConf, "./"))
+		gameConf = gameConf.substr(2);
+	else
+		gameConf = Utils::FileSystem::getFileName(getPath());
+
 	gameConf = Utils::String::replace(gameConf, "=", "");
 	gameConf = Utils::String::replace(gameConf, "#", "");
 	gameConf = getSourceFileData()->getSystem()->getName() + std::string("[\"") + gameConf + std::string("\"]");


### PR DESCRIPTION
### Summary
Enables ES to save unique configs based on relative path and handle 2 cases:
1. Software with multiple media formats (eg. disk and cassette) (batocera-linux/batocera.linux#11781)
2. Multiple MAME rom sets (MAME, MAME2010, MAME2003+)

PR is to be paired with a 1 line change to `Emulator.py` (batocera-linux/batocera.linux#12038) so entries in this format can be parsed by configgen on rom launch.
### Examples
```
coco["zonx.zip"].altromtype=flop1
coco["cas/zonx.zip"].altromtype=cass
```
and
```
mame["cryptklr.zip"].core=mame
mame["cryptklr.zip"].emulator=mame
mame["mame2010/cryptklr.zip"].core=mame0139
mame["mame2010/cryptklr.zip"].emulator=libretro
```
### Custom ES build
Successfully built using [README](https://github.com/batocera-linux/batocera-emulationstation/blob/master/README.md) in this repo (but not usable in Batocera)

What is the proper procedure to build **only** batocera-emulationstation? [Instructions in our wiki](https://wiki.batocera.org/batocera.linux_buildroot_modifications) got me running with a build container but did not allow me to build just Batocera ES with the proper flags and patches.