### PR TITLE
Fix frontend frame pacing when VSync does not throttle

### DIFF
--- a/es-app/src/main.cpp
+++ b/es-app/src/main.cpp
@@ -20,6 +20,7 @@
 #include <SDL_events.h>
 #include <SDL_main.h>
 #include <SDL_timer.h>
+#include <SDL_video.h>
 #include <iostream>
 #include <time.h>
 #include "LocaleES.h"
@@ -352,6 +353,62 @@ void signalHandler(int signum)
 	exit(signum);
 }
 
+static int getDisplayRefreshRate()
+{
+	int displayIndex = -1;
+
+	SDL_Window* window = Renderer::getSDLWindow();
+	if (window != nullptr)
+		displayIndex = SDL_GetWindowDisplayIndex(window);
+
+	if (displayIndex < 0)
+		displayIndex = Settings::getInstance()->getInt("MonitorID");
+
+	if (displayIndex < 0)
+		displayIndex = 0;
+
+	SDL_DisplayMode displayMode;
+	if (SDL_GetCurrentDisplayMode(displayIndex, &displayMode) == 0 && displayMode.refresh_rate > 0)
+		return displayMode.refresh_rate;
+
+#ifdef WIN32
+	DEVMODE lpDevMode;
+	memset(&lpDevMode, 0, sizeof(DEVMODE));
+	lpDevMode.dmSize = sizeof(DEVMODE);
+	lpDevMode.dmFields = DM_BITSPERPEL | DM_PELSWIDTH | DM_PELSHEIGHT | DM_DISPLAYFLAGS | DM_DISPLAYFREQUENCY;
+	lpDevMode.dmDriverExtra = 0;
+
+	if (EnumDisplaySettings(NULL, ENUM_CURRENT_SETTINGS, &lpDevMode) != 0 && lpDevMode.dmDisplayFrequency > 0)
+		return lpDevMode.dmDisplayFrequency;
+#endif
+
+	return 60;
+}
+
+static int getEffectiveFpsLimit(int automaticVSyncFpsLimit)
+{
+	int fpsLimit = Settings::FpsLimit();
+	if (fpsLimit > 0 || !Settings::VSync())
+		return fpsLimit;
+
+	return automaticVSyncFpsLimit > 0 ? automaticVSyncFpsLimit : 60;
+}
+
+static void limitFrameRate(int frameStartTime, int fpsLimit)
+{
+	if (fpsLimit <= 0)
+		return;
+
+	int frameTime = (1000 + fpsLimit / 2) / fpsLimit;
+	int frameDuration = SDL_GetTicks() - frameStartTime;
+	if (frameDuration < frameTime)
+	{
+		int timeToWait = frameTime - frameDuration;
+		if (timeToWait > 0 && timeToWait < 100)
+			SDL_Delay(timeToWait);
+	}
+}
+
 void playVideo()
 {
 	ApiSystem::getInstance()->setReadyFlag(false);
@@ -387,6 +444,7 @@ void playVideo()
 
 	int lastTime = SDL_GetTicks();
 	int totalTime = 0;
+	int automaticVSyncFpsLimit = getDisplayRefreshRate();
 
 	while (!exitLoop)
 	{
@@ -418,6 +476,7 @@ void playVideo()
 		vid.render(transform);
 
 		Renderer::swapBuffers();
+		limitFrameRate(curTime, getEffectiveFpsLimit(automaticVSyncFpsLimit));
 
 		if (ApiSystem::getInstance()->isReadyFlagSet())
 			break;
@@ -642,28 +701,12 @@ int main(int argc, char* argv[])
 		AudioManager::getInstance()->playRandomMusic();
 
 
-#ifdef WIN32	
-	DWORD displayFrequency = 60;
-
-	DEVMODE lpDevMode;
-	memset(&lpDevMode, 0, sizeof(DEVMODE));
-	lpDevMode.dmSize = sizeof(DEVMODE);
-	lpDevMode.dmFields = DM_BITSPERPEL | DM_PELSWIDTH | DM_PELSHEIGHT | DM_DISPLAYFLAGS | DM_DISPLAYFREQUENCY;
-	lpDevMode.dmDriverExtra = 0;
-
-	if (EnumDisplaySettings(NULL, ENUM_CURRENT_SETTINGS, &lpDevMode) != 0) {
-		displayFrequency = lpDevMode.dmDisplayFrequency; // default value if cannot retrieve from user settings.
-	}
-
-	int timeLimit = (1000 / displayFrequency) - 10;	 // Margin for vsync
-	if (timeLimit < 0)
-		timeLimit = 0;
-#endif
-
 	Renderer::setWindowResizable(true);
 
 	int lastTime = SDL_GetTicks();
 	int ps_time = SDL_GetTicks();
+	int automaticVSyncFpsLimit = getDisplayRefreshRate();
+	LOG(LogInfo) << "Detected display refresh rate for automatic VSync frame pacing: " << automaticVSyncFpsLimit << " fps";
 
 	bool running = true;
 
@@ -786,20 +829,8 @@ int main(int argc, char* argv[])
 		TRYCATCH("Window.update" ,window.update(deltaTime))	
 		TRYCATCH("Window.render", window.render())
 
-		int fpsLimit = Settings::FpsLimit();
-		if (fpsLimit > 0)
-		{
-			int frameTime = (1000 + fpsLimit / 2) / fpsLimit;
-			int processDuration = SDL_GetTicks() - curTime;
-			if (processDuration < frameTime)
-			{
-				int timeToWait = frameTime - processDuration;
-				if (timeToWait > 0 && timeToWait < 100)
-					SDL_Delay(timeToWait);
-			}
-		}
-
-		Renderer::swapBuffers();		
+		Renderer::swapBuffers();
+		limitFrameRate(curTime, getEffectiveFpsLimit(automaticVSyncFpsLimit));
 	}
 
 	if (Utils::Platform::isFastShutdown())
@@ -842,4 +873,3 @@ int main(int argc, char* argv[])
 
 	return 0;
 }
-


### PR DESCRIPTION
## Summary

- add automatic frontend frame pacing when VSync is enabled but no explicit FPS limit is configured
- base the automatic limit on the active SDL display refresh rate, with the existing Windows display-frequency fallback and a 60 FPS final fallback
- run frame limiting after buffer swap so working VSync is not double-throttled

## Why

On some virtual-display streaming setups, such as Apollo/Moonlight, the GL swap interval can fail to provide practical throttling even when VSync is enabled. The frontend then renders as fast as possible, which can cause visible flicker unless users configure an external frame limiter or manually set an FPS limit.

This keeps explicit FPS limit settings authoritative, but makes the default VSync path behave like users expect: if swap does not block, the frontend still paces itself to the display refresh rate.

## Validation

- `git diff --check HEAD~1..HEAD`
- `cmake -S . -B build` was attempted, but this WSL environment is missing the FreeImage development package and `sudo` requires a password, so the full configure/build could not be completed here.
