### PR TITLE
Add ability to NOT sort collections/gamelists

### DIFF
--- a/es-app/src/FileSorts.cpp
+++ b/es-app/src/FileSorts.cpp
@@ -69,6 +69,9 @@ namespace FileSorts
 		mSortTypes.push_back(SortType(SYSTEM_RELEASEDATE_DESCENDING, &compareSystemReleaseYear, false, _("SYSTEM, RELEASE YEAR, DESCENDING"), _U("\uF161 ")));
 		mSortTypes.push_back(SortType(RELEASEDATE_SYSTEM_ASCENDING, &compareReleaseYearSystem, true, _("RELEASE YEAR, SYSTEM, ASCENDING"), _U("\uF160 ")));
 		mSortTypes.push_back(SortType(RELEASEDATE_SYSTEM_DESCENDING, &compareReleaseYearSystem, false, _("RELEASE YEAR, SYSTEM, DESCENDING"), _U("\uF161 ")));
+
+		mSortTypes.push_back(SortType(NONE_ASCENDING, &compareNone, true, _("NONE"), _U("\uF15d ")));
+		mSortTypes.push_back(SortType(NONE_DESCENDING, &compareNone, false, _("NONE, REVERSE"), _U("\uF15e ")));
 	}
 
 	//returns if file1 should come before file2
@@ -222,5 +225,10 @@ namespace FileSorts
 		std::string system1 = ((FileData*)file1)->getSourceFileData()->getSystemName();
 		std::string system2 = ((FileData*)file2)->getSourceFileData()->getSystemName();
 		return Utils::String::compareIgnoreCase(system1, system2) < 0;		
+	}
+
+	bool compareNone(const FileData* file1, const FileData* file2)
+	{
+		return false;
 	}
 };

--- a/es-app/src/FileSorts.h
+++ b/es-app/src/FileSorts.h
@@ -37,7 +37,10 @@ namespace FileSorts
 		SYSTEM_RELEASEDATE_ASCENDING = 24,
 		SYSTEM_RELEASEDATE_DESCENDING = 25,
 		RELEASEDATE_SYSTEM_ASCENDING = 26,
-		RELEASEDATE_SYSTEM_DESCENDING = 27
+		RELEASEDATE_SYSTEM_DESCENDING = 27,
+
+		NONE_ASCENDING = 28,
+		NONE_DESCENDING = 29
 	};
 
 	typedef bool ComparisonFunction(const FileData* a, const FileData* b);
@@ -81,6 +84,8 @@ namespace FileSorts
 
 	bool compareSystemReleaseYear(const FileData* file1, const FileData* file2);
 	bool compareReleaseYearSystem(const FileData* file1, const FileData* file2);
+
+	bool compareNone(const FileData* file1, const FileData* file2);
 
 	std::string stripLeadingArticle(const std::string &string, const std::vector<std::string> &articles);
 };


### PR DESCRIPTION
For custom collections it can be nice to have them sorted as-is (ie the same order as written in the file). This PR adds new 'NONE_ASCENDING/NONE_DESCENDING' sort type to do this.