### PR TITLE
Add France(Paris) and Japan(Osaka) to community server

### DIFF
--- a/es-app/src/guis/GuiNetPlaySettings.cpp
+++ b/es-app/src/guis/GuiNetPlaySettings.cpp
@@ -6,6 +6,8 @@
 #include "GuiHashStart.h"
 #include <unordered_map>
 
+#define fake_gettext_paris _("PARIS")
+#define fake_gettext_osaka _("OSAKA")
 #define fake_gettext_seoul _("SEOUL")
 
 static std::vector<std::pair<std::string, std::string>> communityRelayServers;

--- a/resources/community_relay_servers.xml
+++ b/resources/community_relay_servers.xml
@@ -1,4 +1,6 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <community_relay_servers>
+  <server id="paris" address="158.178.213.50" author_email="bulzipke@naver.com" />
+  <server id="osaka" address="150.230.59.239" author_email="bulzipke@naver.com" />
   <server id="seoul" address="138.2.119.137" author_email="bulzipke@naver.com" />
 </community_relay_servers>


### PR DESCRIPTION
<img width="861" height="683" alt="image" src="https://github.com/user-attachments/assets/2302f45e-adf9-40dc-899a-7eec8f1e4374" />

Added community servers in France and Japan using Oracle servers.  
These servers improve Netplay for local players.

source: https://github.com/libretro/netplay-tunnel-server