### PR TITLE
improve-watchers

### DIFF
--- a/es-app/src/FileData.cpp
+++ b/es-app/src/FileData.cpp
@@ -34,6 +34,7 @@
 #include "Paths.h"
 #include "resources/TextureData.h"
 #include "views/gamelist/GameNameFormatter.h"
+#include "watchers/WatchersManager.h"
 
 using namespace Utils::Platform;
 
@@ -722,10 +723,17 @@ bool FileData::launchGame(Window* window, LaunchGameOptions options)
 
 	mRunningGame = gameToUpdate;
 
+	// Pause watchers before game launch
+	WatchersManager::pause();
+
 	ProcessStartInfo process(command);
 	process.window = hideWindow ? NULL : window;
 	
 	int exitCode = process.run();
+	
+	// Resume watchers when returning to ES
+	WatchersManager::resume();
+	
 	if (exitCode != 0)
 		LOG(LogWarning) << "...launch terminated with nonzero exit code " << exitCode << "!";
 

--- a/es-core/src/watchers/WatchersManager.cpp
+++ b/es-core/src/watchers/WatchersManager.cpp
@@ -1,7 +1,6 @@
 #include "WatchersManager.h"
 #include "Log.h"
 #include <chrono>
-#include <SDL.h>
 
 std::mutex											WatchersManager::mNotificationLock;
 std::list<IWatcherNotify*>							WatchersManager::mNotification;
@@ -27,26 +26,39 @@ void WatchersManager::stop()
 	}
 }
 
+void WatchersManager::pause()
+{
+	if (mInstance == nullptr)
+		return;
+
+	{
+		std::unique_lock<std::mutex> lock(mInstance->mThreadLock);
+		mInstance->mPaused = true;
+	}
+
+	mInstance->mEvent.notify_all();
+}
+
+void WatchersManager::resume()
+{
+	if (mInstance == nullptr)
+		return;
+
+	{
+		std::unique_lock<std::mutex> lock(mInstance->mThreadLock);
+		mInstance->mPaused = false;
+	}
+
+	mInstance->mEvent.notify_all();
+}
+
 WatchersManager::WatchersManager()
 {
 	LOG(LogDebug) << "WatchersManager : Starting";
 
 	mRunning = true;
+	mPaused = false;
 	mThread = new std::thread(&WatchersManager::run, this);
-}
-
-void WatchersManager::ResetComponent(IWatcher* instance)
-{
-	std::unique_lock<std::mutex> lock(mWatchersLock);
-
-	for (auto comp : mWatchers)
-	{
-		if (comp->component == instance)
-		{
-			comp->nextCheckTime = 0;
-			return;
-		}
-	}
 }
 
 void WatchersManager::RegisterComponent(IWatcher* instance)
@@ -55,7 +67,9 @@ void WatchersManager::RegisterComponent(IWatcher* instance)
 
 	WatcherInfo* info = new WatcherInfo();
 	info->component = instance;
-	info->nextCheckTime = SDL_GetTicks() + instance->initialUpdateTime();
+	info->nextCheckTime =
+		std::chrono::steady_clock::now() + std::chrono::milliseconds(instance->initialUpdateTime());
+
 	mWatchers.push_back(info);
 }
 
@@ -70,6 +84,20 @@ void WatchersManager::UnregisterComponent(IWatcher* instance)
 		{
 			mWatchers.erase(it);
 			delete info;
+			return;
+		}
+	}
+}
+
+void WatchersManager::ResetComponent(IWatcher* instance)
+{
+	std::unique_lock<std::mutex> lock(mWatchersLock);
+
+	for (auto comp : mWatchers)
+	{
+		if (comp->component == instance)
+		{
+			comp->nextCheckTime = std::chrono::steady_clock::now();
 			return;
 		}
 	}
@@ -107,7 +135,7 @@ WatchersManager::~WatchersManager()
 {
 	if (mThread == nullptr)
 		return;
-	
+
 	LOG(LogDebug) << "WatchersManager : Exit";
 
 	// Remove locks
@@ -125,7 +153,7 @@ WatchersManager::~WatchersManager()
 
 	mThread->join();
 	delete mThread;
-	mThread = nullptr;	
+	mThread = nullptr;
 }
 
 void WatchersManager::run()
@@ -133,19 +161,27 @@ void WatchersManager::run()
 	while (mRunning)
 	{
 		// ThreadLock
-		{			
+		{
 			std::unique_lock<std::mutex> lock(mThreadLock);
-			mEvent.wait_for(lock, std::chrono::seconds(1));
-			
+
+			if (mPaused)
+				mEvent.wait(lock, [this]() { return !mPaused || !mRunning; });
+			else
+				mEvent.wait_for(lock, std::chrono::seconds(1));
+
 			if (!mRunning)
 				return;
+
+			if (mPaused)
+				continue;
 		}
 
 		// Notification Lock
 		{
 			std::unique_lock<std::mutex> lock(mWatchersLock);
 
-			int ticks = SDL_GetTicks();
+			auto now = std::chrono::steady_clock::now();
+
 			for (auto item : mWatchers)
 			{
 				if (!mRunning)
@@ -154,14 +190,14 @@ void WatchersManager::run()
 				if (!item->component->enabled())
 					continue;
 
-				if (ticks < item->nextCheckTime)
+				if (now < item->nextCheckTime)
 					continue;
 
 				if (item->component->check())
 					NotifyComponentChanged(item->component);
 
-				item->nextCheckTime = SDL_GetTicks() + item->component->updateTime();
+				item->nextCheckTime = now + std::chrono::milliseconds(item->component->updateTime());
 			}
-		}		
+		}
 	}
 }

--- a/es-core/src/watchers/WatchersManager.h
+++ b/es-core/src/watchers/WatchersManager.h
@@ -4,6 +4,7 @@
 #include <condition_variable>
 #include <mutex>
 #include <list>
+#include <chrono>
 
 class WatchersManager;
 
@@ -53,6 +54,8 @@ public:
 
 	static WatchersManager* getInstance();
 	static void             stop();
+	static void             pause();
+	static void             resume();
 
 	virtual ~WatchersManager();
 
@@ -63,10 +66,10 @@ private:
 
 	struct WatcherInfo
 	{
-		WatcherInfo() { component = nullptr; nextCheckTime = 0; }
+		WatcherInfo() { component = nullptr; nextCheckTime = std::chrono::steady_clock::now(); }
 
 		IWatcher*	component;
-		int			nextCheckTime;
+		std::chrono::steady_clock::time_point nextCheckTime;
 	};
 
 	void NotifyComponentChanged(IWatcher* component);
@@ -80,6 +83,7 @@ private:
 	std::mutex										mThreadLock;
 	std::condition_variable							mEvent;
 	bool											mRunning;
+	bool											mPaused;
 	
 	std::thread*									mThread;
 


### PR DESCRIPTION
This PR does 2 things:

1. Switches from the older SDL_GetTicks() to a more modern use of std::chrono::steady_clock. This uses monotonic time and removes the SDL dependency.

2. Pauses WatchersManager while a game is running and resumes when returning back to ES. This pauses the watcher threads instead of waking periodically to poll components when there is no active UI to update.