### PR TITLE
Fixing "game-selected" event firing issue

### DIFF
--- a/es-app/src/views/ViewController.cpp
+++ b/es-app/src/views/ViewController.cpp
@@ -344,6 +344,13 @@ void ViewController::goToGameList(SystemData* system, bool forceImmediate)
 		cancelAnimation(0);
 		mDeferPlayViewTransitionTo = view;
 	}
+	
+	// Call setSelectedGame() after setting the current view
+    FileData* selectedGame = view->getCursor();
+    if (selectedGame != nullptr)
+    {
+        selectedGame->setSelectedGame();
+    }
 }
 
 void ViewController::playViewTransition(bool forceImmediate)


### PR DESCRIPTION
Fix for the first "game-selected" script event not fire when come from system menu view to games view