### PR TITLE
Prevent the LED sliders from being polluted by the LED daemon

### DIFF
--- a/es-app/src/ApiSystem.cpp
+++ b/es-app/src/ApiSystem.cpp
@@ -1422,7 +1422,8 @@ bool ApiSystem::getLED(int& red, int& green, int& blue)
         std::getline(ss, token);
         blue = std::stoi(token);
 
-		LOG(LogInfo) << "ApiSystem::getLED > LED colours are:" << red << " " << green << " " << blue;
+        executeScript("batocera-led-handheld block_color_changes"); // temporarily prevent changes from external daemon
+        LOG(LogInfo) << "ApiSystem::getLED > LED colours are:" << red << " " << green << " " << blue;
 
         return true;
     }


### PR DESCRIPTION
For example when getting into the Settings menu.

Longer term, I think we should remove the /sys/class/ led handling from ES, but there are other changes in the kernel for non x86_64 in flight, let's wait until this settles down.