### PR TITLE
faster-game-launch

### DIFF
--- a/es-app/src/FileData.cpp
+++ b/es-app/src/FileData.cpp
@@ -38,6 +38,10 @@
 
 using namespace Utils::Platform;
 
+#ifndef WIN32
+static const char* GAME_LAUNCH_WAIT_FILE = "/tmp/es-gamelaunch.wait";
+#endif
+
 static std::map<std::string, std::function<BindableProperty(FileData*)>> properties =
 {
 	{ "name",				[](FileData* file) { return file->getName(); } },
@@ -688,6 +692,72 @@ std::string FileData::getMessageFromExitCode(int exitCode)
 	return _("UKNOWN ERROR") + " : " + std::to_string(exitCode);
 }
 
+bool FileData::prepareLaunchGame(LaunchGameOptions& options)
+{
+#ifdef WIN32
+	return false;
+#else
+	if (mPreparedLaunchFuture.valid())
+		return true;
+
+	FileData* gameToUpdate = getSourceFileData();
+	if (gameToUpdate == nullptr || gameToUpdate->getSystem() == nullptr)
+		return false;
+
+	std::string command = getlaunchCommand(options);
+	if (command.empty())
+		return false;
+
+	mPreparedLaunchP2k = convertP2kFile();
+
+	// emulatorlauncher.py will wait for removal of wait file
+	Utils::FileSystem::removeFile(GAME_LAUNCH_WAIT_FILE);
+	Utils::FileSystem::writeAllText(GAME_LAUNCH_WAIT_FILE, "");
+
+	if (!Utils::FileSystem::exists(GAME_LAUNCH_WAIT_FILE))
+	{
+		if (!mPreparedLaunchP2k.empty())
+			Utils::FileSystem::removeFile(mPreparedLaunchP2k);
+
+		mPreparedLaunchP2k.clear();
+
+		LOG(LogWarning) << "Unable to create " << GAME_LAUNCH_WAIT_FILE
+		                << "; using normal synchronous launch.";
+		return false;
+	}
+
+	LOG(LogInfo) << "Starting emulatorlauncher during launch transition...";
+	LOG(LogInfo) << "	" << command;
+
+	try
+	{
+		mPreparedLaunchFuture = std::async(std::launch::async, [command]
+		{
+			ProcessStartInfo process(command);
+			process.window = nullptr;
+
+			return process.run();
+		});
+	}
+	catch (...)
+	{
+		Utils::FileSystem::removeFile(GAME_LAUNCH_WAIT_FILE);
+
+		if (!mPreparedLaunchP2k.empty())
+			Utils::FileSystem::removeFile(mPreparedLaunchP2k);
+
+		mPreparedLaunchP2k.clear();
+
+		LOG(LogWarning) << "Unable to start asynchronous game launch; "
+		                << "using normal synchronous launch.";
+
+		return false;
+	}
+
+	return true;
+#endif
+}
+
 bool FileData::launchGame(Window* window, LaunchGameOptions options)
 {
 	LOG(LogInfo) << "Attempting to launch game...";
@@ -700,9 +770,17 @@ bool FileData::launchGame(Window* window, LaunchGameOptions options)
 	if (system == nullptr)
 		return false;
 
-	std::string command = getlaunchCommand(options);
-	if (command.empty())
-		return false;
+	const bool preparedLaunch = mPreparedLaunchFuture.valid();
+
+	std::string command;
+
+	if (!preparedLaunch)
+	{
+		command = getlaunchCommand(options);
+
+		if (command.empty())
+			return false;
+	}
 
 	AudioManager::getInstance()->deinit();
 	VolumeControl::getInstance()->deinit();
@@ -717,23 +795,52 @@ bool FileData::launchGame(Window* window, LaunchGameOptions options)
 
 	time_t tstart = time(NULL);
 
-	LOG(LogInfo) << "	" << command;
+	std::string p2kConv;
 
-	auto p2kConv = convertP2kFile();
+	if (preparedLaunch)
+	{
+		p2kConv = mPreparedLaunchP2k;
+	}
+	else
+	{
+		LOG(LogInfo) << "	" << command;
+		p2kConv = convertP2kFile();
+	}
 
 	mRunningGame = gameToUpdate;
 
 	// Pause watchers before game launch
 	WatchersManager::pause();
 
-	ProcessStartInfo process(command);
-	process.window = hideWindow ? NULL : window;
-	
-	int exitCode = process.run();
-	
+	int exitCode;
+
+	if (preparedLaunch)
+	{
+		// Render the splash on the main thread.
+		if (!hideWindow)
+			window->renderSplashScreen();
+
+	#ifndef WIN32
+		// emulatorlauncher.py can now start the emulator.
+		Utils::FileSystem::removeFile(GAME_LAUNCH_WAIT_FILE);
+	#endif
+
+		// Wait for the game process to exit.
+		exitCode = mPreparedLaunchFuture.get();
+
+		mPreparedLaunchP2k.clear();
+	}
+	else
+	{
+		ProcessStartInfo process(command);
+		process.window = hideWindow ? NULL : window;
+
+		exitCode = process.run();
+	}
+
 	// Resume watchers when returning to ES
 	WatchersManager::resume();
-	
+
 	if (exitCode != 0)
 		LOG(LogWarning) << "...launch terminated with nonzero exit code " << exitCode << "!";
 

--- a/es-app/src/FileData.h
+++ b/es-app/src/FileData.h
@@ -6,6 +6,7 @@
 #include "MetaData.h"
 #include <unordered_map>
 #include <unordered_set>
+#include <future>
 #include <memory>
 #include <vector>
 #include <stack>
@@ -141,7 +142,8 @@ public:
 	std::string getlaunchCommand(bool includeControllers = true) { LaunchGameOptions options; return getlaunchCommand(options, includeControllers); };
 	std::string getlaunchCommand(LaunchGameOptions& options, bool includeControllers = true);
 
-	bool		launchGame(Window* window, LaunchGameOptions options = LaunchGameOptions());
+	bool prepareLaunchGame(LaunchGameOptions& options);
+	bool launchGame(Window* window, LaunchGameOptions options = LaunchGameOptions());
 
 	static void resetSettings();
 	
@@ -191,6 +193,9 @@ private:
 	std::string getKeyboardMappingFilePath();
 	std::string getMessageFromExitCode(int exitCode);
 	MetaDataList mMetadata;
+
+	std::future<int> mPreparedLaunchFuture;
+	std::string mPreparedLaunchP2k;
 
 protected:	
 	std::string  findLocalArt(const std::string& type = "", std::vector<std::string> exts = { ".png", ".jpg" });

--- a/es-app/src/views/ViewController.cpp
+++ b/es-app/src/views/ViewController.cpp
@@ -590,6 +590,9 @@ void ViewController::launch(FileData* game, LaunchGameOptions options, Vector3f 
 	//if (transition_style == "slide" && mCurrentView->isKindOf<GridGameListView>())
 		//transition_style = "fade";
 
+	// Launch game during the launch animation
+	game->prepareLaunchGame(options);
+
 	if (transition_style == "fade" || transition_style == "fast fade")
 	{
 		int fadeDuration = (transition_style == "fast fade") ? 400 : 800; // Halve the duration for fast fade
@@ -652,6 +655,7 @@ void ViewController::launch(FileData* game, LaunchGameOptions options, Vector3f 
 			}
 		});
 	}
+	mWindow->normalizeNextUpdate();
 }
 
 void ViewController::removeGameListView(SystemData* system)


### PR DESCRIPTION
Launch the game before/during the animation instead of waiting until the animation finishes. In my testing even on slower devices it essentially shaves off the length of the animation time from the total over-all game launch time. Measured from input to existing process.

Before:
start=684.96 end=689.04 latency=4.080
start=721.44 end=725.67 latency=4.230
start=742.62 end=746.63 latency=4.010
After:
start=1002.79 end=1005.99 latency=3.200
start=1018.35 end=1021.64 latency=3.290
start=1032.22 end=1035.50 latency=3.280

Using the default fast slide setting.

Currently blocked off for linux only unless tested and verified there's a potential benefit for windows. And kept the legacy behavior in case for some reason the wait file can't be created, or there's some other failure.

Required change in batocera-linux is to add a wait loop in emulatorlauncher.py before the run command until the wait file does not exist. (No PR for this yet, still in the review stage)

Also found an issue with original codes usage of deltatime with animations. Deltatime can be inflated by the time the animation starts, so updating it before the first animation frame ensures the animation plays smoothly.

See batocera-linux PR as an example of how it could be handled there: https://github.com/batocera-linux/batocera.linux/pull/16275