### PR TITLE
fix-powersave-refresh

### DIFF
--- a/es-core/src/PowerSaver.cpp
+++ b/es-core/src/PowerSaver.cpp
@@ -24,9 +24,10 @@ void PowerSaver::pushRefreshEvent()
 	if (mPushEventID == -1)
 		mPushEventID = SDL_RegisterEvents(1);
 
-	SDL_Event ev;
+	SDL_Event ev {};
 	ev.type = mPushEventID;
-	SDL_PushEvent(&ev);
+	if (SDL_PushEvent(&ev) > 0)
+		mHasPushedEvent = true;
 }
 
 void PowerSaver::resetRefreshEvent()


### PR DESCRIPTION
pushRefreshEvent() checks mHasPushedEvent to avoid duplicate refresh events, but the flag was never set after an event was successfully pushed.

This sets mHasPushedEvent when SDL_PushEvent() succeeds, allowing the existing resetRefreshEvent() path to work as intended.