### PR TITLE
New sorting option: hardware type then year

### DIFF
--- a/es-app/src/CollectionSystemManager.cpp
+++ b/es-app/src/CollectionSystemManager.cpp
@@ -291,6 +291,24 @@ static bool systemByHardwareSort(SystemData* sys1, SystemData* sys2)
 	return name1.compare(name2) < 0;
 }
 
+static bool systemByHardwareYearSort(SystemData* sys1, SystemData* sys2)
+{
+	// Move collection at End
+	if (sys1->isCollection() != sys2->isCollection())
+		return sys2->isCollection();
+
+	// Order by hardware
+	std::string mf1 = Utils::String::toUpper(sys1->getSystemMetadata().hardwareType);
+	std::string mf2 = Utils::String::toUpper(sys2->getSystemMetadata().hardwareType);
+	if (mf1 != mf2)
+		return mf1.compare(mf2) < 0;
+
+	// Then by year
+	int y1 = sys1->getSystemMetadata().releaseYear;
+	int y2 = sys2->getSystemMetadata().releaseYear;
+	return y1 < y2;
+}
+
 CollectionSystemManager* CollectionSystemManager::get()
 {
 	assert(sInstance);
@@ -384,6 +402,7 @@ void CollectionSystemManager::updateSystemsList()
 	auto sortMode = Settings::getInstance()->getString("SortSystems");
 	bool sortByManufacturer = SystemData::IsManufacturerSupported && sortMode == "manufacturer";
 	bool sortByHardware = SystemData::IsManufacturerSupported && sortMode == "hardware";
+	bool sortByHardwareYear = SystemData::IsManufacturerSupported && sortMode == "hardware-year";
 	bool sortByReleaseDate = SystemData::IsManufacturerSupported && sortMode == "releaseDate";
 	bool sortBySubgroup = SystemData::IsManufacturerSupported && sortMode == "subgroup";
 
@@ -396,7 +415,7 @@ void CollectionSystemManager::updateSystemsList()
 	// add custom enabled ones
 	addEnabledCollectionsToDisplayedSystems(&mCustomCollectionSystemsData, &map);
 
-	if (!sortMode.empty() && !sortByManufacturer && !sortByHardware && !sortByReleaseDate && !sortBySubgroup)
+	if (!sortMode.empty() && !sortByManufacturer && !sortByHardware && !sortByHardwareYear && !sortByReleaseDate && !sortBySubgroup)
 		std::sort(SystemData::sSystemVector.begin(), SystemData::sSystemVector.end(), systemByAlphaSort);
 
 	// add auto enabled ones
@@ -412,6 +431,8 @@ void CollectionSystemManager::updateSystemsList()
 			std::sort(SystemData::sSystemVector.begin(), SystemData::sSystemVector.end(), systemByManufacurerSort);
 		else if (sortByHardware)
 			std::sort(SystemData::sSystemVector.begin(), SystemData::sSystemVector.end(), systemByHardwareSort);
+		else if (sortByHardwareYear)
+			std::sort(SystemData::sSystemVector.begin(), SystemData::sSystemVector.end(), systemByHardwareYearSort);
 		else if (sortByReleaseDate)
 			std::sort(SystemData::sSystemVector.begin(), SystemData::sSystemVector.end(), systemByReleaseDate);
 		else if (sortBySubgroup)

--- a/es-app/src/SystemData.cpp
+++ b/es-app/src/SystemData.cpp
@@ -1524,7 +1524,7 @@ void SystemData::loadTheme()
 		sysData["system.netplay"] = SystemConf::getInstance()->getBool("global.netplay") && isNetplaySupported() ? "true" : "false";
 		sysData["system.savestates"] = isCurrentFeatureSupported(EmulatorFeatures::autosave) ? "true" : "false";
 
-		if (Settings::getInstance()->getString("SortSystems") == "hardware")
+		if (Settings::getInstance()->getString("SortSystems") == "hardware" || Settings::getInstance()->getString("SortSystems") == "hardware-year")
 			sysData["system.sortedBy"] = Utils::String::proper(getSystemMetadata().hardwareType);
 		else
 			sysData["system.sortedBy"] = getSystemMetadata().manufacturer;

--- a/es-app/src/guis/GuiCollectionSystemsOptions.cpp
+++ b/es-app/src/guis/GuiCollectionSystemsOptions.cpp
@@ -238,7 +238,8 @@ void GuiCollectionSystemsOptions::initializeMenu()
 	if (SystemData::IsManufacturerSupported)
 	{
 		sortType->add(_("BY MANUFACTURER"), "manufacturer", sortMode == "manufacturer");
-		sortType->add(_("BY HARDWARE TYPE"), "hardware", sortMode == "hardware");
+		sortType->add(_("BY HARDWARE TYPE THEN ALPHABETICALLY"), "hardware", sortMode == "hardware");
+		sortType->add(_("BY HARDWARE TYPE THEN YEAR"), "hardware-year", sortMode == "hardware-year");
 		sortType->add(_("BY MANUFACTURER AND TYPE"), "subgroup", sortMode == "subgroup");
 		sortType->add(_("BY RELEASE YEAR"), "releaseDate", sortMode == "releaseDate");
 	}

--- a/es-app/src/views/SystemView.cpp
+++ b/es-app/src/views/SystemView.cpp
@@ -320,7 +320,8 @@ int SystemView::moveCursorFast(bool forward)
 			_moveCursorInRange(cursor, 1, mEntries.size());
 		}
 	}
-	else if (SystemData::IsManufacturerSupported && Settings::getInstance()->getString("SortSystems") == "hardware" && cursor >= 0 && cursor < mEntries.size())
+	else if (SystemData::IsManufacturerSupported && (Settings::getInstance()->getString("SortSystems") == "hardware"
+			|| Settings::getInstance()->getString("SortSystems") == "hardware-year") && cursor >= 0 && cursor < mEntries.size())
 	{
 		std::string hwt = mEntries[mCursor].object->getSystemMetadata().hardwareType;
 
@@ -543,7 +544,7 @@ bool SystemView::showNavigationBar()
 		showNavigationBar(_("GO TO MANUFACTURER"), [](SystemData* meta) { return meta->getSystemMetadata().manufacturer; });
 		return true;
 	}
-	else if (sortMode == "hardware")
+	else if (sortMode == "hardware" || sortMode == "hardware-year")
 	{
 		showNavigationBar(_("GO TO HARDWARE"), [](SystemData* meta) { return meta->getSystemMetadata().hardwareType; });
 		return true;


### PR DESCRIPTION
Kept also the original "hardware type then alphabetical".