### PR TITLE
Remove isNetplayActivated check

### DIFF
--- a/es-app/src/views/ViewController.cpp
+++ b/es-app/src/views/ViewController.cpp
@@ -552,11 +552,7 @@ void ViewController::launch(FileData* game, LaunchGameOptions options, Vector3f 
 		}
 		return;
 	}
-	if (!SystemData::isNetplayActivated() || !SystemConf::getInstance()->getBool("global.netplay"))
-	{
-		options.netPlayMode = DISABLED;
-	}
-	else if (ApiSystem::getInstance()->getIpAdress() == "NOT CONNECTED")
+	if (!SystemConf::getInstance()->getBool("global.netplay") || ApiSystem::getInstance()->getIpAdress() == "NOT CONNECTED")
 	{
 		options.netPlayMode = DISABLED;
 	}


### PR DESCRIPTION
Spectator mode is possible even if core does not support netplay.
If isNetplayActivated makes the netPlayMode=DISABLED, it will be impossible to create or join in spectator mode.

