### PR TITLE
Fix MD5 hashing for .cue/.ccd/.gdi games in ScreenScraper scraper

### DIFF
--- a/es-app/src/scrapers/ScreenScraper.cpp
+++ b/es-app/src/scrapers/ScreenScraper.cpp
@@ -273,7 +273,7 @@ void ScreenScraperScraper::generateRequests(const ScraperSearchParams& params,
 		}
 		else
 		{
-			if (params.game->hasContentFiles() && Utils::String::toLower(Utils::FileSystem::getExtension(fileNameToHash)) == ".m3u")
+			if (params.game->hasContentFiles())
 			{
 				auto content = params.game->getContentFiles();
 				if (content.size())


### PR DESCRIPTION
## Summary

`FileData::hasContentFiles()` recognizes `.m3u`, `.cue`, `.ccd`, and `.gdi` as multi-file disc formats and knows how to resolve each to its real underlying content file(s) via `getContentFiles()`. However, in `ScreenScraperScraper::generateRequests()`, the redirect to that real content file for MD5 hashing was additionally gated on the extension being exactly `.m3u`:

```cpp
if (params.game->hasContentFiles() && Utils::String::toLower(Utils::FileSystem::getExtension(fileNameToHash)) == ".m3u")
```

For `.cue`/`.ccd`/`.gdi`-based games (e.g. Dreamcast `.cue`/`.gdi` rips, PS1/Saturn `.cue`, Sega CD `.ccd`), this condition is never true, so the code falls through and computes an MD5 of the small cue-sheet/index file itself rather than the actual disc image data. That hash can never match ScreenScraper's database (which hashes real track/disc data), so the scraper can't use it to pin down the exact release — it falls back to a fuzzy name-only match, which can land on a different database entry for the same title (e.g. one with incomplete media coverage) instead of the correct/most complete one.

## Fix

Drop the redundant extension check and rely on `hasContentFiles()` alone (which already restricts itself to the four supported formats and validates the extension against the system's config):

```cpp
if (params.game->hasContentFiles())
```

This lets `.cue`/`.ccd`/`.gdi` games redirect to their real content file for hashing, the same way `.m3u` already does.

## Testing

I don't have a local build environment set up to compile and run this, so this hasn't been tested against a live scrape yet. The change is a minimal, low-risk removal of an overly-narrow condition — happy to have a maintainer or another contributor verify against an actual Dreamcast/PS1 `.cue` scrape before merging. Opening as a draft for that reason.