### PR TITLE
Fix to enable filtering based on year

### DIFF
--- a/es-app/src/FileFilterIndex.cpp
+++ b/es-app/src/FileFilterIndex.cpp
@@ -362,9 +362,11 @@ std::string FileFilterIndex::getIndexableKey(FileData* game, FilterIndexType typ
 		return Utils::String::toInteger(game->getMetadata(MetaDataId::PlayCount)) == 0 ? "FALSE" : "TRUE";		
 
 	case YEAR_FILTER:
+	{
 		key = game->getMetadata(MetaDataId::ReleaseDate);
 		key = (key.length() >= 4 && key[0] >= '1' && key[0] <= '2') ? key.substr(0, 4) : "";
-		return key;
+		break;
+	}
 
 	case CHEEVOS_FILTER:
 	{


### PR DESCRIPTION
Fix was found with Claude CLI, but seems like filtering based on year has been broken since a change in 2021. 
Previously you get an empty picker list when selecting the year category, now you get the real list.
Tested by building it into batocera.

<img width="640" height="480" alt="IMG_3618" src="https://github.com/user-attachments/assets/ba032d7a-173a-417e-9f64-a3f03e874f3f" />
<img width="640" height="480" alt="IMG_3619" src="https://github.com/user-attachments/assets/b8d7e96c-4cec-478b-a6bd-8e09e4996595" />
