### PR TITLE
system view : add option to filter by hardware category

### DIFF
--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -1011,6 +1011,12 @@ void GuiMenu::openDeveloperSettings()
 	s->addWithLabel(_("QUICK SYSTEM SELECT"), quick_sys_select);
 	s->addSaveFunc([quick_sys_select] { Settings::getInstance()->setBool("QuickSystemSelect", quick_sys_select->getState()); });
 
+	// category filtering (hardware filtering with directional controls)
+	auto category_filtering = std::make_shared<SwitchComponent>(mWindow);
+	category_filtering->setState(Settings::getInstance()->getBool("CategoryFiltering"));
+	s->addWithDescription(_("CATEGORY FILTERING"), _("Enable hardware category filtering using directional controls. When enabled, Quick System Select will use Page Up/Down instead."), category_filtering);
+	s->addSaveFunc([category_filtering] { Settings::getInstance()->setBool("CategoryFiltering", category_filtering->getState()); });
+
 	// quick jump next letter (R2/L2 in game list view)
 	auto quick_jump_letter = std::make_shared<SwitchComponent>(mWindow);
 	quick_jump_letter->setState(Settings::getInstance()->getBool("QuickJumpLetter"));

--- a/es-app/src/views/SystemView.cpp
+++ b/es-app/src/views/SystemView.cpp
@@ -405,9 +405,23 @@ bool SystemView::input(InputConfig* config, Input input)
 		auto carousel = mCarousel.asCarousel();
 		bool isHorizontal = (carousel != nullptr && carousel->isHorizontalCarousel());
 
-		// For keyboard and gamepad: Use directions based on carousel orientation
-		if (isHorizontal)
+		if (mCarousel.isGrid())
 		{
+			// Grid view uses all 4 directions for navigation, use L2/R2 for filtering
+			if (config->isMappedLike("l2", input))
+			{
+				cycleHardwareFilter(-1);
+				return true;
+			}
+			else if (config->isMappedLike("r2", input))
+			{
+				cycleHardwareFilter(1);
+				return true;
+			}
+		}
+		else if (isHorizontal)
+		{
+			// Horizontal carousel: use up/down for filtering
 			if (config->isMappedLike("up", input))
 			{
 				cycleHardwareFilter(-1);
@@ -421,6 +435,7 @@ bool SystemView::input(InputConfig* config, Input input)
 		}
 		else
 		{
+			// Vertical carousel/textlist: use left/right for filtering
 			if (config->isMappedLike("left", input))
 			{
 				cycleHardwareFilter(-1);

--- a/es-app/src/views/SystemView.h
+++ b/es-app/src/views/SystemView.h
@@ -29,6 +29,14 @@ struct SystemViewData
 	std::vector<GuiComponent*> backgroundExtras;
 };
 
+// Structure to store hardware categories
+struct HardwareCategory
+{
+	std::string name;
+
+	HardwareCategory(const std::string& n) : name(n) {}
+};
+
 
 class SystemView : public GuiComponent
 {
@@ -102,13 +110,23 @@ private:
 	void	 renderCarousel(const Transform4x4f& parentTrans);
 	void	 renderExtras(const Transform4x4f& parentTrans, float lower, float upper);
 	void	 renderInfoBar(const Transform4x4f& trans);
+
+	// Hardware filtering methods
+	std::vector<HardwareCategory> getUniqueHardwareTypes();
+	void	 updateSystemsForHardwareFilter();
+	void	 cycleHardwareFilter(int direction);
 	
 	ControlWrapper						mCarousel;
+
+	std::vector<HardwareCategory>		mHardwareTypes;
+	std::string							mCurrentHardwareFilter;
+	bool								mHardwareFilterEnabled;
 
 	TextComponent						mSystemInfo;
 
 	std::vector<GuiComponent*>			mStaticBackgrounds;
 	std::vector<SystemViewData>			mEntries;
+	std::vector<SystemViewData>			mAllEntries; // To store all unfiltered systems
 
 	float			mCamOffset;
 	float			mExtrasCamOffset;


### PR DESCRIPTION
When enabled,left|right or up|down is switch to next hardware category and only diplay systems from this category.

Ordering by date, manufacter,name,.. is still working inside a filtered hardware categories

Some themes like
https://github.com/BobMoraneRetro/one4all4one-coinopsfriends-bobmorane

already provide nice icons to diplay the current selected categories.  (without theme support, are still a notification indication when the categorie is changed)


