### PR TITLE
[Netplay] Reverted #1799 causing fragmentation

### DIFF
--- a/es-app/src/FileData.cpp
+++ b/es-app/src/FileData.cpp
@@ -587,6 +587,12 @@ std::string FileData::getlaunchCommand(LaunchGameOptions& options, bool includeC
 	if (options.netPlayMode != DISABLED && (forceCore || gameToUpdate->isNetplaySupported()) && command.find("%NETPLAY%") == std::string::npos)
 		command = command + " %NETPLAY%"; // Add command line parameter if the netplay option is defined at <core netplay="true"> level
 
+	if (SystemConf::getInstance()->get("global.netplay.nickname").empty())
+	{
+		SystemConf::getInstance()->set("global.netplay.nickname", ApiSystem::getInstance()->getApplicationName() + " Player");
+		SystemConf::getInstance()->saveSystemConf();
+	}
+
 	if (options.netPlayMode == CLIENT || options.netPlayMode == SPECTATOR)
 	{
 		std::string mode = (options.netPlayMode == SPECTATOR ? "spectator" : "client");

--- a/es-app/src/FileData.h
+++ b/es-app/src/FileData.h
@@ -38,8 +38,7 @@ enum NetPlayMode
 	DISABLED,
 	CLIENT,
 	SERVER,	
-	SPECTATOR,
-	OFFLINE,
+	SPECTATOR
 };
 
 struct GetFileContext

--- a/es-app/src/guis/GuiGameOptions.cpp
+++ b/es-app/src/guis/GuiGameOptions.cpp
@@ -165,7 +165,7 @@ GuiGameOptions::GuiGameOptions(Window* window, FileData* game) : GuiComponent(wi
 			});
 		}
 
-		if (game->isNetplaySupported() && !Settings::NetPlayShowOptionsWhenLaunchingGames())
+		if (game->isNetplaySupported())
 		{
 			mMenu.addEntry(_("START A NETPLAY GAME"), false, [window, game, this]
 				{

--- a/es-app/src/guis/GuiNetPlay.cpp
+++ b/es-app/src/guis/GuiNetPlay.cpp
@@ -147,13 +147,12 @@ static std::map<std::string, std::string> coreList =
 #endif
 };
 
-GuiNetPlay::GuiNetPlay(Window* window, FileData* targetGame)
+GuiNetPlay::GuiNetPlay(Window* window)
 	: GuiComponent(window), 
 	mBusyAnim(window),
 	mBackground(window, ":/frame.png"),
 	mGrid(window, Vector2i(1, 3)),
-	mList(nullptr),
-	mTargetGame(targetGame)
+	mList(nullptr)
 {	
 	addChild(&mBackground);
 	addChild(&mGrid);
@@ -171,10 +170,7 @@ GuiNetPlay::GuiNetPlay(Window* window, FileData* targetGame)
 	mHeaderGrid = std::make_shared<ComponentGrid>(mWindow, Vector2i(1, 5));
 
 	mTitle = std::make_shared<TextComponent>(mWindow, _("CONNECT TO NETPLAY"), theme->Title.font, theme->Title.color, ALIGN_CENTER);
-	if (mTargetGame == nullptr)
-		mSubtitle = std::make_shared<TextComponent>(mWindow, _("Select a game lobby to join"), theme->TextSmall.font, theme->TextSmall.color, ALIGN_CENTER);
-	else
-		mSubtitle = std::make_shared<TextComponent>(mWindow, _("Select a game lobby to create or join"), theme->TextSmall.font, theme->TextSmall.color, ALIGN_CENTER);
+	mSubtitle = std::make_shared<TextComponent>(mWindow, _("Select a game lobby to join"), theme->TextSmall.font, theme->TextSmall.color, ALIGN_CENTER);
 	
 	mHeaderGrid->setEntry(mTitle, Vector2i(0, 1), false, true);
 	mHeaderGrid->setEntry(mSubtitle, Vector2i(0, 3), false, true);
@@ -505,8 +501,7 @@ bool GuiNetPlay::populateFromJson(const std::string json)
 	}
 
 	std::vector<LobbyAppEntry> entries;
-	const std::string targetCRC = mTargetGame == nullptr ? "" : mTargetGame->getMetadata(MetaDataId::Crc32);
-	bool netPlayShowOnlyRelayServerGames = Settings::NetPlayShowOnlyRelayServerGames();
+	entries.reserve(doc.Size());
 
 	for (auto& item : doc.GetArray())
 	{
@@ -543,9 +538,6 @@ bool GuiNetPlay::populateFromJson(const std::string json)
 		if (fields.HasMember("game_crc") && fields["game_crc"].IsString())
 			game.game_crc = fields["game_crc"].GetString();
 
-		if (!targetCRC.empty() && targetCRC != game.game_crc)
-			continue;
-
 		if (file != nullptr)
 		{
 			std::string fileCRC = file->getMetadata(MetaDataId::Crc32);
@@ -577,9 +569,6 @@ bool GuiNetPlay::populateFromJson(const std::string json)
 		if (fields.HasMember("host_method") && fields["host_method"].IsInt())
 			game.host_method = fields["host_method"].GetInt();
 
-		if (netPlayShowOnlyRelayServerGames && game.host_method != 3)
-			continue;
-
 		if (fields.HasMember("has_password") && fields["has_password"].IsBool())
 			game.has_password = fields["has_password"].GetBool();
 
@@ -606,49 +595,18 @@ bool GuiNetPlay::populateFromJson(const std::string json)
 
 		game.coreExists = coreExists(file, game.core_name);
 
-		entries.push_back(game);
+		entries.push_back(std::move(game));
 	}	
-
-	auto theme = ThemeData::getMenuTheme();
 
 	bool groupAvailable = false;
 
-	struct { bool operator()(LobbyAppEntry& a, LobbyAppEntry& b) const 
-	{ 
-		if (a.isCrcValid == b.isCrcValid)
-			return a.coreExists && !b.coreExists;
-
-		return a.isCrcValid && !b.isCrcValid;
-	} } sortByValidCrc;
-
-	std::sort(entries.begin(), entries.end(), sortByValidCrc);
-
-	if (mTargetGame != nullptr)
-	{
-		auto addPlayOption = [this](const std::string& label, NetPlayMode mode) {
-			ComponentListRow row;
-			auto textComponent = std::make_shared<TextComponent>(mWindow);
-			textComponent->setText(label);
-			row.addElement(textComponent, true);
-
-			row.makeAcceptInputHandler([this, mode] {
-				LaunchGameOptions options;
-				options.netPlayMode = mode;
-				ViewController::get()->launch(mTargetGame, options);
-
-				delete this;
-			});
-
-			mList->addRow(row);
-		};
-
-		addPlayOption(_("PLAY ONLINE AS HOST"), SERVER);
-		addPlayOption(_("PLAY OFFLINE"), OFFLINE);
-	}
+	std::sort(entries.begin(), entries.end(), [](const LobbyAppEntry& a, const LobbyAppEntry& b) {
+		return a.isCrcValid ? !b.isCrcValid : (a.coreExists && !b.coreExists);
+	});
 
 	bool netPlayShowMissingGames = Settings::NetPlayShowMissingGames();
 
-	for (auto game : entries)
+	for (auto& game : entries)
 	{
 		if (game.fileData == nullptr)
 			continue;
@@ -658,11 +616,7 @@ bool GuiNetPlay::populateFromJson(const std::string json)
 
 		if (netPlayShowMissingGames && !groupAvailable)
 		{			
-			if (mTargetGame != nullptr)
-				mList->addGroup(_("JOIN EXISTING GAME"), true);
-			else
-				mList->addGroup(_("AVAILABLE GAMES"), true);
-
+			mList->addGroup(_("AVAILABLE GAMES"), true);
 			groupAvailable = true;
 		}
 		
@@ -672,14 +626,14 @@ bool GuiNetPlay::populateFromJson(const std::string json)
 		if (game.fileData != nullptr)
 			row.makeAcceptInputHandler([this, game] { launchGame(game); });
 
-		mList->addRow(row);
+		mList->addRow(std::move(row));
 	}
 
 	if (netPlayShowMissingGames)
 	{
 		bool groupUnavailable = false;
 
-		for (auto game : entries)
+		for (auto& game : entries)
 		{
 			if (game.fileData != nullptr)
 				continue;
@@ -692,7 +646,7 @@ bool GuiNetPlay::populateFromJson(const std::string json)
 
 			ComponentListRow row;
 			row.addElement(std::make_shared<NetPlayLobbyListEntry>(mWindow, game), true);
-			mList->addRow(row);
+			mList->addRow(std::move(row));
 		}
 	}
 
@@ -702,7 +656,7 @@ bool GuiNetPlay::populateFromJson(const std::string json)
 		auto empty = std::make_shared<TextComponent>(mWindow);
 		empty->setText(_("NO GAMES FOUND"));
 		row.addElement(empty, true);
-		mList->addRow(row);
+		mList->addRow(std::move(row));
 
 		mGrid.moveCursor(Vector2i(0, 1));
 	}

--- a/es-app/src/guis/GuiNetPlay.h
+++ b/es-app/src/guis/GuiNetPlay.h
@@ -44,7 +44,7 @@ struct LobbyAppEntry
 class GuiNetPlay : public GuiComponent 
 {
 public:
-	GuiNetPlay(Window* window, FileData* targetGame = nullptr);
+	GuiNetPlay(Window* window);
 
 	void update(int deltaTime) override;
 	void render(const Transform4x4f &parentTrans) override;
@@ -77,6 +77,4 @@ private:
 	BusyComponent					mBusyAnim;
 
 	std::unique_ptr<HttpReq>		mLobbyRequest;
-
-	FileData*						mTargetGame;
 };

--- a/es-app/src/guis/GuiNetPlaySettings.cpp
+++ b/es-app/src/guis/GuiNetPlaySettings.cpp
@@ -22,17 +22,6 @@ GuiNetPlaySettings::GuiNetPlaySettings(Window* window) : GuiSettings(window, _("
 	addInputTextRow(_("PORT"), "global.netplay.port", false);
 	addOptionList(_("USE RELAY SERVER"), { { _("NONE"), "" },{ _("NEW YORK") , "nyc" },{ _("MADRID") , "madrid" },{ _("MONTREAL") , "montreal" },{ _("SAO PAULO") , "saopaulo" },{ _("CUSTOM") , "custom" } }, "global.netplay.relay", false);
 	addInputTextRow(_("CUSTOM RELAY SERVER"), "global.netplay.customserver", false);
-
-	auto public_announce = std::make_shared<SwitchComponent>(mWindow);
-	public_announce->setState(SystemConf::getInstance()->getBool("global.netplay_public_announce"));
-	addWithLabel(_("PUBLICLY ANNOUNCE GAME"), public_announce);
-	addSaveFunc([public_announce] { SystemConf::getInstance()->setBool("global.netplay_public_announce", public_announce->getState()); });
-
-	addInputTextRow(_("PLAYER PASSWORD"), "global.netplay.password", false);
-	addInputTextRow(_("VIEWER PASSWORD"), "global.netplay.spectatepassword", false);
-
-	addSwitch(_("SHOW NETPLAY OPTIONS WHEN LAUNCHING GAME"), _("Allows choice of online, offline, or joining another game."), "NetPlayShowOptionsWhenLaunchingGames", true, nullptr);
-	addSwitch(_("SHOW RELAY SERVER GAMES ONLY"), _("Relay server games have a higher chance of successful entry."), "NetPlayShowOnlyRelayServerGames", true, nullptr);
 	addSwitch(_("SHOW UNAVAILABLE GAMES"), _("Show rooms for games not present on this machine."), "NetPlayShowMissingGames", true, nullptr);
 
 	addGroup(_("GAME INDEXES"));

--- a/es-app/src/views/ViewController.cpp
+++ b/es-app/src/views/ViewController.cpp
@@ -554,14 +554,9 @@ void ViewController::launch(FileData* game, LaunchGameOptions options, Vector3f 
 	}
 
 	if (!SystemConf::getInstance()->getBool("global.netplay") || ApiSystem::getInstance()->getIpAddress() == "NOT CONNECTED" || !game->isNetplaySupported())
-	{
 		options.netPlayMode = DISABLED;
-	}
-	else if (options.netPlayMode == DISABLED && Settings::getInstance()->getBool("NetPlayShowOptionsWhenLaunchingGames"))
-	{
-		mWindow->pushGui(new GuiNetPlay(mWindow, game));
-		return;
-	}
+	else if (options.netPlayMode == DISABLED && SystemConf::getInstance()->getBool("global.netplay_public_announce"))
+		options.netPlayMode = SERVER;
 	
 	Transform4x4f origCamera = mCamera;
 	origCamera.translation() = -mCurrentView->getPosition();

--- a/es-core/src/Settings.cpp
+++ b/es-core/src/Settings.cpp
@@ -353,8 +353,6 @@ void Settings::setDefaults()
 	mIntMap["audio.display_titles_time"] = 10;
 
 	mBoolMap["NetPlayCheckIndexesAtStart"] = false;
-	mBoolMap["NetPlayShowOptionsWhenLaunchingGames"] = false;
-	mBoolMap["NetPlayShowOnlyRelayServerGames"] = false;
 	mBoolMap["NetPlayShowMissingGames"] = false;
 	
 	mBoolMap["CheevosCheckIndexesAtStart"] = false;	

--- a/es-core/src/Settings.h
+++ b/es-core/src/Settings.h
@@ -95,8 +95,6 @@ public:
 	DEFINE_BOOL_SETTING(ThreadedLoading)
 	DEFINE_BOOL_SETTING(CheevosCheckIndexesAtStart)
 	DEFINE_BOOL_SETTING(NetPlayCheckIndexesAtStart)
-	DEFINE_BOOL_SETTING(NetPlayShowOptionsWhenLaunchingGames)
-	DEFINE_BOOL_SETTING(NetPlayShowOnlyRelayServerGames)
 	DEFINE_BOOL_SETTING(NetPlayShowMissingGames)			
 	DEFINE_BOOL_SETTING(LoadEmptySystems)		
 	DEFINE_BOOL_SETTING(HideUniqueGroups)


### PR DESCRIPTION
It seems that no one is interested in this feature even in the new release, and it rather causes fragmented approaches to Netplay access, leading to confusion.

I have reverted #1799 and modified it to enable only the host option with the existing `netplay_public_announce` setting.
And a default value is set if the `netplay.nickname` is empty.

I apologize for bothering the Batocera team.
Feel free to let me know if there are any parts that need to be revised.
