### PR TITLE
Declare Per-Monitor-V2 DPI awareness at startup on Windows

### DIFF
--- a/es-app/src/main.cpp
+++ b/es-app/src/main.cpp
@@ -49,64 +49,6 @@
 #include <Windows.h>
 #include <direct.h>
 #define PATH_MAX MAX_PATH
-
-// Declared locally (instead of pulled from ShellScalingApi.h / a newer
-// winuser.h) so this builds regardless of which Windows SDK version ES is
-// compiled against; on older SDKs the constant/type simply doesn't exist yet.
-#ifndef DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2
-DECLARE_HANDLE(DPI_AWARENESS_CONTEXT);
-#define DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2 ((DPI_AWARENESS_CONTEXT)-4)
-#endif
-
-typedef BOOL(WINAPI* SetProcessDpiAwarenessContext_t)(DPI_AWARENESS_CONTEXT);
-typedef HRESULT(WINAPI* SetProcessDpiAwareness_t)(int);
-typedef BOOL(WINAPI* SetProcessDPIAware_t)();
-
-// Marks the process Per-Monitor-V2 DPI aware so Windows stops bitmap-
-// stretching our output on displays scaled above 100% (e.g. 4K @ 150%).
-// Without this, ES is treated as DPI-unaware, gets handed a virtualized
-// logical resolution, and users have to manually enable the "Override high
-// DPI scaling" compatibility option for fullscreen/video sizing to be correct.
-// Resolved dynamically (rather than via an app manifest or direct linking) so
-// the same binary degrades gracefully on Windows 8.1/7, where PMv2 and even
-// PROCESS_PER_MONITOR_DPI_AWARE don't exist.
-static void setDpiAwareness()
-{
-	HMODULE user32 = LoadLibraryA("user32.dll");
-	if (user32 != NULL)
-	{
-		auto setContext = (SetProcessDpiAwarenessContext_t)GetProcAddress(user32, "SetProcessDpiAwarenessContext");
-		if (setContext != NULL && setContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2))
-		{
-			FreeLibrary(user32);
-			return;
-		}
-	}
-
-	HMODULE shcore = LoadLibraryA("Shcore.dll");
-	if (shcore != NULL)
-	{
-		auto setAwareness = (SetProcessDpiAwareness_t)GetProcAddress(shcore, "SetProcessDpiAwareness");
-		if (setAwareness != NULL && SUCCEEDED(setAwareness(2 /* PROCESS_PER_MONITOR_DPI_AWARE */)))
-		{
-			FreeLibrary(shcore);
-			if (user32 != NULL)
-				FreeLibrary(user32);
-			return;
-		}
-
-		FreeLibrary(shcore);
-	}
-
-	if (user32 != NULL)
-	{
-		auto setAware = (SetProcessDPIAware_t)GetProcAddress(user32, "SetProcessDPIAware");
-		if (setAware != NULL)
-			setAware();
-
-		FreeLibrary(user32);
-	}
-}
 #endif
 
 static std::string gPlayVideo;
@@ -507,7 +449,7 @@ int main(int argc, char* argv[])
 
 #ifdef WIN32
 	// Must run before any window/message-queue APIs are touched.
-	setDpiAwareness();
+	Utils::Platform::setDpiAwareness();
 #endif
 
 	// signal(SIGABRT, signalHandler);

--- a/es-app/src/main.cpp
+++ b/es-app/src/main.cpp
@@ -49,6 +49,64 @@
 #include <Windows.h>
 #include <direct.h>
 #define PATH_MAX MAX_PATH
+
+// Declared locally (instead of pulled from ShellScalingApi.h / a newer
+// winuser.h) so this builds regardless of which Windows SDK version ES is
+// compiled against; on older SDKs the constant/type simply doesn't exist yet.
+#ifndef DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2
+DECLARE_HANDLE(DPI_AWARENESS_CONTEXT);
+#define DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2 ((DPI_AWARENESS_CONTEXT)-4)
+#endif
+
+typedef BOOL(WINAPI* SetProcessDpiAwarenessContext_t)(DPI_AWARENESS_CONTEXT);
+typedef HRESULT(WINAPI* SetProcessDpiAwareness_t)(int);
+typedef BOOL(WINAPI* SetProcessDPIAware_t)();
+
+// Marks the process Per-Monitor-V2 DPI aware so Windows stops bitmap-
+// stretching our output on displays scaled above 100% (e.g. 4K @ 150%).
+// Without this, ES is treated as DPI-unaware, gets handed a virtualized
+// logical resolution, and users have to manually enable the "Override high
+// DPI scaling" compatibility option for fullscreen/video sizing to be correct.
+// Resolved dynamically (rather than via an app manifest or direct linking) so
+// the same binary degrades gracefully on Windows 8.1/7, where PMv2 and even
+// PROCESS_PER_MONITOR_DPI_AWARE don't exist.
+static void setDpiAwareness()
+{
+	HMODULE user32 = LoadLibraryA("user32.dll");
+	if (user32 != NULL)
+	{
+		auto setContext = (SetProcessDpiAwarenessContext_t)GetProcAddress(user32, "SetProcessDpiAwarenessContext");
+		if (setContext != NULL && setContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2))
+		{
+			FreeLibrary(user32);
+			return;
+		}
+	}
+
+	HMODULE shcore = LoadLibraryA("Shcore.dll");
+	if (shcore != NULL)
+	{
+		auto setAwareness = (SetProcessDpiAwareness_t)GetProcAddress(shcore, "SetProcessDpiAwareness");
+		if (setAwareness != NULL && SUCCEEDED(setAwareness(2 /* PROCESS_PER_MONITOR_DPI_AWARE */)))
+		{
+			FreeLibrary(shcore);
+			if (user32 != NULL)
+				FreeLibrary(user32);
+			return;
+		}
+
+		FreeLibrary(shcore);
+	}
+
+	if (user32 != NULL)
+	{
+		auto setAware = (SetProcessDPIAware_t)GetProcAddress(user32, "SetProcessDPIAware");
+		if (setAware != NULL)
+			setAware();
+
+		FreeLibrary(user32);
+	}
+}
 #endif
 
 static std::string gPlayVideo;
@@ -444,8 +502,13 @@ void launchStartupGame()
 // #include "utils/MathExpr.h"
 
 int main(int argc, char* argv[])
-{	
+{
 	// Utils::MathExpr::performUnitTests();
+
+#ifdef WIN32
+	// Must run before any window/message-queue APIs are touched.
+	setDpiAwareness();
+#endif
 
 	// signal(SIGABRT, signalHandler);
 	signal(SIGFPE, signalHandler);

--- a/es-core/src/utils/Platform.cpp
+++ b/es-core/src/utils/Platform.cpp
@@ -598,8 +598,66 @@ namespace Utils
 
 			return result;
 		}
+
+		// Declared locally (instead of pulled from ShellScalingApi.h / a newer
+		// winuser.h) so this builds regardless of which Windows SDK version ES is
+		// compiled against; on older SDKs the constant/type simply doesn't exist yet.
+#ifndef DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2
+		DECLARE_HANDLE(DPI_AWARENESS_CONTEXT);
+#define DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2 ((DPI_AWARENESS_CONTEXT)-4)
+#endif
+
+		typedef BOOL(WINAPI* SetProcessDpiAwarenessContext_t)(DPI_AWARENESS_CONTEXT);
+		typedef HRESULT(WINAPI* SetProcessDpiAwareness_t)(int);
+		typedef BOOL(WINAPI* SetProcessDPIAware_t)();
+
+		// Marks the process Per-Monitor-V2 DPI aware so Windows stops bitmap-
+		// stretching our output on displays scaled above 100% (e.g. 4K @ 150%).
+		// Without this, ES is treated as DPI-unaware, gets handed a virtualized
+		// logical resolution, and users have to manually enable the "Override high
+		// DPI scaling" compatibility option for fullscreen/video sizing to be correct.
+		// Resolved dynamically (rather than via an app manifest or direct linking) so
+		// the same binary degrades gracefully on Windows 8.1/7, where PMv2 and even
+		// PROCESS_PER_MONITOR_DPI_AWARE don't exist.
+		void setDpiAwareness()
+		{
+			HMODULE user32 = LoadLibraryA("user32.dll");
+			if (user32 != NULL)
+			{
+				auto setContext = (SetProcessDpiAwarenessContext_t)GetProcAddress(user32, "SetProcessDpiAwarenessContext");
+				if (setContext != NULL && setContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2))
+				{
+					FreeLibrary(user32);
+					return;
+				}
+			}
+
+			HMODULE shcore = LoadLibraryA("Shcore.dll");
+			if (shcore != NULL)
+			{
+				auto setAwareness = (SetProcessDpiAwareness_t)GetProcAddress(shcore, "SetProcessDpiAwareness");
+				if (setAwareness != NULL && SUCCEEDED(setAwareness(2 /* PROCESS_PER_MONITOR_DPI_AWARE */)))
+				{
+					FreeLibrary(shcore);
+					if (user32 != NULL)
+						FreeLibrary(user32);
+					return;
+				}
+
+				FreeLibrary(shcore);
+			}
+
+			if (user32 != NULL)
+			{
+				auto setAware = (SetProcessDPIAware_t)GetProcAddress(user32, "SetProcessDPIAware");
+				if (setAware != NULL)
+					setAware();
+
+				FreeLibrary(user32);
+			}
+		}
 #else
-		bool isBuildroot() 
+		bool isBuildroot()
 		{
 			static const bool cached = []() 
 			{

--- a/es-core/src/utils/Platform.h
+++ b/es-core/src/utils/Platform.h
@@ -71,7 +71,8 @@ namespace Utils
 
 #if WIN32
 		bool isWindows10();
-		bool isWindows11();		
+		bool isWindows11();
+		void setDpiAwareness();
 #else
 		bool isBuildroot();
 #endif


### PR DESCRIPTION
## Summary
- On Windows, ES has never declared DPI awareness (no manifest, no `SetProcessDpiAwareness*`/`SetProcessDPIAware` call anywhere in the codebase). On displays scaled above 100% (e.g. 4K @ 125%/150%), Windows therefore treats the process as DPI-unaware: it hands ES a virtualized logical resolution and bitmap-stretches the rendered output back up, causing blur and fullscreen/window-sizing issues. Today the only workaround is manually enabling "Override high DPI scaling" in the exe's Compatibility settings.
- `SDL_WINDOW_ALLOW_HIGHDPI` is already set on the window (`Renderer.cpp`), but it has no effect without process-level DPI awareness declared first.
- This declares the process Per-Monitor-V2 DPI aware as the first thing in `main()`, before SDL/window init, so the manual override is no longer needed.
- Resolves `SetProcessDpiAwarenessContext` → `SetProcessDpiAwareness` → `SetProcessDPIAware` dynamically via `GetProcAddress`, falling back through progressively older APIs, so the same binary keeps working on older Windows versions where the newer entry points don't exist, without needing an OS-version-gated manifest.
- Entire change is wrapped in the existing `#ifdef WIN32` block (same one guarding `#include <Windows.h>`); no effect on Linux/other platform builds.

## Test plan
- [ ] On Windows with display scaling set above 100% (e.g. 4K @ 150%), remove any manual DPI compatibility override on the exe, launch ES, and confirm it renders fullscreen at native resolution without blur.
- [ ] Confirm behavior is unchanged at 100% scaling.
- [ ] Confirm Linux build is unaffected (change is fully inside `#ifdef WIN32`).