### PR TITLE
Fix for emulators that never return 0 on exit (ShadPS4)

### DIFF
--- a/es-app/src/FileData.cpp
+++ b/es-app/src/FileData.cpp
@@ -760,24 +760,21 @@ bool FileData::launchGame(Window* window, LaunchGameOptions options)
 	window->normalizeNextUpdate();
 
 	//update number of times the game has been launched
-	if (exitCode == 0)
-	{
-		int timesPlayed = gameToUpdate->getMetadata().getInt(MetaDataId::PlayCount) + 1;
-		gameToUpdate->setMetadata(MetaDataId::PlayCount, std::to_string(static_cast<long long>(timesPlayed)));
+  int timesPlayed = gameToUpdate->getMetadata().getInt(MetaDataId::PlayCount) + 1;
+  gameToUpdate->setMetadata(MetaDataId::PlayCount, std::to_string(static_cast<long long>(timesPlayed)));
 
-		// How long have you played that game? (more than 10 seconds, otherwise
-		// you might have experienced a loading problem)
-		time_t tend = time(NULL);
-		long elapsedSeconds = difftime(tend, tstart);
-		long gameTime = gameToUpdate->getMetadata().getInt(MetaDataId::GameTime) + elapsedSeconds;
-		if (elapsedSeconds >= 10)
-			gameToUpdate->setMetadata(MetaDataId::GameTime, std::to_string(static_cast<long>(gameTime)));
+  // How long have you played that game? (more than 10 seconds, otherwise
+  // you might have experienced a loading problem)
+  time_t tend = time(NULL);
+  long elapsedSeconds = difftime(tend, tstart);
+  long gameTime = gameToUpdate->getMetadata().getInt(MetaDataId::GameTime) + elapsedSeconds;
+  if (elapsedSeconds >= 10)
+    gameToUpdate->setMetadata(MetaDataId::GameTime, std::to_string(static_cast<long>(gameTime)));
 
-		//update last played time
-		gameToUpdate->setMetadata(MetaDataId::LastPlayed, Utils::Time::DateTime(Utils::Time::now()));
-		CollectionSystemManager::get()->refreshCollectionSystems(gameToUpdate);
-		saveToGamelistRecovery(gameToUpdate);
-	}
+  //update last played time
+  gameToUpdate->setMetadata(MetaDataId::LastPlayed, Utils::Time::DateTime(Utils::Time::now()));
+  CollectionSystemManager::get()->refreshCollectionSystems(gameToUpdate);
+  saveToGamelistRecovery(gameToUpdate);
 
 	window->reactivateGui();
 


### PR DESCRIPTION
This fixes https://github.com/batocera-linux/batocera.linux/issues/15021 (and basically all stats for PS4 that are not updated)

We still keep the 10-sec guardrail to discard failed launches.