### PR TITLE
FileTag: fix missing include directives

### DIFF
--- a/es-app/src/FileTag.cpp
+++ b/es-app/src/FileTag.cpp
@@ -1,3 +1,5 @@
+#include <algorithm>
+#include "utils/StringUtil.h"
 #include "FileTag.h"
 #include "LocaleES.h"
 


### PR DESCRIPTION
This fixes building ES on Linux which fails due to the following error:

```
	es-app/src/FileTag.cpp: In static member function 'static std::vector<std::__cxx11::basic_string<char> > FileTag::getDisplayIcons(const std::string&)':
	es-app/src/FileTag.cpp:27:26: error: 'Utils' has not been declared
   27 |         for (auto name : Utils::String::split(names, ','))
      |                          ^~~~~
	es-app/src/FileTag.cpp:29:36: error: 'Utils' has not been declared
   29 |                 std::string test = Utils::String::trim(name);
      |                                    ^~~~~
	es-app/src/FileTag.cpp:31:32: error: 'find_if' is not a member of 'std'
   31 |                 auto it = std::find_if(defaultTags.cbegin(), defaultTags.cend(), [test](const FileTag& ss) { return ss.Name == test; });
      |                                ^~~~~~~
```