### PR TITLE
silence warnings

### DIFF
--- a/es-core/src/utils/TimeUtil.cpp
+++ b/es-core/src/utils/TimeUtil.cpp
@@ -1,7 +1,7 @@
 #include "utils/TimeUtil.h"
 #include "utils/StringUtil.h"
 #include "LocaleES.h"
-#include "Settings.h";
+#include "Settings.h"
 
 #if WIN32
 #include <Windows.h>


### PR DESCRIPTION
Resolved the following warning
```
es-core/src/utils/TimeUtil.cpp:4:22: warning: extra tokens at end of #include directive
```
