### PR TITLE
[Windowed Mode] Fix wrong screen selection on dual-screen CRT setup

### DIFF
--- a/es-core/src/renderers/Renderer.cpp
+++ b/es-core/src/renderers/Renderer.cpp
@@ -228,7 +228,7 @@ namespace Renderer
 		{
 			windowFlags |= SDL_WINDOW_RESIZABLE;
 
-			if (Settings::getInstance()->getInt("WindowWidth") == 0)
+			if (Settings::getInstance()->getInt("WindowWidth") == 0 && Settings::getInstance()->getInt("ScreenWidth") == 0)
 			{
 				windowWidth = 1280; windowHeight = 720;
 				windowFlags |= SDL_WINDOW_MAXIMIZED;


### PR DESCRIPTION
##Problem

When using a dual-screen CRT setup with --screensize (instead of --resolution), 
EmulationStation displays on the wrong screen (HDMI instead of CRT) in windowed mode.

##Root Cause

Introduced in commits 0de5d9c and fff815c ([Windowed Mode] Allow Window resize), 
the following condition in Renderer.cpp triggers SDL_WINDOW_MAXIMIZED when WindowWidth == 0:

    if (Settings::getInstance()->getInt("WindowWidth") == 0)
    {
        windowWidth = 1280; windowHeight = 720;
        windowFlags |= SDL_WINDOW_MAXIMIZED;
    }

When using --screensize, only ScreenWidth is set (not WindowWidth).
SDL_WINDOW_MAXIMIZED ignores window position coordinates and places 
the window on the largest screen (HDMI instead of CRT).

##Fix

Also check ScreenWidth in the condition:

    if (Settings::getInstance()->getInt("WindowWidth") == 0 && 
        Settings::getInstance()->getInt("ScreenWidth") == 0)

##Tested on

- Batocera Linux V43 (x86_64)
- ES binary recompiled from source with this fix applied
- Verified: ES displays correctly on CRT (DP-1) with dual-screen setup

##Setup

- AMD Navi 24 (RX 6500 XT), amdgpu driver. Optiplex 9020 (i7-4790 CPU @ 3.60GHz)
- CRT on DP-1 (15kHz, 769x576@50Hz via SwitchRes)
- HDMI-1 for marquees (1920x1080@60Hz)
- Extended desktop: 2689x1080