### PR TITLE
WIN32 - fix dualsense connection spam (deinit = false when deviceadded)

### DIFF
--- a/es-core/src/InputManager.cpp
+++ b/es-core/src/InputManager.cpp
@@ -627,8 +627,11 @@ bool InputManager::parseEvent(const SDL_Event& ev, Window* window)
 			}
 #endif
 #endif
+#if WIN32
+			rebuildAllJoysticks(false);
+#else
 			rebuildAllJoysticks();
-
+#endif
 			if (Settings::getInstance()->getBool("ShowControllerNotifications") && !addedDeviceName.empty()) {
 			  if(isWheel) {
 			    window->displayNotificationMessage(_U("\uF1B9 ") + Utils::String::format(_("%s connected").c_str(), Utils::String::trim(addedDeviceName).c_str()));


### PR DESCRIPTION
@fabricecaruso : as discussed, i have tested the following and retroarch:
- Connect 2 controllers (xbox and dualsense)
- while in ES : disconnect xbox controller and connect another controller
- Launch retroarch : indexes are consistent with ES indexes (sdl driver)
- Exit retroarch
- Reconnect xbox controller
- Run a game again
- All 3 players are correctly mapped in retroarch