### PR TITLE
add-mitigations-toggle

### DIFF
--- a/es-app/src/ApiSystem.cpp
+++ b/es-app/src/ApiSystem.cpp
@@ -230,6 +230,23 @@ bool ApiSystem::setOverclock(std::string mode)
 	return executeScript("batocera-overclock set " + mode);
 }
 
+#ifdef BATOCERA
+bool ApiSystem::areCpuMitigationsEnabled()
+{
+	auto result = executeScript("batocera-mitigations status", nullptr);
+
+	if (result.second != 0)
+		return true;
+
+	return Utils::String::trim(result.first) != "0";
+}
+
+bool ApiSystem::setCpuMitigationsEnabled(bool enabled)
+{
+	return executeScript(std::string("batocera-mitigations ") + (enabled ? "on" : "off"));
+}
+#endif
+
 // BusyComponent* ui
 std::pair<std::string, int> ApiSystem::updateSystem(const std::function<void(const std::string)>& func, bool fromlocalmedia)
 {

--- a/es-app/src/ApiSystem.h
+++ b/es-app/src/ApiSystem.h
@@ -197,6 +197,11 @@ public:
 
     bool setOverclock(std::string mode);
 
+#ifdef BATOCERA
+    bool areCpuMitigationsEnabled();
+    bool setCpuMitigationsEnabled(bool enabled);
+#endif
+
     virtual std::pair<std::string, int> updateSystem(const std::function<void(const std::string)>& func = nullptr, bool fromlocalmedia = false);
 
     std::pair<std::string, int> backupSystem(BusyComponent* ui, std::string device);

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -2139,7 +2139,16 @@ void GuiMenu::openSystemSettings()
 		auto rootpassword = std::make_shared<TextComponent>(mWindow, ApiSystem::getInstance()->getRootPassword(), ThemeData::getMenuTheme()->Text.font, ThemeData::getMenuTheme()->Text.color);
 		securityGui->addWithLabel(_("ROOT PASSWORD"), rootpassword);
 
-		securityGui->addSaveFunc([this, securityEnabled, s] 
+#ifdef BATOCERA
+		auto cpuMitigations = std::make_shared<SwitchComponent>(mWindow);
+		cpuMitigations->setState(ApiSystem::getInstance()->areCpuMitigationsEnabled());
+		securityGui->addWithDescription(
+			_("CPU SECURITY MITIGATIONS"),
+			_("Disabling mitigations may improve performance on some systems at the cost of reduced protection against certain CPU vulnerabilities."),
+			cpuMitigations);
+#endif
+
+		securityGui->addSaveFunc([this, securityEnabled, s]
 		{
 			Window* window = this->mWindow;
 
@@ -2150,6 +2159,18 @@ void GuiMenu::openSystemSettings()
 				s->setVariable("reboot", true);				
 			}
 		});
+
+#ifdef BATOCERA
+		securityGui->addSaveFunc([cpuMitigations, s]
+		{
+			if (cpuMitigations->changed())
+			{
+				if (ApiSystem::getInstance()->setCpuMitigationsEnabled(cpuMitigations->getState()))
+					s->setVariable("reboot", true);
+			}
+		});
+#endif
+
 		mWindow->pushGui(securityGui);
 	});
 #else


### PR DESCRIPTION
Adds a new switch under security for batocera  to set mitigations to on/off. (batocera-mitigations)

https://github.com/batocera-linux/batocera.linux/pull/15787

uses batocera-mitigations status(returns 1/0) to determine if toggle is enabled/disabled.


@fabricecaruso let me know if I missed anything or if looks good.
