### PR TITLE
Add new option : DON'T SHOW GROUPS WITH ONY ONE SYSTEM

### DIFF
--- a/es-app/src/SystemData.cpp
+++ b/es-app/src/SystemData.cpp
@@ -404,6 +404,13 @@ void SystemData::createGroupedSystems()
 
 	for (auto item : map)
 	{	
+		// Don't group if system count is only 1 		
+		if (item.second.size() == 1 && Settings::getInstance()->HideUniqueGroups())
+		{
+			item.second[0]->getSystemEnvData()->mGroup = "";
+			continue;
+		}
+		
 		SystemData* system = nullptr;
 		bool existingSystem = false;
 

--- a/es-app/src/guis/GuiCollectionSystemsOptions.cpp
+++ b/es-app/src/guis/GuiCollectionSystemsOptions.cpp
@@ -95,7 +95,22 @@ void GuiCollectionSystemsOptions::initializeMenu()
 
 		auto ungroupedSystems = std::make_shared<OptionListComponent<std::string>>(mWindow, _("GROUPED SYSTEMS"), true);
 		for (auto groupName : groupNames)
-		{			
+		{
+			std::vector<std::string> systemNames;
+			for (auto systemName : SystemData::getGroupChildSystemNames(groupName))
+				systemNames.push_back(systemName);
+
+			std::sort(systemNames.begin(), systemNames.end());
+
+			int count = 0;
+			for (auto systemName : systemNames)
+				if (systemName != groupName)
+					count++;
+	
+			// Don't group if system count is only 1
+			if (count == 1 && Settings::getInstance()->HideUniqueGroups())
+				continue;
+
 			SystemData* pSystem = SystemData::getSystem(groupName);
 			if (pSystem != nullptr)
 				ungroupedSystems->addGroup(Utils::String::toUpper(pSystem->getFullName()));
@@ -103,12 +118,6 @@ void GuiCollectionSystemsOptions::initializeMenu()
 				ungroupedSystems->addGroup(Utils::String::toUpper(groupName));
 
 			std::string description;
-
-			std::vector<std::string> systemNames;
-			for (auto systemName : SystemData::getGroupChildSystemNames(groupName))
-				systemNames.push_back(systemName);
-				
-			std::sort(systemNames.begin(), systemNames.end());
 
 			for (auto systemName : systemNames)
 			{
@@ -348,7 +357,8 @@ void GuiCollectionSystemsOptions::initializeMenu()
 	});
 
 	addSwitch(_("SHOW EMPTY SYSTEMS"), "LoadEmptySystems", true, [&] { setVariable("reloadSystems", true); });
-	
+	addSwitch(_("DON'T SHOW GROUPS WITH ONY ONE SYSTEM"), "HideUniqueGroups", true, [&] { setVariable("reloadSystems", true); });
+		
 #if defined(WIN32) && !defined(_DEBUG)		
 	if (!ApiSystem::getInstance()->isScriptingSupported(ApiSystem::GAMESETTINGS))
 		addEntry(_("UPDATE GAMELISTS"), false, [this] { GuiMenu::updateGameLists(mWindow); }); // Game List Update

--- a/es-core/src/Settings.cpp
+++ b/es-core/src/Settings.cpp
@@ -189,6 +189,7 @@ void Settings::setDefaults()
 
 	mBoolMap["GameOptionsAtNorth"] = false;
 	mBoolMap["LoadEmptySystems"] = false;
+	mBoolMap["HideUniqueGroups"] = true;	
 	
 	mIntMap["RecentlyScrappedFilter"] = 3;
 	

--- a/es-core/src/Settings.h
+++ b/es-core/src/Settings.h
@@ -99,6 +99,7 @@ public:
 	DEFINE_BOOL_SETTING(NetPlayShowOnlyRelayServerGames)
 	DEFINE_BOOL_SETTING(NetPlayShowMissingGames)			
 	DEFINE_BOOL_SETTING(LoadEmptySystems)		
+	DEFINE_BOOL_SETTING(HideUniqueGroups)
 	DEFINE_STRING_SETTING(HiddenSystems)
 	DEFINE_STRING_SETTING(TransitionStyle)
 	DEFINE_STRING_SETTING(GameTransitionStyle)		


### PR DESCRIPTION
When a group has only 1 active child system, this option allows not to create the group, but leave the system as is.