### PR TITLE
thread-optimization

### DIFF
--- a/es-app/src/services/HttpServerThread.cpp
+++ b/es-app/src/services/HttpServerThread.cpp
@@ -140,7 +140,11 @@ static bool isAllowed(const httplib::Request& req, httplib::Response& res)
 void HttpServerThread::run()
 {
 	mHttpServer = new httplib::Server();
-
+	
+	mHttpServer->new_task_queue = [] {
+		return new httplib::ThreadPool(2, CPPHTTPLIB_THREAD_POOL_COUNT);
+	};
+	
 	mHttpServer->Get("/", [=](const httplib::Request & req, httplib::Response &res) 
 	{
 		if (!isAllowed(req, res))

--- a/es-app/src/services/httplib.h
+++ b/es-app/src/services/httplib.h
@@ -182,6 +182,7 @@ using socket_t = int;
 #include <array>
 #include <atomic>
 #include <cassert>
+#include <chrono>
 #include <climits>
 #include <condition_variable>
 #include <errno.h>
@@ -445,10 +446,15 @@ public:
 
 class ThreadPool : public TaskQueue {
 public:
-  explicit ThreadPool(size_t n) : shutdown_(false) {
-    while (n) {
-      threads_.emplace_back(worker(*this));
-      n--;
+  explicit ThreadPool(size_t n, size_t max_n = 0)
+      : base_thread_count_(n),
+        max_thread_count_(max_n == 0 ? n : (std::max)(n, max_n)),
+        idle_thread_count_(0),
+        shutdown_(false) {
+    threads_.reserve(base_thread_count_);
+
+    for (size_t i = 0; i < base_thread_count_; i++) {
+      threads_.emplace_back(std::thread([this]() { worker(false); }));
     }
   }
 
@@ -456,13 +462,23 @@ public:
   ~ThreadPool() override = default;
 
   void enqueue(std::function<void()> fn) override {
-    std::unique_lock<std::mutex> lock(mutex_);
-    jobs_.push_back(fn);
+    {
+      std::unique_lock<std::mutex> lock(mutex_);
+      jobs_.push_back(fn);
+
+      // Spawn a temporary worker if all current workers are busy.
+      if (idle_thread_count_ == 0 &&
+          threads_.size() + dynamic_threads_.size() < max_thread_count_) {
+        cleanup_finished_threads();
+        dynamic_threads_.emplace_back(
+            std::thread([this]() { worker(true); }));
+      }
+    }
+
     cond_.notify_one();
   }
 
   void shutdown() override {
-    // Stop all worker threads...
     {
       std::unique_lock<std::mutex> lock(mutex_);
       shutdown_ = true;
@@ -470,41 +486,97 @@ public:
 
     cond_.notify_all();
 
-    // Join...
     for (auto &t : threads_) {
-      t.join();
+      if (t.joinable())
+        t.join();
     }
+
+    std::list<std::thread> remaining_dynamic;
+    {
+      std::unique_lock<std::mutex> lock(mutex_);
+      remaining_dynamic = std::move(dynamic_threads_);
+    }
+
+    for (auto &t : remaining_dynamic) {
+      if (t.joinable())
+        t.join();
+    }
+
+    std::unique_lock<std::mutex> lock(mutex_);
+    cleanup_finished_threads();
   }
 
 private:
-  struct worker {
-    explicit worker(ThreadPool &pool) : pool_(pool) {}
+  void worker(bool is_dynamic) {
+    for (;;) {
+      std::function<void()> fn;
 
-    void operator()() {
-      for (;;) {
-        std::function<void()> fn;
-        {
-          std::unique_lock<std::mutex> lock(pool_.mutex_);
+      {
+        std::unique_lock<std::mutex> lock(mutex_);
+        idle_thread_count_++;
 
-          pool_.cond_.wait(
-              lock, [&] { return !pool_.jobs_.empty() || pool_.shutdown_; });
+        if (is_dynamic) {
+          auto has_work =
+              cond_.wait_for(lock, std::chrono::seconds(3),
+                             [this]() {
+                               return !jobs_.empty() || shutdown_;
+                             });
 
-          if (pool_.shutdown_ && pool_.jobs_.empty()) { break; }
-
-          fn = pool_.jobs_.front();
-          pool_.jobs_.pop_front();
+          if (!has_work) {
+            idle_thread_count_--;
+            move_to_finished(std::this_thread::get_id());
+            break;
+          }
+        } else {
+          cond_.wait(lock, [this]() {
+            return !jobs_.empty() || shutdown_;
+          });
         }
 
-        assert(true == static_cast<bool>(fn));
-        fn();
+        idle_thread_count_--;
+
+        if (shutdown_ && jobs_.empty())
+          break;
+
+        fn = jobs_.front();
+        jobs_.pop_front();
+      }
+
+      assert(true == static_cast<bool>(fn));
+      fn();
+    }
+  }
+
+  void move_to_finished(std::thread::id id) {
+    // Called with mutex_ held.
+    for (auto it = dynamic_threads_.begin();
+         it != dynamic_threads_.end(); ++it) {
+      if (it->get_id() == id) {
+        finished_threads_.push_back(std::move(*it));
+        dynamic_threads_.erase(it);
+        return;
       }
     }
+  }
 
-    ThreadPool &pool_;
-  };
-  friend struct worker;
+  void cleanup_finished_threads() {
+    // Called with mutex_ held.
+    for (auto &t : finished_threads_) {
+      if (t.joinable())
+        t.join();
+    }
+
+    finished_threads_.clear();
+  }
+
+  size_t base_thread_count_;
+  size_t max_thread_count_;
+  size_t idle_thread_count_;
 
   std::vector<std::thread> threads_;
+  std::list<std::thread> dynamic_threads_;
+  std::vector<std::thread> finished_threads_;
+
   std::list<std::function<void()>> jobs_;
 
   bool shutdown_;

--- a/es-core/src/TextToSpeech.cpp
+++ b/es-core/src/TextToSpeech.cpp
@@ -59,6 +59,7 @@ std::weak_ptr<TextToSpeech> TextToSpeech::sInstance;
 TextToSpeech::TextToSpeech()
 {
 	m_isAvailable = false;
+	m_initialized = false;
 	m_enabled = false;
 
 	init();
@@ -83,18 +84,20 @@ std::shared_ptr<TextToSpeech> & TextToSpeech::getInstance()
 
 void TextToSpeech::init()
 {
-	if (m_isAvailable)
+	if (m_initialized)
 		return;
 
 #if WIN32
-	m_isAvailable = false;
 	mShouldTerminate = false;
 	mSpeakThread = new std::thread(&TextToSpeech::SpeakThread, this);
+	m_initialized = true;
 #elif defined(_ENABLE_TTS_)	
 	m_isAvailable = espeak_Initialize(AUDIO_OUTPUT_PLAYBACK, 0, NULL, 0) != EE_INTERNAL_ERROR;
 	if (!m_isAvailable)
 		return;
-	
+
+	m_initialized = true;
+
 	char* envv = getenv("LANGUAGE");
 	if (envv != nullptr && std::string(envv).length() >= 4) 
 		setLanguage(envv);
@@ -109,10 +112,9 @@ void TextToSpeech::init()
 
 void TextToSpeech::deinit()
 {
-	if (!m_isAvailable)
+	if (!m_initialized)
 		return;
 
-	m_isAvailable = false;
 	m_enabled = false;
 
 #if WIN32
@@ -127,11 +129,18 @@ void TextToSpeech::deinit()
 		delete mSpeakThread;
 		mSpeakThread = nullptr;
 	}
+
+	for (auto item : mSpeechQueue)
+		delete item;
+
+	mSpeechQueue.clear();
+
 #elif defined(_ENABLE_TTS_)
 	if (espeak_Terminate() != EE_OK) {
 		LOG(LogError) << "TTS::deinit() - Failed to terminate";
 	}
 #endif
+	m_initialized = false;
 }
 
 bool TextToSpeech::isAvailable()
@@ -144,11 +153,24 @@ bool TextToSpeech::isEnabled()
 	return m_enabled;
 }
 
-void TextToSpeech::enable(bool v, bool playSay) 
+void TextToSpeech::enable(bool v, bool playSay)
 {
 	if (v == m_enabled)
+	{
+		if (!v && m_initialized)
+			deinit();
+
 		return;
-	
+	}
+
+	if (v && !m_initialized)
+	{
+		init();
+
+		if (!m_initialized)
+			return;
+	}
+
 	if (m_isAvailable && playSay)
 	{
 		m_enabled = true; // Force
@@ -156,6 +178,9 @@ void TextToSpeech::enable(bool v, bool playSay)
 	}
 
 	m_enabled = v;
+
+	if (!v)
+		deinit();
 }
 
 bool TextToSpeech::toogle() 

--- a/es-core/src/TextToSpeech.h
+++ b/es-core/src/TextToSpeech.h
@@ -35,6 +35,7 @@ private:
 	static std::weak_ptr<TextToSpeech> sInstance;
 
 	bool m_isAvailable;
+	bool m_initialized;
 	bool m_enabled;
 
 	void init();


### PR DESCRIPTION
The goal is to reduce unnecessary thread count/creation.

First is httpserver threads. Currently it defaults to max(8, CPU threads - 1). This is a bit excessive I think.
Looking at upstream latest version of httplib.h you can see it supports dynamic thread creation/termination. However it won't compile on windows versions older than windows 10. So I cherry picked only the dynamic thread code. This sets a minimum default of 2 threads while still allowing a max(8, CPU threads - 1), so it both sets a conservative minimum while allowing a max thread count that matches current behavior. So we keep support for older windows.

Second is TTS. TTS itself creates 2 threads and is currently initialized unconditionally, even if the setting is disabled. Changing it so that it's only initialized when the setting is enabled means there's 2 less threads when it's not needed.


These changes won't save any meaningful cpu cycles or ram, as most of these threads are probably sleeping while not active, however architecturally they seem like no-brainers in the sense that threads shouldn't exist if not needed.

These changes compiled successfully and tested working.