### PR TITLE
Add custom relay server option to netplay

### DIFF
--- a/es-app/src/guis/GuiNetPlaySettings.cpp
+++ b/es-app/src/guis/GuiNetPlaySettings.cpp
@@ -20,7 +20,8 @@ GuiNetPlaySettings::GuiNetPlaySettings(Window* window) : GuiSettings(window, _("
 	addGroup(_("OPTIONS"));
 
 	addInputTextRow(_("PORT"), "global.netplay.port", false);
-	addOptionList(_("USE RELAY SERVER"), { { _("NONE"), "" },{ _("NEW YORK") , "nyc" },{ _("MADRID") , "madrid" },{ _("MONTREAL") , "montreal" },{ _("SAO PAULO") , "saopaulo" } }, "global.netplay.relay", false);
+	addOptionList(_("USE RELAY SERVER"), { { _("NONE"), "" },{ _("NEW YORK") , "nyc" },{ _("MADRID") , "madrid" },{ _("MONTREAL") , "montreal" },{ _("SAO PAULO") , "saopaulo" },{ _("CUSTOM") , "custom" } }, "global.netplay.relay", false);
+	addInputTextRow(_("CUSTOM RELAY SERVER"), "global.netplay.customserver", false);
 	addSwitch(_("SHOW UNAVAILABLE GAMES"), _("Show rooms for games not present on this machine."), "NetPlayShowMissingGames", true, nullptr);
 
 	addGroup(_("GAME INDEXES"));


### PR DESCRIPTION
Add option in netplay settings:
![image](https://github.com/user-attachments/assets/e4c18eb4-2321-4cfb-a105-709bb1b68061)

The setting of custom server will be stored in es_config as "global.netplay.customserver".

Example of values generated:
`	<string name="global.netplay.customserver" value="192.168.0.9" />
	<string name="global.netplay.nickname" value="Ben" />
	<string name="global.netplay.port" value="55435" />
	<string name="global.netplay.relay" value="custom" />`