### PR TITLE
Startup speed

### DIFF
--- a/es-core/src/utils/FileSystemUtil.cpp
+++ b/es-core/src/utils/FileSystemUtil.cpp
@@ -10,6 +10,7 @@
 #include <string.h>
 #include <algorithm>
 #include <set>
+#include <shared_mutex>
 
 #if defined(_WIN32)
 // because windows...
@@ -91,7 +92,7 @@ namespace Utils
 				if (!Settings::UseFileCache())
 					return;
 
-				std::unique_lock<std::mutex> guard(mFileCacheMutex);
+				std::unique_lock<std::shared_mutex> guard(mFileCacheMutex);
 
 				auto [it, inserted] = mFileCache.try_emplace(hashPath(key), data);
 				if (!inserted)
@@ -108,7 +109,7 @@ namespace Utils
 				if (!Settings::UseFileCache())
 					return;
 
-				std::unique_lock<std::mutex> guard(mFileCacheMutex);
+				std::unique_lock<std::shared_mutex> guard(mFileCacheMutex);
 
 				auto [it, inserted] = mFileCache.try_emplace(hashPath(key), dwFileAttributes); 
 				if (!inserted)
@@ -136,7 +137,7 @@ namespace Utils
 #if WIN32			
 				int ret = _wstat64(Utils::String::convertToWideString(key).c_str(), info);
 
-				std::unique_lock<std::mutex> guard(mFileCacheMutex);
+				std::unique_lock<std::shared_mutex> guard(mFileCacheMutex);
 				mFileCache.try_emplace(hashPath(key), ret == 0, ret == 0 && S_ISDIR(info->st_mode));				
 #else
 				int ret = stat64(key.c_str(), info);
@@ -154,7 +155,7 @@ namespace Utils
 					}
 				}
 
-				std::unique_lock<std::mutex> guard(mFileCacheMutex);
+				std::unique_lock<std::shared_mutex> guard(mFileCacheMutex);
 				mFileCache[hashPath(key)] = cache;			
 #endif
 
@@ -166,7 +167,7 @@ namespace Utils
 				if (!Settings::UseFileCache())
 					return;
 
-				std::unique_lock<std::mutex> guard(mFileCacheMutex);
+				std::unique_lock<std::shared_mutex> guard(mFileCacheMutex);
 				auto [it, inserted] = mFileCache.try_emplace(hashPath(key), exists, dir, symlink);
 				if (!inserted)
 				{
@@ -181,7 +182,7 @@ namespace Utils
 				if (!Settings::UseFileCache())
 					return;
 
-				std::unique_lock<std::mutex> guard(mFileCacheMutex);
+				std::unique_lock<std::shared_mutex> guard(mFileCacheMutex);
 
 				mFileCache.erase(hashPath(key));
 				
@@ -195,7 +196,7 @@ namespace Utils
 
 			static std::optional<bool> exists(const std::string& key) 
 			{
-				std::unique_lock<std::mutex> lock(mFileCacheMutex);
+				std::unique_lock<std::shared_mutex> lock(mFileCacheMutex);
 
 				auto val = getCacheEntry(key);
 				if (val)
@@ -206,7 +207,7 @@ namespace Utils
 
 			static std::optional<bool> isRegularFile(const std::string& key)
 			{
-				std::unique_lock<std::mutex> lock(mFileCacheMutex);
+				std::unique_lock<std::shared_mutex> lock(mFileCacheMutex);
 
 				auto val = getCacheEntry(key);
 				if (val)
@@ -217,7 +218,7 @@ namespace Utils
 
 			static std::optional<bool> isDirectory(const std::string& key)
 			{
-				std::unique_lock<std::mutex> lock(mFileCacheMutex);
+				std::unique_lock<std::shared_mutex> lock(mFileCacheMutex);
 
 				auto val = getCacheEntry(key);
 				if (val)
@@ -228,7 +229,7 @@ namespace Utils
 
 			static std::optional<bool> isSymlink(const std::string& key)
 			{
-				std::unique_lock<std::mutex> lock(mFileCacheMutex);
+				std::unique_lock<std::shared_mutex> lock(mFileCacheMutex);
 
 				auto val = getCacheEntry(key);
 				if (val)
@@ -239,7 +240,7 @@ namespace Utils
 
 			static std::optional<bool> isHidden(const std::string& key)
 			{
-				std::unique_lock<std::mutex> lock(mFileCacheMutex);
+				std::unique_lock<std::shared_mutex> lock(mFileCacheMutex);
 
 				auto val = getCacheEntry(key);
 				if (val)
@@ -250,7 +251,7 @@ namespace Utils
 
 			static void resetCache()
 			{
-				std::unique_lock<std::mutex> guard(mFileCacheMutex);
+				std::unique_lock<std::shared_mutex> guard(mFileCacheMutex);
 				mFileCache.clear();
 			}
 
@@ -299,7 +300,7 @@ namespace Utils
 			bool _symlink;
 
 			static std::unordered_map<size_t, FileCache> mFileCache;
-			static std::mutex mFileCacheMutex;
+			static std::shared_mutex mFileCacheMutex;
 
 			static size_t hashPath(const std::string& path) 
 			{ 
@@ -308,7 +309,7 @@ namespace Utils
 		};
 
 		std::unordered_map<size_t, FileCache> FileCache::mFileCache;
-		std::mutex FileCache::mFileCacheMutex;
+		std::shared_mutex FileCache::mFileCacheMutex;
 
 		void FileSystemCache::reset()
 		{

--- a/es-core/src/utils/FileSystemUtil.cpp
+++ b/es-core/src/utils/FileSystemUtil.cpp
@@ -712,7 +712,12 @@ namespace Utils
 			if (path.find("./") == std::string::npos && path.find(".\\") == std::string::npos)
 				return path;
 #else
-			std::string path = exists(_path) ? getAbsolutePath(_path) : _path;
+			// For absolute paths, skip the stat — exists() is only needed to resolve
+			// relative paths, and getAbsolutePath() on an already-absolute path is a no-op.
+			std::string path = isAbsolute(_path) ? getGenericPath(_path) : (exists(_path) ? getAbsolutePath(_path) : getGenericPath(_path));
+			// Early return if there are no . or .. components to normalize
+			if (path.find("/.") == std::string::npos)
+				return path;
 #endif
 			
 			int indexes[32];

--- a/es-core/src/utils/FileSystemUtil.cpp
+++ b/es-core/src/utils/FileSystemUtil.cpp
@@ -194,59 +194,62 @@ namespace Utils
 				}
 			}
 
-			static std::optional<bool> exists(const std::string& key) 
+			template<typename Func>
+			static std::optional<bool> queryCacheEntry(const std::string& key, Func func)
 			{
+				if (!Settings::UseFileCache())
+					return std::nullopt;
+
+				auto hash = hashPath(key);
+				{
+					std::shared_lock<std::shared_mutex> lock(mFileCacheMutex);
+					if (auto* e = getCacheEntry(key, hash))
+						return func(e);
+				}
+
+				auto fetched = statKey(key);
 				std::unique_lock<std::shared_mutex> lock(mFileCacheMutex);
+				return func(&insertEntry(hash, key, std::move(fetched)));
+			}
 
-				auto val = getCacheEntry(key);
-				if (val)
-					return val->_exists;
+			static std::optional<bool> exists(const std::string& key)
+			{
+				return queryCacheEntry(key, [](const FileCache* e) { return std::optional<bool>(e->_exists); });
+			}
 
-				return std::nullopt;
+			// Non-blocking probe: returns true if the key's existence is already
+			// recorded in the cache (either exists or known-not-to-exist).
+			// Never calls stat64 — safe to call from the render thread.
+			static bool isCached(const std::string& key)
+			{
+				if (!Settings::UseFileCache())
+					return false;
+
+				auto hash = hashPath(key);
+				std::shared_lock<std::shared_mutex> lock(mFileCacheMutex);
+				if (mFileCache.count(hash))
+					return true;
+				return mFileCache.count(hashPath(Utils::FileSystem::getParent(key) + "/*")) > 0;
 			}
 
 			static std::optional<bool> isRegularFile(const std::string& key)
 			{
-				std::unique_lock<std::shared_mutex> lock(mFileCacheMutex);
-
-				auto val = getCacheEntry(key);
-				if (val)
-					return val->_exists && !val->_directory && !val->_symlink;
-
-				return std::nullopt;
+				return queryCacheEntry(key, [](const FileCache* e) { return std::optional<bool>(e->_exists && !e->_directory && !e->_symlink); });
 			}
 
 			static std::optional<bool> isDirectory(const std::string& key)
 			{
-				std::unique_lock<std::shared_mutex> lock(mFileCacheMutex);
-
-				auto val = getCacheEntry(key);
-				if (val)
-					return val->_exists && val->_directory;
-
-				return std::nullopt;
+				return queryCacheEntry(key, [](const FileCache* e) { return std::optional<bool>(e->_exists && e->_directory); });
 			}
 
 			static std::optional<bool> isSymlink(const std::string& key)
 			{
-				std::unique_lock<std::shared_mutex> lock(mFileCacheMutex);
-
-				auto val = getCacheEntry(key);
-				if (val)
-					return val->_exists && val->_symlink;
-
-				return std::nullopt;
+				return queryCacheEntry(key, [](const FileCache* e) { return std::optional<bool>(e->_exists && e->_symlink); });
 			}
 
 			static std::optional<bool> isHidden(const std::string& key)
 			{
-				std::unique_lock<std::shared_mutex> lock(mFileCacheMutex);
-
-				auto val = getCacheEntry(key);
-				if (val)
-					return val->_exists && (val->_hidden || getFileName(key)[0] == '.');
-
-				return std::nullopt;
+				return queryCacheEntry(key, [&key](const FileCache* e) { return std::optional<bool>(e->_exists && (e->_hidden || getFileName(key)[0] == '.')); });
 			}
 
 			static void resetCache()
@@ -256,26 +259,33 @@ namespace Utils
 			}
 
 		private:
-			static FileCache* getCacheEntry(const std::string& key)
+			// Looks up key in the cache. MUST be called under at least a shared_lock.
+			// Returns pointer to the entry if found (including parent-wildcard hits,
+			// which return a static "not exists" sentinel), or nullptr if not cached.
+			static const FileCache* getCacheEntry(const std::string& key, size_t hash)
 			{
-				if (!Settings::UseFileCache())
+				if (mFileCache.empty())
 					return nullptr;
 
-				auto hash = hashPath(key);
+				auto it = mFileCache.find(hash);
+				if (it != mFileCache.cend())
+					return &it->second;
 
-				if (mFileCache.size())
+				it = mFileCache.find(hashPath(Utils::FileSystem::getParent(key) + "/*"));
+				if (it != mFileCache.cend())
 				{
-					auto it = mFileCache.find(hash);
-					if (it != mFileCache.cend())
-						return &it->second;
-
-					it = mFileCache.find(hashPath(Utils::FileSystem::getParent(key) + "/*"));
-					if (it != mFileCache.cend())
-						return &mFileCache.try_emplace(hash, false, false).first->second;
+					static const FileCache notExists(false, false);
+					return &notExists;
 				}
 
-#ifdef WIN32			
-				return &mFileCache.try_emplace(hash, GetFileAttributesW(Utils::String::convertToWideString(key).c_str())).first->second;
+				return nullptr;
+			}
+
+			// Performs filesystem I/O with NO lock held — safe to call concurrently.
+			static FileCache statKey(const std::string& key)
+			{
+#ifdef WIN32
+				return FileCache(GetFileAttributesW(Utils::String::convertToWideString(key).c_str()));
 #else
 				struct stat64 info;
 				int ret = stat64(key.c_str(), &info);
@@ -290,8 +300,24 @@ namespace Utils
 						directory = S_ISDIR(si.st_mode);
 				}
 
-				return &mFileCache.try_emplace(hash, exists, directory, symlink).first->second;
+				return FileCache(exists, directory, symlink);
 #endif
+			}
+
+			// Inserts a pre-computed entry. MUST be called with exclusive lock held.
+			// Double-checks for races: returns the authoritative entry (ours or a
+			// concurrent thread's insert, whichever arrived first).
+			static const FileCache& insertEntry(size_t hash, const std::string& key, FileCache fetched)
+			{
+				auto it = mFileCache.find(hash);
+				if (it != mFileCache.cend())
+					return it->second;
+
+				it = mFileCache.find(hashPath(Utils::FileSystem::getParent(key) + "/*"));
+				if (it != mFileCache.cend())
+					return mFileCache.try_emplace(hash, false, false).first->second;
+
+				return mFileCache.try_emplace(hash, std::move(fetched)).first->second;
 			}
 
 			bool _exists;


### PR DESCRIPTION
Two improvements to FileCache to reduce startup time when many systems
load in parallel via ThreadPool:

1. Upgrade std::mutex to std::shared_mutex. Read-only cache hits
   (exists, isDirectory, etc.) now use a shared_lock, allowing all
   threads to read concurrently with no blocking between them.

2. Move stat64/filesystem I/O out of the exclusive lock. Previously
   getCacheEntry() performed stat() while holding the write lock,
   serializing all threads through slow network I/O. Now statKey()
   does the I/O with no lock held; the exclusive lock is only acquired
   for the brief map insertion, with a double-check for races.

For absolute paths (the common case for ROM paths), getCanonicalPath was
calling exists() which performs a stat64 just to decide whether to call
getAbsolutePath() — but getAbsolutePath() on an already-absolute path is
a no-op anyway. Skip the stat entirely by checking isAbsolute() first.

Also add an early return when the path contains no '.' components, since
there is nothing to normalize. This mirrors the same optimization already
present in the Windows code path above.

Together these eliminate the per-ROM stat calls in removeMultiDiskContent
→ getCanonicalPath that were serializing startup on network-backed ROM
libraries.
