### PR TITLE
Windows: enumerate video modes on the selected monitor

### DIFF
--- a/es-app/src/Win32ApiSystem.cpp
+++ b/es-app/src/Win32ApiSystem.cpp
@@ -889,7 +889,7 @@ void Win32ApiSystem::updateEmulatorLauncher(const std::function<void(const std::
 bool Win32ApiSystem::canUpdate(std::vector<std::string>& output)
 {
 	// Update using 'es-checkversion.cmd' scripts ?
-	std::string esUpdateScript = getScriptPath("es-checkversion");
+	std::string esUpdateScript = getScriptPath("es-update");
 	if (!esUpdateScript.empty())
 	{
 		std::string esUpdateDirectory = Utils::FileSystem::getPreferredPath(Utils::FileSystem::getParent(esUpdateScript));
@@ -976,14 +976,43 @@ bool Win32ApiSystem::isReadyFlagSet()
 	return Utils::FileSystem::exists(Paths::getUserEmulationStationPath() + "/tmp/emulationstation.ready");
 }
 
+static std::string getWindowsDisplayDeviceName(int monitorId)
+{
+	if (monitorId < 0 || monitorId >= SDL_GetNumVideoDisplays())
+		return "";
+
+	SDL_Rect bounds;
+	if (SDL_GetDisplayBounds(monitorId, &bounds) != 0)
+		return "";
+
+	POINT point = { bounds.x + bounds.w / 2, bounds.y + bounds.h / 2 };
+	HMONITOR monitor = MonitorFromPoint(point, MONITOR_DEFAULTTONULL);
+	if (monitor == nullptr)
+		return "";
+
+	MONITORINFOEXA monitorInfo = {};
+	monitorInfo.cbSize = sizeof(monitorInfo);
+	if (!GetMonitorInfoA(monitor, &monitorInfo))
+		return "";
+
+	return monitorInfo.szDevice;
+}
+
 std::vector<std::string> Win32ApiSystem::getVideoModes(const std::string output)
 {
 	std::vector<std::string> ret;
 
-	DEVMODE vDevMode;
+	std::string displayDevice = output;
+	if (displayDevice.empty() || displayDevice == "auto" || displayDevice == "none")
+		displayDevice = getWindowsDisplayDeviceName(Settings::getInstance()->getInt("MonitorID"));
+
+	const char* deviceName = displayDevice.empty() ? nullptr : displayDevice.c_str();
+
+	DEVMODEA vDevMode = {};
+	vDevMode.dmSize = sizeof(vDevMode);
 
 	int i = 0;
-	while (EnumDisplaySettings(nullptr, i, &vDevMode))
+	while (EnumDisplaySettingsA(deviceName, i, &vDevMode))
 	{
 		if (vDevMode.dmDisplayFixedOutput == 0)
 		{			
@@ -1014,6 +1043,8 @@ std::vector<std::string> Win32ApiSystem::getVideoModes(const std::string output)
 		}
 
 		i++;
+		vDevMode = {};
+		vDevMode.dmSize = sizeof(vDevMode);
 	}
 
 	return ret;
@@ -1170,5 +1201,4 @@ bool Win32ApiSystem::forgetBluetoothControllers()
 }
 
 #endif
-
 

--- a/es-app/src/Win32ApiSystem.cpp
+++ b/es-app/src/Win32ApiSystem.cpp
@@ -889,7 +889,7 @@ void Win32ApiSystem::updateEmulatorLauncher(const std::function<void(const std::
 bool Win32ApiSystem::canUpdate(std::vector<std::string>& output)
 {
 	// Update using 'es-checkversion.cmd' scripts ?
-	std::string esUpdateScript = getScriptPath("es-update");
+	std::string esUpdateScript = getScriptPath("es-checkversion");
 	if (!esUpdateScript.empty())
 	{
 		std::string esUpdateDirectory = Utils::FileSystem::getPreferredPath(Utils::FileSystem::getParent(esUpdateScript));
@@ -1201,4 +1201,5 @@ bool Win32ApiSystem::forgetBluetoothControllers()
 }
 
 #endif
+
 


### PR DESCRIPTION
I hit this while testing a CRT as a secondary screen on Windows.

The CRT has a custom 640x400 @ 70 Hz mode made with CRU. Windows and RetroArch can use it, but ES does not show it in Advanced Video Resolution. If I make the CRT the primary screen, the 70 Hz mode appears immediately.

Looking at the Windows code, getVideoModes(output) receives an output but EnumDisplaySettings(nullptr, ...) always enumerates the default display.

This PR makes the Win32 code ask Windows for the modes of the correct screen:

use the explicit output when one is provided
otherwise resolve ES MonitorID from the SDL display to the Windows \\.\DISPLAYx device
keep the existing mode list and refresh-rate handling unchanged

There is no hardcoded 70 Hz list here: refresh rates still come directly from dmDisplayFrequency. The problem is mainly that ES was asking Windows for the modes of the wrong screen.

My setup that exposed it:

Windows 11
RTX 3070 + Intel UHD 770
CRT on a secondary output
custom resolutions with CRU
640x400 @ 70 Hz

Before: 70 Hz only appears in ES when the CRT is set as the primary screen.

Expected with this change: ES can enumerate the modes of the selected secondary monitor without having to change the Windows primary display.

I kept the change intentionally limited to the Win32 video-mode enumeration path.