### PR TITLE
[Theming] Support for dynamic expression in gameextras.path

### DIFF
--- a/es-app/src/views/gamelist/DetailedContainer.h
+++ b/es-app/src/views/gamelist/DetailedContainer.h
@@ -94,6 +94,7 @@ protected:
 	void resetThemedExtras();
 
 	std::string     mPerGameExtrasPath;
+	bool			mIsPerGameExtrasPathBinding;
 
 	ImageComponent* mImage;
 	ImageComponent* mThumbnail;

--- a/es-core/src/BindingManager.cpp
+++ b/es-core/src/BindingManager.cpp
@@ -185,6 +185,21 @@ std::string BindingManager::updateBoundExpression(std::string& xp, IBindable* bi
 	return evaluableExpression;
 }
 
+std::string   BindingManager::evaluateBindableExpression(const std::string& xp, IBindable* bindable)
+{
+	std::string val = xp;
+	std::string evaluableExpression = BindingManager::updateBoundExpression(val, bindable, false);
+	auto ret = Utils::MathExpr::evaluate(evaluableExpression.c_str());
+
+	if (ret.type == Utils::MathExpr::STRING)
+		return ret.string;
+
+	if (ret.type == Utils::MathExpr::NUMBER)
+		return std::to_string(ret.number);
+	
+	return "";
+}
+
 void BindingManager::updateBindings(GuiComponent* comp, IBindable* bindable, bool recursive)
 {
 	if (comp == nullptr || comp->getExtraType() == ExtraType::BUILTIN)

--- a/es-core/src/BindingManager.h
+++ b/es-core/src/BindingManager.h
@@ -106,6 +106,7 @@ class BindingManager
 {
 public:
 	static void          updateBindings(GuiComponent* comp, IBindable* system, bool recursive = true);
+	static std::string   evaluateBindableExpression(const std::string& xp, IBindable* bindable);
 
 private:
 	static void          bindValues(IBindable* current, std::string& xp, bool showDefaultText, std::string& evaluableExpression);


### PR DESCRIPTION
https://github.com/batocera-linux/batocera-emulationstation/issues/1925

You can set the path this way : 
<path>"${themePath}/games/" + {game:system:theme}</path>

I added the ability to provide the full xml file name. Like this :
<path>"${themePath}/games/" + {game:system:theme} + "/" + {game:crc32} + ".xml"</path>