### PR TITLE
Add ps4 screenscraper ID + win32 gun models in gunmanager

### DIFF
--- a/es-app/src/scrapers/ScreenScraper.cpp
+++ b/es-app/src/scrapers/ScreenScraper.cpp
@@ -94,7 +94,7 @@ const std::map<PlatformId, unsigned short> screenscraper_platformid_map{
 	{ PLAYSTATION, 57 },
 	{ PLAYSTATION_2, 58 },
 	{ PLAYSTATION_3, 59 },
-	// missing Sony Playstation 4 ?
+	{ PLAYSTATION_4, 60 },
 	{ PLAYSTATION_VITA, 62 },
 	{ PLAYSTATION_PORTABLE, 61 },
 	{ SUPER_NINTENDO, 4 },

--- a/es-core/src/GunManager.cpp
+++ b/es-core/src/GunManager.cpp
@@ -37,7 +37,11 @@ enum class LightGunType
 	Mouse,
 	SindenLightgun,
 	Gun4Ir,
-	MayFlashWiimote
+	MayFlashWiimote,
+	RetroShooter,
+	Blamcon,
+	Aimtrak,
+	AELightgun
 };
 
 class RawInputManager
@@ -52,7 +56,7 @@ public:
 			if (name.find(id) != std::string::npos)
 				return LightGunType::SindenLightgun;
 
-		std::string gun4irDeviceIds[] = { "VID_2341&PID_8042", "VID_2341&PID_8043", "VID_2341&PID_8044", "VID_2341&PID_8045" };
+		std::string gun4irDeviceIds[] = { "VID_2341&PID_8042", "VID_2341&PID_8043", "VID_2341&PID_8044", "VID_2341&PID_8045", "VID_2341&PID_8046", "VID_2341&PID_8047" };
 		for (auto id : gun4irDeviceIds)
 			if (name.find(id) != std::string::npos)
 				return LightGunType::Gun4Ir;
@@ -61,6 +65,26 @@ public:
 		for (auto id : mayFlashWiimoteIds)
 			if (name.find(id) != std::string::npos)
 				return LightGunType::MayFlashWiimote;
+
+		std::string rsDeviceIds[] = { "VID_0483&PID_5750", "VID_0483&PID_5751", "VID_0483&PID_5752", "VID_0483&PID_5753" };
+		for (auto id : rsDeviceIds)
+			if (name.find(id) != std::string::npos)
+				return LightGunType::RetroShooter;
+
+		std::string blamconDeviceIds[] = { "VID_3673&PID_0100", "VID_3673&PID_0101", "VID_3673&PID_0102", "VID_3673&PID_0103", "VID_3673&PID_0104" };
+		for (auto id : blamconDeviceIds)
+			if (name.find(id) != std::string::npos)
+				return LightGunType::Blamcon;
+
+		std::string aimtrakDeviceIds[] = { "VID_D209&PID_1601", "VID_D209&PID_1602", "VID_D209&PID_1603" };
+		for (auto id : aimtrakDeviceIds)
+			if (name.find(id) != std::string::npos)
+				return LightGunType::Aimtrak;
+
+		std::string aeDeviceIds[] = { "VID_2341&PID_8037", "VID_2341&PID_8038" };
+		for (auto id : aeDeviceIds)
+			if (name.find(id) != std::string::npos)
+				return LightGunType::AELightgun;
 
 		return LightGunType::Mouse;
 	}


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/15d2168c-8c95-4270-bfe0-a739d570c913)

![image](https://github.com/user-attachments/assets/5a3cd823-beb0-4b7d-8342-fbc7801234d2)


@nadenislamarre : can you validate this PR ?