### PR TITLE
http api : addgames/removegames : include folders in fileMap

### DIFF
--- a/es-app/src/services/HttpServerThread.cpp
+++ b/es-app/src/services/HttpServerThread.cpp
@@ -647,7 +647,8 @@ void HttpServerThread::run()
 		}
 			
 		std::unordered_map<std::string, FileData*> fileMap;
-		for (auto file : system->getRootFolder()->getFilesRecursive(GAME))
+		fileMap[system->getRootFolder()->getPath()] = system->getRootFolder();
+		for (auto file : system->getRootFolder()->getFilesRecursive(GAME | FOLDER))
 			fileMap[file->getPath()] = file;
 
 		auto fileList = loadGamelistFile(req.body, system, fileMap, SIZE_MAX, false);
@@ -715,7 +716,8 @@ void HttpServerThread::run()
 		}
 
 		std::unordered_map<std::string, FileData*> fileMap;
-		for (auto file : system->getRootFolder()->getFilesRecursive(GAME))
+		fileMap[system->getRootFolder()->getPath()] = system->getRootFolder();
+		for (auto file : system->getRootFolder()->getFilesRecursive(GAME | FOLDER))
 			fileMap[file->getPath()] = file;
 
 		auto fileList = loadGamelistFile(req.body, system, fileMap, SIZE_MAX, false);


### PR DESCRIPTION
When a game with a subdirectory path (e.g. ./subdir/game.zip) was added via the HTTP API, the fileMap was built with only GAME nodes. findOrCreateFile could not find the existing subfolder causing the game to appear in the root folder instead of the correct subdirectory.