### PR TITLE
[Groups] Fix HideUniqueGroups when embedding a system into another one with games

### DIFF
--- a/es-app/src/SystemData.cpp
+++ b/es-app/src/SystemData.cpp
@@ -407,8 +407,12 @@ void SystemData::createGroupedSystems()
 		// Don't group if system count is only 1 		
 		if (item.second.size() == 1 && Settings::getInstance()->HideUniqueGroups())
 		{
-			item.second[0]->getSystemEnvData()->mAutoUngroup = true;
-			continue;
+			auto groupSys = SystemData::getSystem(item.first);
+			if (groupSys == nullptr)
+			{
+				item.second[0]->getSystemEnvData()->mAutoUngroup = true;
+				continue;
+			}
 		}
 		
 		SystemData* system = nullptr;
@@ -1755,7 +1759,7 @@ std::unordered_set<std::string> SystemData::getAllGroupNames()
 	return names;
 }
 
-std::unordered_set<std::string> SystemData::getGroupChildSystemNames(const std::string groupName)
+std::unordered_set<std::string> SystemData::getGroupChildSystemNames(const std::string& groupName)
 {
 	std::unordered_set<std::string> names;
 
@@ -1914,7 +1918,7 @@ bool SystemData::hasEmulatorSelection()
 	return ec > 1 || cc > 1;
 }
 
-SystemData* SystemData::getSystem(const std::string name)
+SystemData* SystemData::getSystem(const std::string& name)
 {	
 	for (auto sys : SystemData::sSystemVector)
 		if (Utils::String::compareIgnoreCase(sys->getName(), name) == 0)

--- a/es-app/src/SystemData.h
+++ b/es-app/src/SystemData.h
@@ -88,7 +88,7 @@ public:
     SystemData(const SystemMetadata& type, SystemEnvironmentData* envData, std::vector<EmulatorData>* pEmulators, bool CollectionSystem = false, bool groupedSystem = false, bool withTheme = true, bool loadThemeOnlyIfElements = false);
 	~SystemData();
 
-	static SystemData* getSystem(const std::string name);
+	static SystemData* getSystem(const std::string& name);
 	static SystemData* getFirstVisibleSystem();
 
 	inline FolderData* getRootFolder() const { return mRootFolder; };
@@ -188,7 +188,7 @@ public:
 	SystemData* getParentGroupSystem();
 
 	static std::unordered_set<std::string> getAllGroupNames();
-	static std::unordered_set<std::string> getGroupChildSystemNames(const std::string groupName);
+	static std::unordered_set<std::string> getGroupChildSystemNames(const std::string& groupName);
 
 	std::string getEmulator(bool resolveDefault = true);
 	std::string getCore(bool resolveDefault = true);

--- a/es-app/src/guis/GuiCollectionSystemsOptions.cpp
+++ b/es-app/src/guis/GuiCollectionSystemsOptions.cpp
@@ -102,14 +102,17 @@ void GuiCollectionSystemsOptions::initializeMenu()
 
 			std::sort(systemNames.begin(), systemNames.end());
 
-			int count = 0;
-			for (auto systemName : systemNames)
-				if (systemName != groupName)
-					count++;
-	
-			// Don't group if system count is only 1
-			if (count == 1 && Settings::getInstance()->HideUniqueGroups())
-				continue;
+			// Don't group if system count is only 1 ?
+			if (Settings::getInstance()->HideUniqueGroups())
+			{
+				int count = std::count_if(systemNames.cbegin(), systemNames.cend(), [&groupName](const std::string& name) { return name != groupName; });
+				if (count == 1)
+				{
+					auto groupSys = SystemData::getSystem(groupName);
+					if (groupSys == nullptr)
+						continue;
+				}
+			}
 
 			SystemData* pSystem = SystemData::getSystem(groupName);
 			if (pSystem != nullptr)


### PR DESCRIPTION
Ex : Embedding of cannonball into ports does not work if there is no other child systems to embed.