### PR TITLE
Add LED support for R36 Ultra

### DIFF
--- a/es-app/src/ApiSystem.cpp
+++ b/es-app/src/ApiSystem.cpp
@@ -716,6 +716,33 @@ bool ApiSystem::setPowerLedGameForce(std::string selected)
 	return executeScript("batocera-gameforce powerLed " + selected);
 }
 
+bool ApiSystem::setButtonColorR36Ultra(const std::string& selected)
+{
+	std::map<std::string, std::string> r36UltraModeMap = {
+		{"off", "0 0 0"},
+		{"red", "255 0 0"},
+		{"yellow", "255 255 0"},
+		{"green", "0 255 0"},
+		{"cyan", "0 255 255"},
+		{"blue", "0 0 255"},
+		{"purple", "255 0 255"},
+		{"white", "255 255 255"}
+	};
+	SystemConf::getInstance()->set("led.colour", r36UltraModeMap[selected]);
+	SystemConf::getInstance()->saveSystemConf();
+	return true;
+}
+
+bool ApiSystem::setPowerLedR36(const std::string& selected)
+{
+	if(selected == "off") {
+		Utils::FileSystem::writeAllText("/sys/class/leds/blue:power/brightness", "0");
+		return true;
+	}
+	Utils::FileSystem::writeAllText("/sys/class/leds/blue:power/brightness", "1");
+	return true;
+}
+
 bool ApiSystem::forgetBluetoothControllers() 
 {
 	return executeScript("batocera-config forgetBT");

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -1871,6 +1871,40 @@ void GuiMenu::openSystemSettings()
 	});
 #endif
 
+#if RK3326
+	if (Utils::FileSystem::exists("/sys/class/leds/keros::ambient")) {
+		auto buttonColor_r36ultra = std::make_shared< OptionListComponent<std::string> >(mWindow, _("BUTTON LED COLOR"));
+		buttonColor_r36ultra->add(_("off"), "off", SystemConf::getInstance()->get("color_rgb") == "off" || SystemConf::getInstance()->get("color_rgb") == "");
+		buttonColor_r36ultra->add(_("red"), "red", SystemConf::getInstance()->get("color_rgb") == "red");
+		buttonColor_r36ultra->add(_("yellow"), "yellow", SystemConf::getInstance()->get("color_rgb") == "yellow");
+		buttonColor_r36ultra->add(_("green"), "green", SystemConf::getInstance()->get("color_rgb") == "green");
+		buttonColor_r36ultra->add(_("cyan"), "cyan", SystemConf::getInstance()->get("color_rgb") == "cyan");
+		buttonColor_r36ultra->add(_("blue"), "blue", SystemConf::getInstance()->get("color_rgb") == "blue");
+		buttonColor_r36ultra->add(_("purple"), "purple", SystemConf::getInstance()->get("color_rgb") == "purple");
+		buttonColor_r36ultra->add(_("white"), "white", SystemConf::getInstance()->get("color_rgb") == "white");		
+		s->addWithLabel(_("BUTTON LED COLOR"), buttonColor_r36ultra);
+		s->addSaveFunc([buttonColor_r36ultra] 
+		{
+			if (buttonColor_r36ultra->changed()) {
+				ApiSystem::getInstance()->setButtonColorR36Ultra(buttonColor_r36ultra->getSelected());
+				SystemConf::getInstance()->set("color_rgb", buttonColor_r36ultra->getSelected());
+			}
+		});
+	}
+
+	auto powerled_r36 = std::make_shared< OptionListComponent<std::string> >(mWindow, _("POWER LED COLOR"));
+	powerled_r36->add(_("on"), "on", SystemConf::getInstance()->get("option_powerled") == "on" || SystemConf::getInstance()->get("option_powerled") == "");
+	powerled_r36->add(_("off"), "off", SystemConf::getInstance()->get("option_powerled") == "off");
+	s->addWithLabel(_("POWER LED COLOR"), powerled_r36);
+	s->addSaveFunc([powerled_r36]
+	{
+		if (powerled_r36->changed()) {
+			ApiSystem::getInstance()->setPowerLedR36(powerled_r36->getSelected());
+			SystemConf::getInstance()->set("option_powerled", powerled_r36->getSelected());
+		}
+	});
+#endif
+
 	// Overclock choice
 	if (ApiSystem::getInstance()->isScriptingSupported(ApiSystem::OVERCLOCK))
 	{

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -1838,7 +1838,7 @@ void GuiMenu::openSystemSettings()
 	});
 #endif
 
-#if GAMEFORCE || RK3326
+#if GAMEFORCE
 	auto buttonColor_GameForce = std::make_shared< OptionListComponent<std::string> >(mWindow, _("BUTTON LED COLOR"));
 	buttonColor_GameForce->add(_("off"), "off", SystemConf::getInstance()->get("color_rgb") == "off" || SystemConf::getInstance()->get("color_rgb") == "");
 	buttonColor_GameForce->add(_("red"), "red", SystemConf::getInstance()->get("color_rgb") == "red");


### PR DESCRIPTION
Title says all.

As explained in the commits, user can change the LED colours and power LED on/off via the settings menu.

Should the user want the pulse or rainbow effects, they should change the leds.conf from the batocera-led-handheld script