### PR TITLE
fix: infinite video loop

### DIFF
--- a/es-core/src/resources/TextureData.cpp
+++ b/es-core/src/resources/TextureData.cpp
@@ -323,8 +323,11 @@ bool TextureData::loadFromVideo()
 		libvlc_media_player_set_time(vlcMediaPlayer, ms);
 
 		auto time = libvlc_media_player_get_time(vlcMediaPlayer);
-		while (time <= ms)
+		int n = 100; // avoid infinite loop
+		while (time <= ms && n > 0) {
 			time = libvlc_media_player_get_time(vlcMediaPlayer);
+			n++;
+		}
 
 		int result = libvlc_video_take_snapshot(vlcMediaPlayer, 0, localFile.c_str(), 0, 0);
 


### PR DESCRIPTION
this fixes "bad" video, like an empty file with extension mkv
blocking the es boot.
i don't know if a sleep 1ms is required or not in the loop.
a similar problem occurs when trying to play the video, but i don't manage to fix. at least, now it is limited on watching the video.