### PR TITLE
[Screensaver] Add Date Time display

### DIFF
--- a/es-app/src/SystemScreenSaver.h
+++ b/es-app/src/SystemScreenSaver.h
@@ -20,6 +20,7 @@ public:
 	virtual void setGame(FileData* mCurrentGame);
 
 	void render(const Transform4x4f& transform) override;
+	void update(int deltaTime) override;
 
 	void setOpacity(unsigned char opacity) override;
 
@@ -27,10 +28,15 @@ protected:
 	ImageComponent*		mMarquee;
 	TextComponent*		mLabelGame;
 	TextComponent*		mLabelSystem;
+	TextComponent*		mLabelDate;
+	TextComponent*		mLabelTime;
 
 	ImageComponent*		mDecoration;
 
 	Renderer::Rect		mViewport;
+
+	int 				mDateTimeUpdateAccumulator;
+	time_t				mDateTimeLastUpdate;
 };
 
 class ImageScreenSaver : public GameScreenSaverBase

--- a/es-app/src/guis/GuiGeneralScreensaverOptions.cpp
+++ b/es-app/src/guis/GuiGeneralScreensaverOptions.cpp
@@ -122,6 +122,38 @@ void GuiGeneralScreensaverOptions::addVideoScreensaverOptions(int selectItem)
 	addWithLabel(_("SHOW GAME INFO"), ss_info);
 	addSaveFunc([ss_info, this] { Settings::getInstance()->setString("ScreenSaverGameInfo", ss_info->getSelected()); });
 
+	// SHOW DATE TIME
+	{
+		bool showDateTime = Settings::getInstance()->getBool("ScreenSaverDateTime");
+
+		auto datetime_screensaver = std::make_shared<SwitchComponent>(mWindow);
+		datetime_screensaver->setState(showDateTime);
+		addWithLabel(_("SHOW DATE TIME"), datetime_screensaver, selectItem == 5);
+
+		datetime_screensaver->setOnChangedCallback([this, datetime_screensaver]()
+			{
+				if (Settings::getInstance()->setBool("ScreenSaverDateTime", datetime_screensaver->getState()))
+				{
+					Window* pw = mWindow;
+					delete this;
+					pw->pushGui(new GuiGeneralScreensaverOptions(pw, 5));
+				}
+			});
+
+		if (showDateTime)
+		{
+			auto sss_date_format = std::make_shared< OptionListComponent<std::string> >(mWindow, _("DATE FORMAT"), false);
+			sss_date_format->addRange({ "%Y-%m-%d", "%d-%m-%Y", "%A, %B %d", "%b %d, %Y" }, Settings::getInstance()->getString("ScreenSaverDateFormat"));
+			addWithLabel(_("DATE FORMAT"), sss_date_format);
+			addSaveFunc([sss_date_format] { Settings::getInstance()->setString("ScreenSaverDateFormat", sss_date_format->getSelected()); });
+
+			auto sss_time_format = std::make_shared< OptionListComponent<std::string> >(mWindow, _("TIME FORMAT"), false);
+			sss_time_format->addRange({ "%H:%M:%S", "%I:%M %p", "%p %I:%M" }, Settings::getInstance()->getString("ScreenSaverTimeFormat"));
+			addWithLabel(_("TIME FORMAT"), sss_time_format);
+			addSaveFunc([sss_time_format] { Settings::getInstance()->setString("ScreenSaverTimeFormat", sss_time_format->getSelected()); });
+		}
+	}
+
 	bool advancedOptions = true;
 
 #ifdef _RPI_
@@ -212,6 +244,38 @@ void GuiGeneralScreensaverOptions::addSlideShowScreensaverOptions(int selectItem
 	ss_controls->setState(Settings::getInstance()->getBool("SlideshowScreenSaverGameName"));
 	addWithLabel(_("SHOW GAME INFO"), ss_controls);
 	addSaveFunc([ss_controls] { Settings::getInstance()->setBool("SlideshowScreenSaverGameName", ss_controls->getState()); });
+
+	// SHOW DATE TIME
+	{
+		bool showDateTime = Settings::getInstance()->getBool("ScreenSaverDateTime");
+
+		auto datetime_screensaver = std::make_shared<SwitchComponent>(mWindow);
+		datetime_screensaver->setState(showDateTime);
+		addWithLabel(_("SHOW DATE TIME"), datetime_screensaver, selectItem == 6);
+
+		datetime_screensaver->setOnChangedCallback([this, datetime_screensaver]()
+			{
+				if (Settings::getInstance()->setBool("ScreenSaverDateTime", datetime_screensaver->getState()))
+				{
+					Window* pw = mWindow;
+					delete this;
+					pw->pushGui(new GuiGeneralScreensaverOptions(pw, 6));
+				}
+			});
+
+		if (showDateTime)
+		{
+			auto sss_date_format = std::make_shared< OptionListComponent<std::string> >(mWindow, _("DATE FORMAT"), false);
+			sss_date_format->addRange({ "%Y-%m-%d", "%d-%m-%Y", "%A, %B %d", "%b %d, %Y"}, Settings::getInstance()->getString("ScreenSaverDateFormat"));
+			addWithLabel(_("DATE FORMAT"), sss_date_format);
+			addSaveFunc([sss_date_format] { Settings::getInstance()->setString("ScreenSaverDateFormat", sss_date_format->getSelected()); });
+
+			auto sss_time_format = std::make_shared< OptionListComponent<std::string> >(mWindow, _("TIME FORMAT"), false);
+			sss_time_format->addRange({ "%H:%M:%S", "%I:%M %p", "%p %I:%M"}, Settings::getInstance()->getString("ScreenSaverTimeFormat"));
+			addWithLabel(_("TIME FORMAT"), sss_time_format);
+			addSaveFunc([sss_time_format] { Settings::getInstance()->setString("ScreenSaverTimeFormat", sss_time_format->getSelected()); });
+		}
+	}
 
 	auto marquee_screensaver = std::make_shared<SwitchComponent>(mWindow);
 	marquee_screensaver->setState(Settings::getInstance()->getBool("ScreenSaverMarquee"));

--- a/es-core/src/Settings.cpp
+++ b/es-core/src/Settings.cpp
@@ -224,7 +224,10 @@ void Settings::setDefaults()
 	mStringMap["ScrapperLogoSrc"] = "wheel";
 	mBoolMap["ScrapeVideos"] = false;
 	mBoolMap["ScrapeShortTitle"] = false;
-	
+
+	mBoolMap["ScreenSaverDateTime"] = false;
+	mStringMap["ScreenSaverDateFormat"] = "%Y-%m-%d";
+	mStringMap["ScreenSaverTimeFormat"] = "%H:%M:%S";
 	mBoolMap["ScreenSaverMarquee"] = true;
 	mBoolMap["ScreenSaverControls"] = true;
 	mStringMap["ScreenSaverGameInfo"] = "never";


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/c9100fbb-d0d9-4495-b016-3f86f968b76b)
![image](https://github.com/user-attachments/assets/2340836f-b632-456e-bf75-a6a6906200f3)


- Added SHOW DATE TIME option to toggle date and time display.
- Select the display format using DATE FORMAT and TIME FORMAT options.
- This feature works with both RANDOM VIDEO and SLIDESHOW modes.