### PR TITLE
Fix game install from store when using cache

### DIFF
--- a/es-app/src/Win32ApiSystem.cpp
+++ b/es-app/src/Win32ApiSystem.cpp
@@ -225,7 +225,7 @@ int Win32ApiSystem::executeCMD(const char* lpCommandLine, std::string& output, c
 			//spawn the child process
 			std::wstring commandLineW = Utils::String::convertToWideString(lpCommandLine);
 			std::wstring directory = lpCurrentDirectory == NULL ? L"" : Utils::String::convertToWideString(lpCurrentDirectory);
-			if (CreateProcessW(NULL, (LPWSTR)commandLineW.c_str(), NULL, NULL, TRUE, CREATE_NEW_CONSOLE, NULL, lpCurrentDirectory == NULL ? NULL : (LPWSTR)directory.c_str(), &si, &pi))
+			if (CreateProcessW(NULL, (LPWSTR)commandLineW.c_str(), NULL, NULL, TRUE, CREATE_NO_WINDOW, NULL, lpCurrentDirectory == NULL ? NULL : (LPWSTR)directory.c_str(), &si, &pi))
 			{
 				if (m_hJob != nullptr)
 					AssignProcessToJobObject(m_hJob, pi.hProcess);

--- a/es-app/src/services/HttpServerThread.cpp
+++ b/es-app/src/services/HttpServerThread.cpp
@@ -645,6 +645,8 @@ void HttpServerThread::run()
 
 			deleteSystem = true;
 		}
+
+		Utils::FileSystem::FileSystemCache::reset();
 			
 		std::unordered_map<std::string, FileData*> fileMap;
 		fileMap[system->getRootFolder()->getPath()] = system->getRootFolder();


### PR DESCRIPTION
Without resetting the cache, the game is not entered in gamelist.xml as it does not detect the extracted game.
Also, fixing the focus lost on windows when opening the store (batocera-store.exe).

@fabricecaruso  @lbrpdx  @dmanlfc  ==> Can you merge this ?