### PR TITLE
NetPlay : Add relay server ( chuncheon )

### DIFF
--- a/es-app/src/guis/GuiNetPlaySettings.cpp
+++ b/es-app/src/guis/GuiNetPlaySettings.cpp
@@ -20,7 +20,7 @@ GuiNetPlaySettings::GuiNetPlaySettings(Window* window) : GuiSettings(window, _("
 	addGroup(_("OPTIONS"));
 
 	addInputTextRow(_("PORT"), "global.netplay.port", false);
-	addOptionList(_("USE RELAY SERVER"), { { _("NONE"), "" },{ _("NEW YORK") , "nyc" },{ _("MADRID") , "madrid" },{ _("MONTREAL") , "montreal" },{ _("SAO PAULO") , "saopaulo" },{ _("CUSTOM") , "custom" } }, "global.netplay.relay", false);
+	addOptionList(_("USE RELAY SERVER"), { { _("NONE"), "" },{ _("NEW YORK") , "nyc" },{ _("MADRID") , "madrid" },{ _("MONTREAL") , "montreal" },{ _("SAO PAULO") , "saopaulo" },{ _("CHUNCHEON") , "chuncheon" },{ _("CUSTOM") , "custom" } }, "global.netplay.relay", false);
 	addInputTextRow(_("CUSTOM RELAY SERVER"), "global.netplay.customserver", false);
 	addSwitch(_("SHOW UNAVAILABLE GAMES"), _("Show rooms for games not present on this machine."), "NetPlayShowMissingGames", true, nullptr);
 


### PR DESCRIPTION
Add Chuncheon (Korea) to relay servers.
This should be ready to use as soon as RetroArch's DNS is updated.

Related PR: https://github.com/libretro/RetroArch/pull/17055