### PR TITLE
[Netplay] lobby loading speed using futures

### DIFF
--- a/es-app/src/guis/GuiNetPlay.cpp
+++ b/es-app/src/guis/GuiNetPlay.cpp
@@ -1,6 +1,7 @@
 #include "GuiNetPlay.h"
 #include "Window.h"
 #include <string>
+#include <future>
 #include "Log.h"
 #include "Settings.h"
 #include "SystemConf.h"
@@ -318,6 +319,9 @@ FileData* GuiNetPlay::getFileData(std::string gameInfo, bool crc, std::string co
 		lowCore = Utils::String::toLower(Utils::String::replace(coreName, " ", "_"));
 	
 	std::string normalizedName = normalizeName(gameInfo);
+	std::string normalizedNameNoSpace = Utils::String::replace(normalizedName, " ", "");
+
+	std::vector<std::future<FileData*>> futures;
 	for (auto sys : SystemData::sSystemVector)
 	{
 		if (!sys->isNetplaySupported())
@@ -330,36 +334,49 @@ FileData* GuiNetPlay::getFileData(std::string gameInfo, bool crc, std::string co
 			for (auto& emul : sys->getEmulators())
 				for (auto& core : emul.cores)
 					if (Utils::String::toLower(core.name) == lowCore)
+					{
 						coreExists = true;
+						break;
+					}
 
 			if (!coreExists)
 				continue;
 		}
 
-		for (auto file : sys->getRootFolder()->getFilesRecursive(GAME))
-		{
-			if (crc)
+		futures.push_back(std::async(std::launch::async, [sys, crc, gameInfo, normalizedName, normalizedNameNoSpace, &normalizeName]() -> FileData* {
+			for (auto file : sys->getRootFolder()->getFilesRecursive(GAME, false, sys))
 			{
-				if (file->getMetadata(MetaDataId::Crc32) == gameInfo)
-					return file;
+				if (crc)
+				{
+					if (file->getMetadata(MetaDataId::Crc32) == gameInfo)
+						return file;
 
-				continue;
+					continue;
+				}
+				else
+				{
+					std::string stem = normalizeName(file->getName());
+					if (stem == normalizedName)
+						return file;
+
+					stem = normalizeName(Utils::FileSystem::getStem(file->getPath()));
+					if (stem == normalizedName)
+						return file;
+
+					stem = Utils::String::replace(normalizeName(file->getName()), " ", "");
+					if (stem == Utils::String::replace(normalizedName, " ", ""))
+						return file;
+				}
 			}
-			else
-			{
-				std::string stem = normalizeName(file->getName());
-				if (stem == normalizedName)
-					return file;
+			return nullptr;
+		}));
+	}
 
-				stem = normalizeName(Utils::FileSystem::getStem(file->getPath()));
-				if (stem == normalizedName)
-					return file;
-
-				stem = Utils::String::replace(normalizeName(file->getName()), " ", "");
-				if (stem == Utils::String::replace(normalizedName, " ", ""))
-					return file;
-			}
-		}
+	for (auto& fut : futures)
+	{
+		FileData* file = fut.get();
+		if (file != nullptr)
+			return file;
 	}
 
 	return nullptr;


### PR DESCRIPTION

https://github.com/user-attachments/assets/d3f55bc5-a421-4763-8a5a-efdf144804be



Left: Current version, Right: Improved version.

Both have the same game_list size (16017),
and the Netplay lobby loading speed has been improved using futures.

Building a cache using Crc32 or name in FileData.cpp would be faster,
but due to concerns about performance on low-end devices, futures were used instead.