### PR TITLE
[NetPlay] Add automatic hotspot creation feature

### DIFF
--- a/es-app/src/ApiSystem.cpp
+++ b/es-app/src/ApiSystem.cpp
@@ -490,6 +490,13 @@ std::string ApiSystem::getIpAddress()
 	return result;
 }
 
+bool ApiSystem::isWifiAPModeSupported()
+{
+	LOG(LogDebug) << "ApiSystem::isWifiAPModeSupported";
+
+	return executeScript("batocera-wifi has_ap_mode");
+}
+
 bool ApiSystem::enableBluetooth()
 {
 	return executeScript("batocera-bluetooth enable 2>&1 >/dev/null");
@@ -1563,7 +1570,7 @@ void ApiSystem::scanWifiNetworks()
 
 std::string ApiSystem::getWifiRoute()
 {
-	std::vector<std::string> result = executeEnumerationScript("batocera-wifi getroute");
+	std::vector<std::string> result = executeEnumerationScript("batocera-wifi get_route");
 
 	if (result.empty() || result[0].empty())
 		return "NOT CONNECTED";

--- a/es-app/src/ApiSystem.cpp
+++ b/es-app/src/ApiSystem.cpp
@@ -1556,6 +1556,21 @@ std::vector<std::string> ApiSystem::getWifiNetworks(bool scan)
 	return executeEnumerationScript(scan ? "batocera-wifi scanlist" : "batocera-wifi list");
 }
 
+void ApiSystem::scanWifiNetworks()
+{
+	executeScript("batocera-wifi scanlist &");
+}
+
+std::string ApiSystem::getWifiRoute()
+{
+	std::vector<std::string> result = executeEnumerationScript("batocera-wifi getroute");
+
+	if (result.empty() || result[0].empty())
+		return "NOT CONNECTED";
+
+	return result[0];
+}
+
 std::vector<std::string> ApiSystem::executeEnumerationScript(const std::string command)
 {
 	LOG(LogDebug) << "ApiSystem::executeEnumerationScript -> " << command;

--- a/es-app/src/ApiSystem.cpp
+++ b/es-app/src/ApiSystem.cpp
@@ -2026,6 +2026,21 @@ std::vector<std::string> ApiSystem::getWifiNetworks(bool scan)
 	return executeEnumerationScript(scan ? "batocera-wifi scanlist" : "batocera-wifi list");
 }
 
+void ApiSystem::scanWifiNetworks()
+{
+	executeScript("batocera-wifi scanlist &");
+}
+
+std::string ApiSystem::getWifiRoute()
+{
+	std::vector<std::string> result = executeEnumerationScript("batocera-wifi getroute");
+
+	if (result.empty() || result[0].empty())
+		return "NOT CONNECTED";
+
+	return result[0];
+}
+
 std::vector<std::string> ApiSystem::executeEnumerationScript(const std::string command)
 {
 	LOG(LogDebug) << "ApiSystem::executeEnumerationScript -> " << command;

--- a/es-app/src/ApiSystem.cpp
+++ b/es-app/src/ApiSystem.cpp
@@ -640,6 +640,13 @@ std::string ApiSystem::getIpAddress()
 	return result;
 }
 
+bool ApiSystem::isWifiAPModeSupported()
+{
+	LOG(LogDebug) << "ApiSystem::isWifiAPModeSupported";
+
+	return executeScript("batocera-wifi has_ap_mode");
+}
+
 bool ApiSystem::enableBluetooth()
 {
 	return executeScript("batocera-bluetooth enable 2>&1 >/dev/null");
@@ -2033,7 +2040,7 @@ void ApiSystem::scanWifiNetworks()
 
 std::string ApiSystem::getWifiRoute()
 {
-	std::vector<std::string> result = executeEnumerationScript("batocera-wifi getroute");
+	std::vector<std::string> result = executeEnumerationScript("batocera-wifi get_route");
 
 	if (result.empty() || result[0].empty())
 		return "NOT CONNECTED";

--- a/es-app/src/ApiSystem.h
+++ b/es-app/src/ApiSystem.h
@@ -167,6 +167,7 @@ public:
     bool disableWifi();
 
 	virtual std::string getIpAddress();
+	virtual bool isWifiAPModeSupported();
 
 	bool enableBluetooth();
 	bool disableBluetooth();

--- a/es-app/src/ApiSystem.h
+++ b/es-app/src/ApiSystem.h
@@ -258,6 +258,8 @@ public:
 	void setLEDBrightness(int value);
 
 	std::vector<std::string> getWifiNetworks(bool scan = false);
+	void scanWifiNetworks();
+	std::string getWifiRoute();
 
 	bool downloadFile(const std::string url, const std::string fileName, const std::string label = "", const std::function<void(const std::string)>& func = nullptr);
 	

--- a/es-app/src/ApiSystem.h
+++ b/es-app/src/ApiSystem.h
@@ -351,6 +351,8 @@ public:
 	void setLEDMode(const std::string& mode);
 
 	std::vector<std::string> getWifiNetworks(bool scan = false);
+	void scanWifiNetworks();
+	std::string getWifiRoute();
 
 	bool downloadFile(const std::string url, const std::string fileName, const std::string label = "", const std::function<void(const std::string)>& func = nullptr);
 	

--- a/es-app/src/ApiSystem.h
+++ b/es-app/src/ApiSystem.h
@@ -250,6 +250,7 @@ public:
     bool disableWifi();
 
 	virtual std::string getIpAddress();
+	virtual bool isWifiAPModeSupported();
 
 	// BlueTooth methods
 	virtual bool enableBluetooth();

--- a/es-app/src/guis/GuiGameOptions.cpp
+++ b/es-app/src/guis/GuiGameOptions.cpp
@@ -174,7 +174,7 @@ GuiGameOptions::GuiGameOptions(Window* window, FileData* game) : GuiComponent(wi
 					msgBox->addGroup(_("START GAME"));
 					msgBox->addEntry(_U("\uF144 ") + _("HOST A NETPLAY GAME"), false, [window, msgBox, game]
 						{
-							if (ApiSystem::getInstance()->getIpAddress() == "NOT CONNECTED")
+							if (ApiSystem::getInstance()->getIpAddress() == "NOT CONNECTED" && !SystemConf::getInstance()->getBool("global.netplay.hotspot"))
 							{
 								window->pushGui(new GuiMsgBox(window, _("YOU ARE NOT CONNECTED TO A NETWORK"), _("OK"), nullptr));
 								return;

--- a/es-app/src/guis/GuiGameOptions.cpp
+++ b/es-app/src/guis/GuiGameOptions.cpp
@@ -177,7 +177,7 @@ GuiGameOptions::GuiGameOptions(Window* window, FileData* game) : GuiComponent(wi
 					msgBox->addGroup(_("START GAME"));
 					msgBox->addEntry(_U("\uF144 ") + _("HOST A NETPLAY GAME"), false, [window, msgBox, game]
 						{
-							if (ApiSystem::getInstance()->getIpAddress() == "NOT CONNECTED")
+							if (ApiSystem::getInstance()->getIpAddress() == "NOT CONNECTED" && !SystemConf::getInstance()->getBool("global.netplay.hotspot"))
 							{
 								window->pushGui(new GuiMsgBox(window, _("YOU ARE NOT CONNECTED TO A NETWORK"), _("OK"), nullptr));
 								return;

--- a/es-app/src/guis/GuiNetPlay.cpp
+++ b/es-app/src/guis/GuiNetPlay.cpp
@@ -38,6 +38,7 @@
 #endif
 
 #define WINDOW_WIDTH (float)Math::min(Renderer::getScreenHeight() * 1.125f, Renderer::getScreenWidth() * 0.90f)
+#define NETPLAY_LOBBY_FAIL_GRACE_MS	(100)
 
 // http://lobby.libretro.com/list/
 // Core list :
@@ -163,6 +164,7 @@ static std::map<std::string, std::string> coreList =
 
 GuiNetPlay::GuiNetPlay(Window* window)
 	: GuiComponent(window), 
+	mFindingHotspot(false),
 	mBusyAnim(window),
 	mBackground(window, ":/frame.png"),
 	mGrid(window, Vector2i(1, 3)),
@@ -200,7 +202,13 @@ GuiNetPlay::GuiNetPlay(Window* window)
 
 	// Buttons
 	std::vector< std::shared_ptr<ButtonComponent> > buttons;
-	buttons.push_back(std::make_shared<ButtonComponent>(mWindow, _("REFRESH"), _("REFRESH"), [this] { startRequest(); }));
+	buttons.push_back(std::make_shared<ButtonComponent>(mWindow, _("REFRESH"), _("REFRESH"), [this]
+	{
+		if (ApiSystem::getInstance()->getIpAddress() != "NOT CONNECTED")
+			startRequest();
+		else if (SystemConf::getInstance()->getBool("wifi.enabled") && SystemConf::getInstance()->getBool("global.netplay.hotspot"))
+			findHotspot();
+	}));
 	buttons.push_back(std::make_shared<ButtonComponent>(mWindow, _("CLOSE"), _("CLOSE"), [this] { delete this; }));
 
 	mButtonGrid = makeButtonGrid(mWindow, buttons);
@@ -233,8 +241,11 @@ GuiNetPlay::GuiNetPlay(Window* window)
 
 	// Loading
     mBusyAnim.setSize(Vector2f(Renderer::getScreenWidth(), Renderer::getScreenHeight()));
-	mBusyAnim.setText(_("PLEASE WAIT"));
-	startRequest();
+
+	if (ApiSystem::getInstance()->getIpAddress() != "NOT CONNECTED")
+		startRequest();
+	else if (SystemConf::getInstance()->getBool("wifi.enabled") && SystemConf::getInstance()->getBool("global.netplay.hotspot"))
+		findHotspot();
 }
 
 GuiNetPlay::~GuiNetPlay()
@@ -278,6 +289,8 @@ void GuiNetPlay::startRequest()
 	if (mLobbyRequest != nullptr)
 		return;
 
+	mBusyAnim.setText(_("PLEASE WAIT"));
+
 	mList->clear();
 	mLobbyEntries.clear();
 	mLanEntries.clear();
@@ -289,12 +302,32 @@ void GuiNetPlay::startRequest()
 		netPlayLobby = "http://lobby.libretro.com/list/";
 
 	mLobbyRequest = std::unique_ptr<HttpReq>(new HttpReq(netPlayLobby));
+	mLobbyGracePeriodElapsed = 0;
+}
+
+void GuiNetPlay::findHotspot()
+{
+	mBusyAnim.setText(_("SEARCHING FOR HOTSPOTS"));
+
+	ApiSystem::getInstance()->scanWifiNetworks();
+	mFindingHotspot = true;
 }
 
 void GuiNetPlay::update(int deltaTime)
 {
 	GuiComponent::update(deltaTime);
 
+	if (mFindingHotspot)
+	{
+		mBusyAnim.update(deltaTime);
+
+		if (ApiSystem::getInstance()->getWifiRoute() == "NOT CONNECTED")
+			return;
+
+		mFindingHotspot = false;
+		startRequest();
+	}
+		
 	if (mLanLobbySocketTimeout < 20000 && mPopulateThread == nullptr) // allow receiving answers from the LAN for 20 seconds
 	{
 		mLanLobbySocketTimeout += deltaTime;
@@ -324,6 +357,10 @@ void GuiNetPlay::update(int deltaTime)
 	if (!mLobbyRequest)
 		return;
 
+	mLobbyGracePeriodElapsed += deltaTime;
+	if (mLobbyGracePeriodElapsed < NETPLAY_LOBBY_FAIL_GRACE_MS)
+		return;
+
 	auto status = mLobbyRequest->status();
 	if (status == HttpReq::REQ_IN_PROGRESS)
 	{
@@ -333,7 +370,10 @@ void GuiNetPlay::update(int deltaTime)
 
 	if (status != HttpReq::REQ_SUCCESS)
 	{
-		mWindow->pushGui(new GuiMsgBox(mWindow, _("FAILED") + std::string(" : ") + mLobbyRequest->getErrorMsg()));
+		// Games found on the LAN are already listed, so a failing lobby request is not an error the user needs to see
+		if (mList->size() == 0)
+			mWindow->pushGui(new GuiMsgBox(mWindow, _("FAILED") + std::string(" : ") + mLobbyRequest->getErrorMsg()));
+
 		mLobbyRequest.reset();
 		return;
 	}
@@ -992,7 +1032,10 @@ bool GuiNetPlay::populateFromLan()
 		game.coreExists = coreExists(file, game.core_name);
 
 		if (!std::any_of(mLanEntries.cbegin(), mLanEntries.cend(), [game](const LobbyAppEntry& entry) { return entry.country == "lan" && entry.ip == game.ip && entry.port == game.port && entry.username == game.username && entry.game_crc == game.game_crc; }))
+		{
 			mLanEntries.push_back(std::move(game));
+			changed = true;
+		}
 	}
 
 	if (changed)
@@ -1005,7 +1048,7 @@ void GuiNetPlay::render(const Transform4x4f &parentTrans)
 {
 	GuiComponent::render(parentTrans);
 
-	if (mLobbyRequest)
+	if (mLobbyRequest || mFindingHotspot)
 		mBusyAnim.render(parentTrans);
 }
 

--- a/es-app/src/guis/GuiNetPlay.h
+++ b/es-app/src/guis/GuiNetPlay.h
@@ -81,6 +81,7 @@ public:
 
 private:
 	void startRequest();
+	void findHotspot();
 	
 	bool populateFromJson(const std::string json);
 	bool populateFromLan();
@@ -96,6 +97,8 @@ private:
 	int								mLanLobbySocket;
 	int								mLanLobbySocketTimeout;
 
+	bool							mFindingHotspot;
+
 	NinePatchComponent				mBackground;
 	ComponentGrid					mGrid;
 
@@ -110,6 +113,7 @@ private:
 	BusyComponent					mBusyAnim;
 
 	std::unique_ptr<HttpReq>		mLobbyRequest;
+	int								mLobbyGracePeriodElapsed;
 
 	std::vector<LobbyAppEntry>		mLanEntries;
 	std::vector<LobbyAppEntry>		mLobbyEntries;

--- a/es-app/src/guis/GuiNetPlay.h
+++ b/es-app/src/guis/GuiNetPlay.h
@@ -83,6 +83,7 @@ public:
 
 private:
 	void startRequest();
+	void findHotspot();
 	
 	bool populateFromJson(const std::string json);
 	bool populateFromLan();
@@ -98,6 +99,8 @@ private:
 	int								mLanLobbySocket;
 	int								mLanLobbySocketTimeout;
 
+	bool							mFindingHotspot;
+
 	NinePatchComponent				mBackground;
 	ComponentGrid					mGrid;
 
@@ -112,6 +115,7 @@ private:
 	BusyComponent					mBusyAnim;
 
 	std::unique_ptr<HttpReq>		mLobbyRequest;
+	int								mLobbyGracePeriodElapsed;
 
 	std::vector<LobbyAppEntry>		mLanEntries;
 	std::vector<LobbyAppEntry>		mLobbyEntries;

--- a/es-app/src/guis/GuiNetPlaySettings.cpp
+++ b/es-app/src/guis/GuiNetPlaySettings.cpp
@@ -23,6 +23,16 @@ GuiNetPlaySettings::GuiNetPlaySettings(Window* window) : GuiSettings(window, _("
 	addOptionList(_("USE RELAY SERVER"), { { _("NONE"), "" },{ _("NEW YORK") , "nyc" },{ _("MADRID") , "madrid" },{ _("MONTREAL") , "montreal" },{ _("SAO PAULO") , "saopaulo" },{ _("CUSTOM") , "custom" } }, "global.netplay.relay", false);
 	addInputTextRow(_("CUSTOM RELAY SERVER"), "global.netplay.customserver", false);
 
+#ifndef WIN32
+	auto enableHotspot = std::make_shared<SwitchComponent>(mWindow);
+	enableHotspot->setState(SystemConf::getInstance()->getBool("global.netplay.hotspot"));
+	addWithDescription(_("AUTOMATICALLY USE HOTSPOT FOR LOCAL NETPLAY"), _("Creates a hotspot when hosting, or connects when joining.") + _U("\n\uF071 ") + _("CAUTION: This may drain battery faster."), enableHotspot);
+	addSaveFunc([enableHotspot] {
+		if (enableHotspot->getState() != SystemConf::getInstance()->getBool("global.netplay.hotspot"))
+			SystemConf::getInstance()->setBool("global.netplay.hotspot", enableHotspot->getState());
+	});
+#endif
+
 	addSwitch(_("AUTOMATICALLY CREATE LOBBY"), _("Automatically creates a Netplay lobby when starting a game."), "NetPlayAutomaticallyCreateLobby", true, nullptr);
 	addSwitch(_("SHOW RELAY SERVER GAMES ONLY"), _("Relay server games have a higher chance of successful entry."), "NetPlayShowOnlyRelayServerGames", true, nullptr);
 	addSwitch(_("SHOW UNAVAILABLE GAMES"), _("Show rooms for games not present on this machine."), "NetPlayShowMissingGames", true, nullptr);

--- a/es-app/src/guis/GuiNetPlaySettings.cpp
+++ b/es-app/src/guis/GuiNetPlaySettings.cpp
@@ -26,7 +26,11 @@ GuiNetPlaySettings::GuiNetPlaySettings(Window* window) : GuiSettings(window, _("
 #ifndef WIN32
 	auto enableHotspot = std::make_shared<SwitchComponent>(mWindow);
 	enableHotspot->setState(SystemConf::getInstance()->getBool("global.netplay.hotspot"));
-	addWithDescription(_("AUTOMATICALLY USE HOTSPOT FOR LOCAL NETPLAY"), _("Creates a hotspot when hosting, or connects when joining.") + _U("\n\uF071 ") + _("CAUTION: This may drain battery faster."), enableHotspot);
+	if (ApiSystem::getInstance()->isWifiAPModeSupported())
+		addWithDescription(_("AUTOMATICALLY USE HOTSPOT FOR LOCAL NETPLAY"), _("Creates a hotspot when hosting, or connects when joining.") + _U("\n\uF071 ") + _("CAUTION: This may drain battery faster."), enableHotspot);
+	else
+		addWithDescription(_("AUTOMATICALLY USE HOTSPOT FOR LOCAL NETPLAY"), _("Connects when a hotspot is available.") + _U("\n\uF071 ") + _("CAUTION: Hosting not supported on this device."), enableHotspot);
+
 	addSaveFunc([enableHotspot] {
 		if (enableHotspot->getState() != SystemConf::getInstance()->getBool("global.netplay.hotspot"))
 			SystemConf::getInstance()->setBool("global.netplay.hotspot", enableHotspot->getState());

--- a/es-app/src/guis/GuiNetPlaySettings.cpp
+++ b/es-app/src/guis/GuiNetPlaySettings.cpp
@@ -31,6 +31,16 @@ GuiNetPlaySettings::GuiNetPlaySettings(Window* window, int selectItem) : GuiSett
 
 	addRelayServerOptions(selectItem);
 
+#ifndef WIN32
+	auto enableHotspot = std::make_shared<SwitchComponent>(mWindow);
+	enableHotspot->setState(SystemConf::getInstance()->getBool("global.netplay.hotspot"));
+	addWithDescription(_("AUTOMATICALLY USE HOTSPOT FOR LOCAL NETPLAY"), _("Creates a hotspot when hosting, or connects when joining.") + _U("\n\uF071 ") + _("CAUTION: This may drain battery faster."), enableHotspot);
+	addSaveFunc([enableHotspot] {
+		if (enableHotspot->getState() != SystemConf::getInstance()->getBool("global.netplay.hotspot"))
+			SystemConf::getInstance()->setBool("global.netplay.hotspot", enableHotspot->getState());
+	});
+#endif
+
 	addSwitch(_("AUTOMATICALLY CREATE LOBBY"), _("Automatically creates a Netplay lobby when starting a game."), "NetPlayAutomaticallyCreateLobby", true, nullptr);
 	addSwitch(_("SHOW RELAY SERVER GAMES ONLY"), _("Relay server games have a higher chance of successful entry."), "NetPlayShowOnlyRelayServerGames", true, nullptr);
 	addSwitch(_("SHOW UNAVAILABLE GAMES"), _("Show rooms for games not present on this machine."), "NetPlayShowMissingGames", true, nullptr);

--- a/es-app/src/guis/GuiNetPlaySettings.cpp
+++ b/es-app/src/guis/GuiNetPlaySettings.cpp
@@ -34,7 +34,11 @@ GuiNetPlaySettings::GuiNetPlaySettings(Window* window, int selectItem) : GuiSett
 #ifndef WIN32
 	auto enableHotspot = std::make_shared<SwitchComponent>(mWindow);
 	enableHotspot->setState(SystemConf::getInstance()->getBool("global.netplay.hotspot"));
-	addWithDescription(_("AUTOMATICALLY USE HOTSPOT FOR LOCAL NETPLAY"), _("Creates a hotspot when hosting, or connects when joining.") + _U("\n\uF071 ") + _("CAUTION: This may drain battery faster."), enableHotspot);
+	if (ApiSystem::getInstance()->isWifiAPModeSupported())
+		addWithDescription(_("AUTOMATICALLY USE HOTSPOT FOR LOCAL NETPLAY"), _("Creates a hotspot when hosting, or connects when joining.") + _U("\n\uF071 ") + _("CAUTION: This may drain battery faster."), enableHotspot);
+	else
+		addWithDescription(_("AUTOMATICALLY USE HOTSPOT FOR LOCAL NETPLAY"), _("Connects when a hotspot is available.") + _U("\n\uF071 ") + _("CAUTION: Hosting not supported on this device."), enableHotspot);
+
 	addSaveFunc([enableHotspot] {
 		if (enableHotspot->getState() != SystemConf::getInstance()->getBool("global.netplay.hotspot"))
 			SystemConf::getInstance()->setBool("global.netplay.hotspot", enableHotspot->getState());

--- a/es-app/src/views/SystemView.cpp
+++ b/es-app/src/views/SystemView.cpp
@@ -375,10 +375,13 @@ void SystemView::showNetplay()
 	if (!SystemData::isNetplayActivated() && SystemConf::getInstance()->getBool("global.netplay"))
 		return;
 
-	if (ApiSystem::getInstance()->getIpAddress() == "NOT CONNECTED")
+	if (ApiSystem::getInstance()->getIpAddress() == "NOT CONNECTED" && (!SystemConf::getInstance()->getBool("wifi.enabled") || !SystemConf::getInstance()->getBool("global.netplay.hotspot")))
+	{
 		mWindow->pushGui(new GuiMsgBox(mWindow, _("YOU ARE NOT CONNECTED TO A NETWORK"), _("OK"), nullptr));
-	else
-		mWindow->pushGui(new GuiNetPlay(mWindow));
+		return;
+	}
+
+	mWindow->pushGui(new GuiNetPlay(mWindow));
 }
 
 SystemData* SystemView::getSelected()

--- a/es-app/src/views/SystemView.cpp
+++ b/es-app/src/views/SystemView.cpp
@@ -361,10 +361,13 @@ void SystemView::showNetplay()
 	if (!SystemData::isNetplayActivated() && SystemConf::getInstance()->getBool("global.netplay"))
 		return;
 
-	if (ApiSystem::getInstance()->getIpAddress() == "NOT CONNECTED")
+	if (ApiSystem::getInstance()->getIpAddress() == "NOT CONNECTED" && (!SystemConf::getInstance()->getBool("wifi.enabled") || !SystemConf::getInstance()->getBool("global.netplay.hotspot")))
+	{
 		mWindow->pushGui(new GuiMsgBox(mWindow, _("YOU ARE NOT CONNECTED TO A NETWORK"), _("OK"), nullptr));
-	else
-		mWindow->pushGui(new GuiNetPlay(mWindow));
+		return;
+	}
+
+	mWindow->pushGui(new GuiNetPlay(mWindow));
 }
 
 SystemData* SystemView::getSelected()

--- a/es-app/src/views/ViewController.cpp
+++ b/es-app/src/views/ViewController.cpp
@@ -553,7 +553,7 @@ void ViewController::launch(FileData* game, LaunchGameOptions options, Vector3f 
 		return;
 	}
 
-	if (!SystemConf::getInstance()->getBool("global.netplay") || ApiSystem::getInstance()->getIpAddress() == "NOT CONNECTED" || !game->isNetplaySupported())
+	if (!SystemConf::getInstance()->getBool("global.netplay") || (ApiSystem::getInstance()->getIpAddress() == "NOT CONNECTED" && !SystemConf::getInstance()->getBool("global.netplay.hotspot")) || !game->isNetplaySupported())
 		options.netPlayMode = DISABLED;
 	else if (options.netPlayMode == DISABLED && Settings::getInstance()->getBool("NetPlayAutomaticallyCreateLobby"))
 		options.netPlayMode = SERVER;

--- a/es-app/src/views/ViewController.cpp
+++ b/es-app/src/views/ViewController.cpp
@@ -552,7 +552,7 @@ void ViewController::launch(FileData* game, LaunchGameOptions options, Vector3f 
 		return;
 	}
 
-	if (!SystemConf::getInstance()->getBool("global.netplay") || ApiSystem::getInstance()->getIpAddress() == "NOT CONNECTED" || !game->isNetplaySupported())
+	if (!SystemConf::getInstance()->getBool("global.netplay") || (ApiSystem::getInstance()->getIpAddress() == "NOT CONNECTED" && !SystemConf::getInstance()->getBool("global.netplay.hotspot")) || !game->isNetplaySupported())
 		options.netPlayMode = DISABLED;
 	else if (options.netPlayMode == DISABLED && Settings::getInstance()->getBool("NetPlayAutomaticallyCreateLobby"))
 		options.netPlayMode = SERVER;


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/4ce1795c-f9aa-4294-89da-99bfd7be9e19)

**Short Summary**  
Added Adhoc (Hotspot) feature for local Netplay with nearby players.  
Users can now play Netplay together without going through a router.
When the `AUTOMATICALLY USE HOTSPOT FOR LOCAL NETPLAY` option is enabled, a hotspot will be created when starting a game if Wi-Fi is not available, and the Netplay menu will search for available hotspots.


**Detailed Description**
1. **es-app/src/ApiSystem.cpp**
   - Added logic to retrieve the IP address of the current Wi-Fi route.
   - The existing queryIPAddress function does not ensure that the network is fully ready.
   - This update ensures that LAN games can be reliably discovered via broadcast immediately after connecting to a hotspot.

2. **es-app/src/guis/GuiGameOptions.cpp**
3. **es-app/src/views/ViewController.cpp**
   - If the hotspot option is enabled, the system will attempt to create a hotspot and act as a host even without an internet connection.

4. **es-app/src/guis/GuiNetPlay.cpp**
   - In hotspot mode, `mLobbyRequest` consistently fails and causes unnecessary error dialogs.
   - To address this, if LAN games exist (`mList` is not empty), the error is ignored.
   - Additionally, a short delay (100ms) was added before error checking to give LAN broadcasts time to complete.
   - The `populateFromLan` function was also updated to handle list changes (`changed`) internally.

5. **es-app/src/guis/GuiNetPlaySettings.cpp**
   - Added the hotspot option toggle.
   - It is hidden on Windows, where hotspot-related functionality is not implemented.

6. **es-app/src/views/SystemView.cpp**
   - When there is no active Wi-Fi connection and the hotspot option is enabled, pressing the Netplay button will initiate a scan for nearby hotspot APs (up to 20 seconds).
   - If Wi-Fi is already connected or the option is disabled, it behaves as before.


**Related Issue**  
https://github.com/batocera-linux/batocera.linux/pull/14075

from https://github.com/knulli-cfw/batocera-emulationstation/pull/39