### PR TITLE
[NetPlay] Revert to checking isNetplaySupported() during NetPlay.

### DIFF
--- a/es-app/src/FileData.cpp
+++ b/es-app/src/FileData.cpp
@@ -588,7 +588,7 @@ std::string FileData::getlaunchCommand(LaunchGameOptions& options, bool includeC
 	if (includeControllers)
 		command = Utils::String::replace(command, "%CONTROLLERSCONFIG%", controllersConfig);
 
-	if (options.netPlayMode != DISABLED && command.find("%NETPLAY%") == std::string::npos)
+	if (options.netPlayMode != DISABLED && (forceCore || gameToUpdate->isNetplaySupported()) && command.find("%NETPLAY%") == std::string::npos)
 		command = command + " %NETPLAY%"; // Add command line parameter if the netplay option is defined at <core netplay="true"> level
 
 	if (options.netPlayMode == CLIENT || options.netPlayMode == SPECTATOR)

--- a/es-app/src/guis/GuiNetPlay.cpp
+++ b/es-app/src/guis/GuiNetPlay.cpp
@@ -320,6 +320,9 @@ FileData* GuiNetPlay::getFileData(std::string gameInfo, bool crc, std::string co
 	std::string normalizedName = normalizeName(gameInfo);
 	for (auto sys : SystemData::sSystemVector)
 	{
+		if (!sys->isNetplaySupported())
+			continue;
+
 		if (!crc)
 		{
 			bool coreExists = false;

--- a/es-app/src/views/ViewController.cpp
+++ b/es-app/src/views/ViewController.cpp
@@ -552,7 +552,8 @@ void ViewController::launch(FileData* game, LaunchGameOptions options, Vector3f 
 		}
 		return;
 	}
-	if (!SystemConf::getInstance()->getBool("global.netplay") || ApiSystem::getInstance()->getIpAdress() == "NOT CONNECTED")
+
+	if (!SystemConf::getInstance()->getBool("global.netplay") || ApiSystem::getInstance()->getIpAdress() == "NOT CONNECTED" || !game->isNetplaySupported())
 	{
 		options.netPlayMode = DISABLED;
 	}


### PR DESCRIPTION
- The behavior differs across cores. For example:
  - **Gambatte**:
    - core_info NetPlay support as `false`.
    - However, it can still run in **WATCH mode (SPECTATOR)**.
  - **PCSX ReARMed**:
    - Also reports NetPlay support as `false`.
    - Neither allows WATCH mode nor runs at all.
- This will remain as-is until RetroArch's `core_info` defines NetPlay support more granularly, such as:
  - `NetPlay support (SPECTATOR ONLY)`
  - `NetPlay support (FULL PLAY)`