### PR TITLE
[Performance] Non-blocking media preload and VLC teardown

### DIFF
--- a/es-app/src/FileData.cpp
+++ b/es-app/src/FileData.cpp
@@ -1778,6 +1778,21 @@ FolderData::~FolderData()
 	clear();
 }
 
+std::set<std::string> FolderData::getMediaDirectories() const
+{
+	std::set<std::string> dirs;
+	for (auto file : mChildren)
+	{
+		std::string img = file->getMetadata(MetaDataId::Image);
+		if (!img.empty()) dirs.insert(Utils::FileSystem::getParent(img));
+		std::string mq = file->getMetadata(MetaDataId::Marquee);
+		if (!mq.empty()) dirs.insert(Utils::FileSystem::getParent(mq));
+		std::string vid = file->getMetadata(MetaDataId::Video);
+		if (!vid.empty()) dirs.insert(Utils::FileSystem::getParent(vid));
+	}
+	return dirs;
+}
+
 void FolderData::clear() {
 	if (mOwnsChildrens)
 		for (auto* child : mChildren)

--- a/es-app/src/FileData.h
+++ b/es-app/src/FileData.h
@@ -244,6 +244,7 @@ public:
 	FileData* FindByPath(const std::string& path);
 
 	inline const std::vector<FileData*>& getChildren() const { return mChildren; }
+	std::set<std::string> getMediaDirectories() const;
 	const std::vector<FileData*> getChildrenListToDisplay();
 	std::shared_ptr<std::vector<FileData*>> findChildrenListToDisplayAtCursor(FileData* toFind, std::stack<FileData*>& stack);
 

--- a/es-app/src/views/SystemView.cpp
+++ b/es-app/src/views/SystemView.cpp
@@ -1,6 +1,7 @@
 #include "views/SystemView.h"
 
 #include "animations/LambdaAnimation.h"
+#include "FileData.h"
 #include "guis/GuiMsgBox.h"
 #include "views/UIModeController.h"
 #include "views/ViewController.h"
@@ -649,7 +650,7 @@ void SystemView::onCursorChanged(const CursorState& state)
 	if (AudioManager::isInitialized())
 		AudioManager::getInstance()->changePlaylist(getSelected()->getTheme());
 
-	Utils::FileSystem::preloadFileSystemCache(mEntries.at(mCursor).object->getRootFolder()->getPath(), true);
+	Utils::FileSystem::preloadFileSystemCache(mEntries.at(mCursor).object->getRootFolder()->getMediaDirectories());
 
 	// update help style
 	updateHelpPrompts();

--- a/es-app/src/views/ViewController.cpp
+++ b/es-app/src/views/ViewController.cpp
@@ -1025,6 +1025,7 @@ void ViewController::preload()
 		}
 
 		(*it)->resetFilters();
+		Utils::FileSystem::preloadFileSystemCache((*it)->getRootFolder()->getMediaDirectories());
 		getGameListView(*it);
 	}
 }

--- a/es-app/src/views/gamelist/GridGameListView.cpp
+++ b/es-app/src/views/gamelist/GridGameListView.cpp
@@ -193,6 +193,8 @@ void GridGameListView::populateList(const std::vector<FileData*>& files)
 		for (auto file : files)
 			mGrid.add(formatter.getDisplayName(file, file->getType() == FOLDER && Utils::FileSystem::exists(getImagePath(file))), getImagePath(file), file);
 
+		Utils::FileSystem::preloadFileSystemCache(mRoot->getSystem()->getRootFolder()->getMediaDirectories());
+
 		// if we have the ".." PLACEHOLDER, then select the first game instead of the placeholder
 		if (showParentFolder && mCursorStack.size() && mGrid.size() > 1 && mGrid.getCursorIndex() == 0)
 			mGrid.setCursorIndex(1);

--- a/es-core/src/components/VideoVlcComponent.cpp
+++ b/es-core/src/components/VideoVlcComponent.cpp
@@ -1,6 +1,7 @@
 #include "components/VideoVlcComponent.h"
 
 #include "renderers/Renderer.h"
+#include <thread>
 #include "resources/TextureResource.h"
 #include "utils/StringUtil.h"
 #include "PowerSaver.h"
@@ -853,7 +854,7 @@ void VideoVlcComponent::startVideo()
 
 	PowerSaver::pause();
 
-	// use : vlc –long-help
+	// use : vlc ï¿½long-help
 	// WIN32 ? libvlc_media_add_option(mMedia, ":avcodec-hw=dxva2");
 	// RPI/OMX ? libvlc_media_add_option(mMedia, ":codec=mediacodec,iomx,all"); .
 
@@ -913,15 +914,24 @@ void VideoVlcComponent::stopVideo()
 
 	mContext = nullptr;
 
-	// Release the media
+	// Release the media.
+	// Both libvlc_media_parse_stop and libvlc_media_release can block while
+	// VLC's internal parse thread acknowledges the cancellation.  Do both on
+	// a background thread so the UI thread is never stalled.
 	if (mMedia)
 	{
 		mIsParsing = false;
-		libvlc_media_release(mMedia); 
-		mMedia = NULL;
+		auto* mediaToRelease = mMedia;
+		mMedia = nullptr;
+		std::thread([mediaToRelease]() {
+#if LIBVLC_VERSION_MAJOR >= 3
+			libvlc_media_parse_stop(mediaToRelease);
+#endif
+			libvlc_media_release(mediaToRelease);
+		}).detach();
 
 		PowerSaver::resume();
-	}		
+	}
 
 	if (mIsTopWindow) // Release texture memory -> except if mDisable by topWindow ( ex: menu was poped )
 		mTexture = nullptr;

--- a/es-core/src/utils/FileSystemUtil.cpp
+++ b/es-core/src/utils/FileSystemUtil.cpp
@@ -1755,46 +1755,35 @@ namespace Utils
 			}
 		}
 #endif
-		void preloadFileSystemCache(const std::string& path, bool trySaveStates)
+		void preloadFileSystemCache(std::set<std::string> dirs)
 		{
-			if (path.empty())
+			if (dirs.empty() || !Settings::UseFileCache())
 				return;
 
-			if (!Settings::UseFileCache())
-				return;
-
+			static std::mutex preloadMutex;
 			static std::set<std::string> preloaded;
 
-			if (preloaded.find(path) != preloaded.cend())
+			std::set<std::string> todo;
+			{
+				std::lock_guard<std::mutex> lock(preloadMutex);
+				for (auto& d : dirs)
+				{
+					if (preloaded.find(d) == preloaded.cend())
+					{
+						preloaded.insert(d);
+						todo.insert(d);
+					}
+				}
+			}
+
+			if (todo.empty())
 				return;
 
-			preloaded.insert(path);
-
-			auto doWork = [&](std::string* dir)
+			std::thread([dirs = std::move(todo)]()
 			{
-				if (trySaveStates)
-				{
-					std::string systemName = Utils::FileSystem::getFileName(*dir);
-					Utils::FileSystem::getDirContent(Utils::FileSystem::combine(Paths::getSavesPath(), systemName), true);
-				}
-
-				Utils::FileSystem::getDirContent(Utils::FileSystem::combine(*dir, "/images"));
-				Utils::FileSystem::getDirContent(Utils::FileSystem::combine(*dir, "/videos"));
-				Utils::FileSystem::getDirContent(Utils::FileSystem::combine(*dir, "/manuals"));
-
-				delete dir;
-			};
-
-			std::thread thread(doWork, new std::string(path));
-
-#if WIN32		
-			if (Utils::Platform::isWindows10())
-				::SetThreadDescription(thread.native_handle(), L"PreloadFileSystemCache");
-
-			::SetThreadPriority(thread.native_handle(), THREAD_PRIORITY_LOWEST);
-#endif
-
-			thread.detach();
+				for (const auto& d : dirs)
+					Utils::FileSystem::getDirContent(d, false, true);
+			}).detach();
 		}
 
 	} // FileSystem::

--- a/es-core/src/utils/FileSystemUtil.h
+++ b/es-core/src/utils/FileSystemUtil.h
@@ -3,6 +3,7 @@
 #define ES_CORE_UTILS_FILE_SYSTEM_UTIL_H
 
 #include <list>
+#include <set>
 #include <string>
 #include <vector>
 #include "utils/TimeUtil.h"
@@ -82,7 +83,7 @@ namespace Utils
 #ifdef WIN32
 		void		splitCommand(const std::string& cmd, std::string* executable, std::string* parameters);
 #endif
-		void		preloadFileSystemCache(const std::string& path, bool trySaveStates = true);
+		void		preloadFileSystemCache(std::set<std::string> dirs);
 
 		std::string getFileCrc32(const std::string& filename);
 		std::string getFileMd5(const std::string& filename);


### PR DESCRIPTION
Two sources of UI stall when switching systems or opening the grid gamelist, both addressed here:

- **FileSystem preload**: `preloadFileSystemCache` previously scanned fixed subdirectories (`/images`, `/videos`, `/manuals`) under the system root. This switches it to scan the actual media paths derived from game metadata which matters most for network-backed libraries (NAS/SMB) where `stat64` latency is significant. `FolderData::getMediaDirectories()` collects these paths in one place. The overload is updated to take `std::set<std::string>` and owns the background thread and dedup logic. Preload is now triggered from `SystemView::onCursorChanged` (before the grid opens), `ViewController::preload()` (PreloadUI=true path), and `GridGameListView::populateList` (fallback for L2/R2 quick-select which bypasses `onCursorChanged`).

- **VLC teardown**: `libvlc_media_parse_stop` and `libvlc_media_release` can block the UI thread while VLC's internal parse thread acknowledges cancellation. Both are now moved off-thread in `stopVideo()`.


Before (practically unusable when scrolling)

https://github.com/user-attachments/assets/77b323da-1121-44c8-a369-fd9f4c1c41c6



After

https://github.com/user-attachments/assets/9bc57270-62f7-4fb4-885d-e2bfc9533dd9


