### PR TITLE
[Netplay] Hasher now computes the CRC for every system, even if they don't support NetPlay.

### DIFF
--- a/es-app/src/ThreadedHasher.cpp
+++ b/es-app/src/ThreadedHasher.cpp
@@ -190,7 +190,7 @@ void ThreadedHasher::start(Window* window, HasherType type, bool forceAllGames, 
 		if (sys->isGroupSystem() || sys->isCollection())
 			continue;
 
-		bool takeNetplay = ((type & HASH_NETPLAY_CRC) == HASH_NETPLAY_CRC);
+		bool takeNetplay = ((type & HASH_NETPLAY_CRC) == HASH_NETPLAY_CRC) && sys->isNetplaySupported();
 		bool takeCheevos = ((type & HASH_CHEEVOS_MD5) == HASH_CHEEVOS_MD5) && sys->isCheevosSupported();
 
 		if (!takeNetplay && !takeCheevos)

--- a/es-app/src/guis/GuiHashStart.cpp
+++ b/es-app/src/guis/GuiHashStart.cpp
@@ -52,7 +52,7 @@ GuiHashStart::GuiHashStart(Window* window, ThreadedHasher::HasherType type) : Gu
 		if (!sys->isGameSystem())
 			continue;
 
-		bool takeNetplay = ((type & ThreadedHasher::HASH_NETPLAY_CRC) == ThreadedHasher::HASH_NETPLAY_CRC);
+		bool takeNetplay = ((type & ThreadedHasher::HASH_NETPLAY_CRC) == ThreadedHasher::HASH_NETPLAY_CRC) && sys->isNetplaySupported();
 		bool takeCheevos = ((type & ThreadedHasher::HASH_CHEEVOS_MD5) == ThreadedHasher::HASH_CHEEVOS_MD5) && sys->isCheevosSupported();
 		if (!takeNetplay && !takeCheevos)
 			continue;


### PR DESCRIPTION
Since https://github.com/batocera-linux/batocera-emulationstation/pull/1799

The Hasher now computes the CRC for the games in every system, even if they don't support NetPlay.
-> The CRC fails for systems where games are directories (ps3, teknoparrot, dos), and it tries to re-index those files everytime ES starts.

Revert changes and limit indexation to systems that really support Netplay.