### PR TITLE
Add user community relay server feature with SEOUL as the first preset

### DIFF
--- a/es-app/src/guis/GuiNetPlaySettings.cpp
+++ b/es-app/src/guis/GuiNetPlaySettings.cpp
@@ -1,10 +1,17 @@
 #include "GuiNetPlaySettings.h"
 #include "SystemConf.h"
 #include "ThreadedHasher.h"
+#include "components/OptionListComponent.h"
 #include "components/SwitchComponent.h"
 #include "GuiHashStart.h"
+#include <unordered_map>
 
-GuiNetPlaySettings::GuiNetPlaySettings(Window* window) : GuiSettings(window, _("NETPLAY SETTINGS").c_str())
+static std::unordered_map<std::string, std::string> communityRelayServers =
+{
+	{"seoul",		"138.2.119.137"},
+};
+
+GuiNetPlaySettings::GuiNetPlaySettings(Window* window, int selectItem) : GuiSettings(window, _("NETPLAY SETTINGS").c_str())
 {
 	std::string port = SystemConf::getInstance()->get("global.netplay.port");
 	if (port.empty())
@@ -20,8 +27,8 @@ GuiNetPlaySettings::GuiNetPlaySettings(Window* window) : GuiSettings(window, _("
 	addGroup(_("OPTIONS"));
 
 	addInputTextRow(_("PORT"), "global.netplay.port", false);
-	addOptionList(_("USE RELAY SERVER"), { { _("NONE"), "" },{ _("NEW YORK") , "nyc" },{ _("MADRID") , "madrid" },{ _("MONTREAL") , "montreal" },{ _("SAO PAULO") , "saopaulo" },{ _("CUSTOM") , "custom" } }, "global.netplay.relay", false);
-	addInputTextRow(_("CUSTOM RELAY SERVER"), "global.netplay.customserver", false);
+
+	addRelayServerOptions(selectItem);
 
 	addSwitch(_("AUTOMATICALLY CREATE LOBBY"), _("Automatically creates a Netplay lobby when starting a game."), "NetPlayAutomaticallyCreateLobby", true, nullptr);
 	addSwitch(_("SHOW RELAY SERVER GAMES ONLY"), _("Relay server games have a higher chance of successful entry."), "NetPlayShowOnlyRelayServerGames", true, nullptr);
@@ -47,4 +54,76 @@ GuiNetPlaySettings::GuiNetPlaySettings(Window* window) : GuiSettings(window, _("
 			}
 		}
 	});
+}
+
+void GuiNetPlaySettings::addRelayServerOptions(int selectItem)
+{
+	const std::string customRelayServerAddress = SystemConf::getInstance()->get("global.netplay.customserver");
+	std::string selectedRelayServer = SystemConf::getInstance()->get("global.netplay.relay");
+	if (selectedRelayServer == "custom")
+	{
+		for (const auto& kv : communityRelayServers)
+		{
+			if (kv.second != customRelayServerAddress)
+				continue;
+
+			selectedRelayServer = kv.first;
+			break;
+		}
+	}
+
+	auto relayServer = std::make_shared<OptionListComponent<std::string>>(mWindow, _("USE RELAY SERVER"), false);
+	relayServer->add(_("NONE"), "", selectedRelayServer.empty());
+
+	// Official RetroArch relay servers
+	relayServer->add(_("NEW YORK"), "nyc", selectedRelayServer == "nyc");
+	relayServer->add(_("MADRID"), "madrid", selectedRelayServer == "madrid");
+	relayServer->add(_("MONTREAL"), "montreal", selectedRelayServer == "montreal");
+	relayServer->add(_("SAO PAULO"), "saopaulo", selectedRelayServer == "saopaulo");
+
+	// User Community relay servers
+	relayServer->add(_("SEOUL"), "seoul", selectedRelayServer == "seoul");
+
+	// Custom relay server
+	relayServer->add(_("CUSTOM"), "custom", selectedRelayServer == "custom");
+
+	if (!relayServer->hasSelection())
+		relayServer->selectFirstItem();
+
+	addWithLabel(_("USE RELAY SERVER"), relayServer, selectItem == 1);
+
+	relayServer->setSelectedChangedCallback([this](const std::string& newRelayServer)
+	{
+		std::string originalCustomServerAddress = SystemConf::getInstance()->get("global.netplay.customserver");
+		std::string backupCustomServerAddress = SystemConf::getInstance()->get("global.netplay.customserver.backup");
+
+		if (communityRelayServers.find(newRelayServer) != communityRelayServers.end())
+		{
+			SystemConf::getInstance()->set("global.netplay.relay", "custom");
+			SystemConf::getInstance()->set("global.netplay.customserver", communityRelayServers[newRelayServer]);
+
+			if (!std::any_of(communityRelayServers.begin(), communityRelayServers.end(), [&](const auto& kv) { return kv.second == originalCustomServerAddress; }))
+				SystemConf::getInstance()->set("global.netplay.customserver.backup", originalCustomServerAddress);
+		}
+		else if (newRelayServer == "custom")
+		{
+			SystemConf::getInstance()->set("global.netplay.relay", newRelayServer);
+
+			if (!backupCustomServerAddress.empty())
+				SystemConf::getInstance()->set("global.netplay.customserver", backupCustomServerAddress);
+			else if (std::any_of(communityRelayServers.begin(), communityRelayServers.end(), [&](const auto& kv) { return kv.second == originalCustomServerAddress; }))
+				SystemConf::getInstance()->set("global.netplay.customserver", "");
+		}
+		else
+		{
+			SystemConf::getInstance()->set("global.netplay.relay", newRelayServer);
+		}
+		
+		Window* pw = mWindow;
+		delete this;
+		pw->pushGui(new GuiNetPlaySettings(pw, 1));
+	});
+
+	if (selectedRelayServer == "custom" && std::find_if(communityRelayServers.begin(), communityRelayServers.end(), [&](const auto& kv) { return kv.second == customRelayServerAddress; }) == communityRelayServers.end())
+		addInputTextRow(_("CUSTOM RELAY SERVER"), "global.netplay.customserver", false);
 }

--- a/es-app/src/guis/GuiNetPlaySettings.h
+++ b/es-app/src/guis/GuiNetPlaySettings.h
@@ -7,5 +7,8 @@ class Window;
 class GuiNetPlaySettings : public GuiSettings
 {
 public:
-	GuiNetPlaySettings(Window* window);
+	GuiNetPlaySettings(Window* window, int selectItem = -1);
+
+private:
+	void addRelayServerOptions(int selectItem);
 };

--- a/es-app/src/guis/GuiNetPlaySettings.h
+++ b/es-app/src/guis/GuiNetPlaySettings.h
@@ -10,5 +10,6 @@ public:
 	GuiNetPlaySettings(Window* window, int selectItem = -1);
 
 private:
+	void loadCommunityRelayServers();
 	void addRelayServerOptions(int selectItem);
 };

--- a/resources/community_relay_servers.xml
+++ b/resources/community_relay_servers.xml
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<community_relay_servers>
+  <server id="seoul" address="138.2.119.137" author_email="bulzipke@naver.com" />
+</community_relay_servers>


### PR DESCRIPTION
Batocera currently provides RetroArch’s official relay servers as options for netplay.
This update adds support for user community relay servers, allowing additional community-hosted relays to be included.
I have added a relay server for Korean players (SEOUL) as the first community option, and I hope this opens the door for more countries to add their own in the future.

from https://github.com/knulli-cfw/batocera-emulationstation/pull/51