### PR TITLE
reduce-screensaver-rendering

### DIFF
--- a/es-app/src/SystemScreenSaver.cpp
+++ b/es-app/src/SystemScreenSaver.cpp
@@ -25,9 +25,11 @@
 #include "utils/Randomizer.h"
 #include "Paths.h"
 #include "ApiSystem.h"
+#include <algorithm>
 
 #define FADE_TIME					(500)
 #define DATE_TIME_UPDATE_INTERVAL	(100)
+#define STATIC_SCREENSAVER_POLL_INTERVAL	(100)
 
 SystemScreenSaver::SystemScreenSaver(Window* window) :
 	mVideoScreensaver(NULL),
@@ -67,6 +69,29 @@ bool SystemScreenSaver::allowSleep()
 bool SystemScreenSaver::isScreenSaverActive()
 {
 	return (mState != STATE_INACTIVE);
+}
+
+int SystemScreenSaver::getNextUpdateTimeout()
+{
+	// Fades and video require continuous rendering.
+	if (mState != STATE_SCREENSAVER_ACTIVE || mVideoScreensaver)
+		return 0;
+
+	// Black/dim periodically wake for polling-based input such as lightguns.
+	if (!mImageScreensaver)
+		return STATIC_SCREENSAVER_POLL_INTERVAL;
+
+	// Slideshow: wake for the next image change.
+	int timeout = mVideoChangeTime - mTimer;
+	if (timeout < 1)
+		timeout = 1;
+
+	// Without the clock, periodically wake for polling-based input.
+	if (!Settings::getInstance()->getBool("ScreenSaverDateTime"))
+		return std::min(timeout, STATIC_SCREENSAVER_POLL_INTERVAL);
+
+	// Use the existing date/time update cadence.
+	return std::min(timeout, DATE_TIME_UPDATE_INTERVAL);
 }
 
 void SystemScreenSaver::startScreenSaver()
@@ -485,7 +510,7 @@ void SystemScreenSaver::update(int deltaTime)
 	{
 		// Update the timer that swaps the videos
 		mTimer += deltaTime;
-		if (mTimer > mVideoChangeTime)
+		if (mTimer >= mVideoChangeTime)
 			nextVideo();
 	}
 

--- a/es-app/src/SystemScreenSaver.h
+++ b/es-app/src/SystemScreenSaver.h
@@ -88,6 +88,7 @@ public:
 	virtual bool allowSleep();
 	virtual void update(int deltaTime);
 	virtual bool isScreenSaverActive();
+	int getNextUpdateTimeout();
 
 	virtual FileData* getCurrentGame();
 	virtual void launchGame();

--- a/es-app/src/main.cpp
+++ b/es-app/src/main.cpp
@@ -680,8 +680,24 @@ int main(int argc, char* argv[])
 	{
 		SDL_Event event;
 
-		bool ps_standby = PowerSaver::getState() && (int) SDL_GetTicks() - ps_time > PowerSaver::getMode();
-		if(ps_standby ? SDL_WaitEventTimeout(&event, PowerSaver::getTimeout()) : SDL_PollEvent(&event))
+		int screenSaverTimeout = screensaver.getNextUpdateTimeout();
+		bool screenSaverWait = screenSaverTimeout > 0;
+
+		bool ps_standby =
+			!screenSaverWait &&
+			PowerSaver::getState() &&
+			(int)SDL_GetTicks() - ps_time > PowerSaver::getMode();
+
+		int eventResult;
+
+		if (screenSaverWait)
+			eventResult = SDL_WaitEventTimeout(&event, screenSaverTimeout);
+		else if (ps_standby)
+			eventResult = SDL_WaitEventTimeout(&event, PowerSaver::getTimeout());
+		else
+			eventResult = SDL_PollEvent(&event);
+
+		if (eventResult)
 		{
 			// PowerSaver can push events to exit SDL_WaitEventTimeout immediatly
 			// Reset this event's state
@@ -756,7 +772,7 @@ int main(int argc, char* argv[])
 			InputManager::getInstance()->updateGuns(&window);
 
 			// triggered if exiting from SDL_WaitEvent due to event
-			if (ps_standby)
+			if (ps_standby || (screenSaverWait && !screensaver.isScreenSaverActive()))
 				// show as if continuing from last event
 				lastTime = SDL_GetTicks();
 
@@ -767,6 +783,9 @@ int main(int argc, char* argv[])
 		{
 		  // check guns
 		  InputManager::getInstance()->updateGuns(&window);
+
+		  if (screenSaverWait)
+			ps_time = SDL_GetTicks();
 
 		  // If exitting SDL_WaitEventTimeout due to timeout. Trail considering
 		  // timeout as an event


### PR DESCRIPTION
Reduce unnecessary rendering and wakeups during static screensaver states.

Slideshow, dim, and blank screensavers now wait between updates, while video and fade transitions continue rendering normally. Uses the existing 100ms cadence for clock updates if enabled, and polling-based input such as lightguns.

Testing showed approximately an 80% reduction in update/render frequency while in a static screensaver state resulting in lower overall cpu utilization.