### PR TITLE
[NetPlay] Added Netplay options: Auto Lobby & Relay Filter

### DIFF
--- a/es-app/src/guis/GuiNetPlay.cpp
+++ b/es-app/src/guis/GuiNetPlay.cpp
@@ -784,6 +784,8 @@ bool GuiNetPlay::populateFromJson(const std::string json)
 		return false;
 	}
 
+	bool netPlayShowOnlyRelayServerGames = Settings::NetPlayShowOnlyRelayServerGames();
+
 	std::vector<LobbyAppEntry> entries;
 	entries.reserve(doc.Size());
 
@@ -798,6 +800,12 @@ bool GuiNetPlay::populateFromJson(const std::string json)
 
 		LobbyAppEntry game;	
 		game.isCrcValid = false;
+
+		if (fields.HasMember("host_method") && fields["host_method"].IsInt())
+			game.host_method = fields["host_method"].GetInt();
+
+		if (netPlayShowOnlyRelayServerGames && game.host_method != 3)
+			continue;
 
 		if (fields.HasMember("core_name") && fields["core_name"].IsString())
 			game.core_name = fields["core_name"].GetString();
@@ -849,9 +857,6 @@ bool GuiNetPlay::populateFromJson(const std::string json)
 
 		if (fields.HasMember("country") && fields["country"].IsString())
 			game.country = fields["country"].GetString();
-
-		if (fields.HasMember("host_method") && fields["host_method"].IsInt())
-			game.host_method = fields["host_method"].GetInt();
 
 		if (fields.HasMember("has_password") && fields["has_password"].IsBool())
 			game.has_password = fields["has_password"].GetBool();

--- a/es-app/src/guis/GuiNetPlaySettings.cpp
+++ b/es-app/src/guis/GuiNetPlaySettings.cpp
@@ -22,6 +22,9 @@ GuiNetPlaySettings::GuiNetPlaySettings(Window* window) : GuiSettings(window, _("
 	addInputTextRow(_("PORT"), "global.netplay.port", false);
 	addOptionList(_("USE RELAY SERVER"), { { _("NONE"), "" },{ _("NEW YORK") , "nyc" },{ _("MADRID") , "madrid" },{ _("MONTREAL") , "montreal" },{ _("SAO PAULO") , "saopaulo" },{ _("CUSTOM") , "custom" } }, "global.netplay.relay", false);
 	addInputTextRow(_("CUSTOM RELAY SERVER"), "global.netplay.customserver", false);
+
+	addSwitch(_("AUTOMATICALLY CREATE LOBBY"), _("Automatically creates a Netplay lobby when starting a game."), "NetPlayAutomaticallyCreateLobby", true, nullptr);
+	addSwitch(_("SHOW RELAY SERVER GAMES ONLY"), _("Relay server games have a higher chance of successful entry."), "NetPlayShowOnlyRelayServerGames", true, nullptr);
 	addSwitch(_("SHOW UNAVAILABLE GAMES"), _("Show rooms for games not present on this machine."), "NetPlayShowMissingGames", true, nullptr);
 
 	addGroup(_("GAME INDEXES"));

--- a/es-app/src/views/ViewController.cpp
+++ b/es-app/src/views/ViewController.cpp
@@ -555,6 +555,8 @@ void ViewController::launch(FileData* game, LaunchGameOptions options, Vector3f 
 
 	if (!SystemConf::getInstance()->getBool("global.netplay") || ApiSystem::getInstance()->getIpAddress() == "NOT CONNECTED" || !game->isNetplaySupported())
 		options.netPlayMode = DISABLED;
+	else if (options.netPlayMode == DISABLED && Settings::getInstance()->getBool("NetPlayAutomaticallyCreateLobby"))
+		options.netPlayMode = SERVER;
 	
 	Transform4x4f origCamera = mCamera;
 	origCamera.translation() = -mCurrentView->getPosition();

--- a/es-core/src/Settings.cpp
+++ b/es-core/src/Settings.cpp
@@ -357,6 +357,8 @@ void Settings::setDefaults()
 	mIntMap["audio.display_titles_time"] = 10;
 
 	mBoolMap["NetPlayCheckIndexesAtStart"] = false;
+	mBoolMap["NetPlayAutomaticallyCreateLobby"] = false;
+	mBoolMap["NetPlayShowOnlyRelayServerGames"] = false;
 	mBoolMap["NetPlayShowMissingGames"] = false;
 	
 	mBoolMap["CheevosCheckIndexesAtStart"] = false;	

--- a/es-core/src/Settings.h
+++ b/es-core/src/Settings.h
@@ -95,6 +95,8 @@ public:
 	DEFINE_BOOL_SETTING(ThreadedLoading)
 	DEFINE_BOOL_SETTING(CheevosCheckIndexesAtStart)
 	DEFINE_BOOL_SETTING(NetPlayCheckIndexesAtStart)
+	DEFINE_BOOL_SETTING(NetPlayAutomaticallyCreateLobby)
+	DEFINE_BOOL_SETTING(NetPlayShowOnlyRelayServerGames)
 	DEFINE_BOOL_SETTING(NetPlayShowMissingGames)			
 	DEFINE_BOOL_SETTING(LoadEmptySystems)		
 	DEFINE_BOOL_SETTING(HideUniqueGroups)


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/fc2aa506-57c0-4081-9331-7dd71af4078d)

AUTOMATICALLY CREATE LOBBY
Starts the game in host mode automatically when launched.
This option is disabled by default.
from: https://github.com/batocera-linux/batocera-emulationstation/pull/1887

SHOW RELAY SERVER GAMES ONLY
Displays only servers that use a relay server in the lobby.
This option is not needed for LAN play.
Additionally, it now calls the function earlier than `getFileData`, resulting in faster lobby loading.
