### PR TITLE
Improve destructor performance by 97% on very large folders

### DIFF
--- a/es-app/src/FileData.h
+++ b/es-app/src/FileData.h
@@ -5,6 +5,7 @@
 #include "utils/FileSystemUtil.h"
 #include "MetaData.h"
 #include <unordered_map>
+#include <unordered_set>
 #include <memory>
 #include <vector>
 #include <stack>
@@ -251,6 +252,7 @@ public:
 
 	void addChild(FileData* file, bool assignParent = true); // Error if mType != FOLDER
 	void removeChild(FileData* file); //Error if mType != FOLDER
+	void bulkRemoveChildren(std::vector<FileData*>& mChildren, const std::unordered_set<FileData*>& filesToRemove); //Error if mType != FOLDER
 
 	void createChildrenByFilenameMap(std::unordered_map<std::string, FileData*>& map);
 


### PR DESCRIPTION
- Use iter_swap/pop_back idiom to improve FolderData::removeChild() performance
- Re-order deletions to take advantage of iter_swap/pop_back idiom
- Add FolderData::bulkRemoveChildren() and use it for removal of virtual folders
- Prevent inefficient unlinking of child files from a folder being destroyed