### PR TITLE
Fix systems automatically hidden when closing settings

### DIFF
--- a/es-app/src/guis/GuiCollectionSystemsOptions.cpp
+++ b/es-app/src/guis/GuiCollectionSystemsOptions.cpp
@@ -43,14 +43,14 @@ void GuiCollectionSystemsOptions::initializeMenu()
 				man = system->getSystemMetadata().manufacturer;
 			}
 
-			displayedSystems->add(system->getFullName(), system, std::find(hiddenSystems.cbegin(), hiddenSystems.cend(), system->getName()) == hiddenSystems.cend());
+			displayedSystems->add(system->getFullName(), system, std::find(hiddenSystems.cbegin(), hiddenSystems.cend(), system->getName()) == hiddenSystems.cend(), false);
 		}
 	}
 	else
 	{
 		for (auto system : SystemData::sSystemVector)
 			if (!system->isCollection()/* && !system->isGroupChildSystem()*/)
-				displayedSystems->add(system->getFullName(), system, std::find(hiddenSystems.cbegin(), hiddenSystems.cend(), system->getName()) == hiddenSystems.cend());
+				displayedSystems->add(system->getFullName(), system, std::find(hiddenSystems.cbegin(), hiddenSystems.cend(), system->getName()) == hiddenSystems.cend(), false);
 	}
 
 	addWithLabel(_("SYSTEMS DISPLAYED"), displayedSystems);


### PR DESCRIPTION
Hi.

I observed that when two systems share the same `<fullName>`, they get automatically hidden upon changing the settings, despite not being explicitly unchecked from the list of systems to hide.

This is a small inconvenience but this surprised me, as I was not expecting my systems to disappear this way (it's not uncommon to share the same "full names" for US/JP versions for example).

The fix implemented here is quite straightforward: duplicates should not be removed when listing systems by their full name in the settings. We could also imagine a disambiguation display instead of duplicates.

Before:

https://github.com/user-attachments/assets/90c5868b-8bd5-4641-99a2-6a105ce5a27e


After:

https://github.com/user-attachments/assets/9adb22f6-7a10-4394-bbd8-e523e2844fd7



