### PR TITLE
[WIN32] Fix dualsense detection once and for all

### DIFF
--- a/es-core/src/InputManager.cpp
+++ b/es-core/src/InputManager.cpp
@@ -352,10 +352,40 @@ void InputManager::rebuildAllJoysticks(bool deinit)
 		SDL_SetHint(SDL_HINT_JOYSTICK_HIDAPI, "0");
 
 	SDL_SetHint("SDL_JOYSTICK_HIDAPI_WII", "0");
+
+	// Disable PS5 enhanced feature reports (rumble, LED, haptics).
+	// On Windows, SDL attempts these HID exchanges during HIDAPI init.
+	// If the Bluetooth audio endpoint isn't ready yet, SDL gets an error,
+	// marks the controller disconnected, and retries endlessly — causing
+	// the infinite "DualSense connected" notification loop. Disabling them
+	// prevents that cycle and also allows the controller to be detected
+	// when it is already paired before ES starts.
+	SDL_SetHint("SDL_JOYSTICK_HIDAPI_PS5_RUMBLE", "0");
+	SDL_SetHint("SDL_JOYSTICK_HIDAPI_PS5_PLAYER_LED", "0");
 #endif
 			
 	SDL_SetHint(SDL_HINT_JOYSTICK_ALLOW_BACKGROUND_EVENTS, Settings::getInstance()->getBool("BackgroundJoystickInput") ? "1" : "0");
 	SDL_InitSubSystem(SDL_INIT_JOYSTICK);	
+
+#if WIN32
+	// SDL's HIDAPI thread enumerates devices asynchronously after SDL_InitSubSystem.
+	// For DualSense/DS4 over Bluetooth, the HID handshake is not complete by the
+	// time SDL_NumJoysticks() is called immediately after init, so the controller
+	// is missed. Poll until the count stabilises (max 500ms) instead of a fixed sleep.
+	if (!deinit)
+	{
+		int prevCount = -1;
+		int stableCount = SDL_NumJoysticks();
+		int attempts = 0;
+		while (stableCount != prevCount && attempts < 10)
+		{
+			prevCount = stableCount;
+			SDL_Delay(50);
+			SDL_PumpEvents();
+			stableCount = SDL_NumJoysticks();
+		}
+	}
+#endif
 
 	mJoysticksLock.lock();
 


### PR DESCRIPTION
Tested with RetroBat, fixes Dualsense detection when controller is already plugged in at RetroBat start