### PR TITLE
reset system configs [WIP]

### DIFF
--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -828,6 +828,18 @@ void GuiMenu::openDeveloperSettings()
 				_("NO"), nullptr));
 		});
 	}
+	
+#ifdef BATOCERA
+    s->addEntry(_("RESET SYSTEM CONFIGS"), true, [window] 
+	{
+		window->pushGui(new GuiMsgBox(window, _("DO YOU WANT TO RETURN SYSTEM CONFIGS TO DEFAULTS AND RESTART ?"), _("YES"),
+			[window] 
+			{
+				system("/usr/bin/batocera-resetsystem");
+			},
+			_("NO"), nullptr));
+	});
+#endif
 
 	if (ApiSystem::getInstance()->isScriptingSupported(ApiSystem::DISKFORMAT))
 		s->addEntry(_("FORMAT A DISK"), true, [this] { openFormatDriveSettings(); });


### PR DESCRIPTION
Allow users to easily return system configs to defaults from within the ES GUI. Helpful for troubleshooting and resolving issues related to various config files.

There is a sister PR on batocera side so that all relevant code can be executed outside ES, so risk of any potential issues can be mitigated by stopping ES beforehand.

Sister PR here: https://github.com/batocera-linux/batocera.linux/pull/12293

