### PR TITLE
[InputConfig] Fix hotkey assignment being skipped when holding a button

### DIFF
--- a/es-core/src/guis/GuiInputConfig.cpp
+++ b/es-core/src/guis/GuiInputConfig.cpp
@@ -74,7 +74,7 @@ void GuiInputConfig::initInputConfigStructure(InputConfig* target)
 		{ "l3",              true,  "LEFT STICK PRESS",   ":/help/analog_thumb.svg" },
 		{ "r3",              true,  "RIGHT STICK PRESS",  ":/help/analog_thumb.svg" },
 
-		{ "hotkey",          true,  "HOTKEY",             ":/help/button_hotkey.svg" }
+		{ "hotkey",          false, "HOTKEY",             ":/help/button_hotkey.svg" }
 	};
 	
 #ifdef INVERTEDINPUTCONFIG


### PR DESCRIPTION
## Summary

- The `hotkey` entry in `GUI_INPUT_CONFIG_LIST` was marked `skippable = true`, causing the hold-to-skip timer (1000ms) to fire when a user held a button on the HOTKEY configuration row
- This called `clearAssignment("hotkey")` and advanced past the row, so the hotkey was never mapped
- Changing `skippable` to `false` for the hotkey entry prevents the skip timer from running on that row — holding a button now assigns it as intended
- Users who want no hotkey can still skip it via the existing "DO NOT ASSIGN HOTKEY" option in the modal that appears when pressing OK without a hotkey set

## Root cause

`GuiInputConfig::update()` runs the hold-to-skip logic for any row where `skippable == true`. Since the hotkey row had `skippable = true`, holding a button for ≥1 second cleared the assignment and moved on, rather than mapping it. This is the same 1 second threshold used by `GuiDetectDevice` to begin configuration — training users to hold buttons, only for that behavior to backfire on the hotkey step.

The "use Select as hotkey" modal path worked because it bypasses the hold mechanism entirely, reading the already-configured Select input directly.

## Test plan

- [ ] Configure a controller from scratch; hold a button on the HOTKEY row — it should assign and advance normally
- [ ] Configure a controller and skip past the HOTKEY row without assigning — pressing OK should still prompt with the Select/no-hotkey modal
- [ ] Verify other skippable rows (analog sticks, triggers, etc.) still respond to hold-to-skip as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)