### PR TITLE
Fix Bezel (decorations menu)

### DIFF
--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4582,7 +4582,7 @@ void GuiMenu::createDecorationItemTemplate(Window* window, std::vector<Decoratio
 
 	// spacer between icon and text
 	auto spacer = std::make_shared<GuiComponent>(window);
-	spacer->setSize(IMGPADDING, 0);
+	spacer->setSize(IMGPADDING, maxSize.y());
 	row.addElement(spacer, false);
 
 	std::string label = data;


### PR DESCRIPTION
Image is loaded with setImage(imageUrl, false, maxSize), when positionning cursor, ImageComponent not yet loaded have a reduced height, when textures finally arrive, it creates a resizing but mSelectorBarOffset is never recalculated.

The fix here is to create all lines with maxsize, there might be a better fix (dynamic recalculation) but i don't want to touch a component used in all menus.