### PR TITLE
Add frontend MSAA setting

### DIFF
--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -707,6 +707,21 @@ void GuiMenu::openDeveloperSettings()
 	
 	s->addSwitch(_("SHOW FRAMERATE"), _("Also turns on the emulator's native FPS counter, if available."), "DrawFramerate", true, nullptr);
 	s->addSwitch(_("VSYNC"), "VSync", true, [] { Renderer::setSwapInterval(); });
+	
+	// Antialiasing (solves flickering issues with AMD on Windows in some cases)
+	auto antiAliasing = std::make_shared<OptionListComponent<int>>(mWindow, _("ANTI-ALIASING (MSAA)"), false);
+	antiAliasing->add(_("DISABLED"), 0, Settings::getInstance()->getInt("AntiAliasing") == 0);
+	antiAliasing->add("2X", 2, Settings::getInstance()->getInt("AntiAliasing") == 2);
+	antiAliasing->add("4X", 4, Settings::getInstance()->getInt("AntiAliasing") == 4);
+	if (!antiAliasing->hasSelection())
+		antiAliasing->selectFirstItem();
+	s->addWithLabel(_("ANTI-ALIASING (MSAA)"), antiAliasing);
+	s->addSaveFunc([s, antiAliasing]
+		{
+			if (Settings::getInstance()->setInt("AntiAliasing", antiAliasing->getSelected()))
+				s->setVariable("reboot", true);
+		});
+
 	auto fpsLimit = std::make_shared<OptionListComponent<int>>(mWindow, _("FPS LIMIT"), false);
 	fpsLimit->add(_("NO"), 0, Settings::FpsLimit() == 0);
 	fpsLimit->add("25", 25, Settings::FpsLimit() == 25);

--- a/es-app/src/main.cpp
+++ b/es-app/src/main.cpp
@@ -210,6 +210,24 @@ bool parseArgs(int argc, char* argv[])
 			int maxVRAM = atoi(argv[i + 1]);
 			Settings::getInstance()->setInt("MaxVRAM", maxVRAM);
 		}
+		else if (strcmp(argv[i], "--anti-aliasing") == 0)
+		{
+			if (i >= argc - 1)
+			{
+				std::cerr << "Invalid anti-aliasing supplied.";
+				return false;
+			}
+
+			int antiAliasing = atoi(argv[i + 1]);
+			if (antiAliasing != 0 && antiAliasing != 2 && antiAliasing != 4)
+			{
+				std::cerr << "Invalid anti-aliasing supplied.";
+				return false;
+			}
+
+			Settings::getInstance()->setInt("AntiAliasing", antiAliasing);
+			i++;
+		}
 		else if (strcmp(argv[i], "--force-kiosk") == 0)
 		{
 			Settings::getInstance()->setBool("ForceKiosk", true);
@@ -247,6 +265,7 @@ bool parseArgs(int argc, char* argv[])
 				"--windowed			not fullscreen, should be used with --resolution\n"
 				"--vsync [1/on or 0/off]		turn vsync on or off (default is on)\n"
 				"--max-vram [size]		Max VRAM to use in Mb before swapping. 0 for unlimited\n"
+				"--anti-aliasing [0, 2 or 4]	set MSAA anti-aliasing to disabled, 2x or 4x\n"
 				"--force-kid		Force the UI mode to be Kid\n"
 				"--force-kiosk		Force the UI mode to be Kiosk\n"
 				"--force-disable-filters		Force the UI to ignore applied filters in gamelist\n"

--- a/es-core/src/Settings.cpp
+++ b/es-core/src/Settings.cpp
@@ -216,6 +216,7 @@ void Settings::setDefaults()
 	
 	mIntMap["ScreenSaverTime"] = Settings::_ScreenSaverTime;
 	mIntMap["FpsLimit"] = 0;
+	mIntMap["AntiAliasing"] = 0;
 	mIntMap["ScraperResizeWidth"] = 640;
 	mIntMap["ScraperResizeHeight"] = 0;
 

--- a/es-core/src/renderers/Renderer_GL21.cpp
+++ b/es-core/src/renderers/Renderer_GL21.cpp
@@ -66,8 +66,12 @@ namespace Renderer
 		SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 1);
 
 		// Antialias : Not supported on every machine
-		// SDL_GL_SetAttribute(SDL_GL_MULTISAMPLEBUFFERS, 1);
-		// SDL_GL_SetAttribute(SDL_GL_MULTISAMPLESAMPLES, 2);
+		int antiAliasing = Settings::getInstance()->getInt("AntiAliasing");
+		if (antiAliasing == 2 || antiAliasing == 4)
+		{
+			SDL_GL_SetAttribute(SDL_GL_MULTISAMPLEBUFFERS, 1);
+			SDL_GL_SetAttribute(SDL_GL_MULTISAMPLESAMPLES, antiAliasing);
+		}
 
 	} // setupWindow
 
@@ -107,6 +111,15 @@ namespace Renderer
 		std::string glExts = (const char*)glGetString(GL_EXTENSIONS);
 		LOG(LogInfo) << "Checking available OpenGL extensions...";
 		LOG(LogInfo) << " ARB_texture_non_power_of_two: " << (glExts.find("ARB_texture_non_power_of_two") != std::string::npos ? "ok" : "MISSING");
+
+		int antiAliasing = Settings::getInstance()->getInt("AntiAliasing");
+		if (antiAliasing == 2 || antiAliasing == 4)
+		{
+			glEnable(GL_MULTISAMPLE);
+			LOG(LogInfo) << "Anti-aliasing: " << antiAliasing << "x MSAA";
+		}
+		else
+			LOG(LogInfo) << "Anti-aliasing: disabled";
 
 	} // createContext
 
@@ -311,7 +324,10 @@ namespace Renderer
 
 	void OpenGL21Renderer::drawTriangleFan(const Vertex* _vertices, const unsigned int _numVertices, const Blend::Factor _srcBlendFactor, const Blend::Factor _dstBlendFactor)
 	{
-		glEnable(GL_MULTISAMPLE);
+		int antiAliasing = Settings::getInstance()->getInt("AntiAliasing");
+		bool hasAntiAliasing = antiAliasing == 2 || antiAliasing == 4;
+		if (!hasAntiAliasing)
+			glEnable(GL_MULTISAMPLE);
 
 		glEnable(GL_BLEND);
 		glBlendFunc(convertBlendFactor(_srcBlendFactor), convertBlendFactor(_dstBlendFactor));
@@ -331,7 +347,8 @@ namespace Renderer
 		glDisableClientState(GL_VERTEX_ARRAY);
 
 		glDisable(GL_BLEND);
-		glDisable(GL_MULTISAMPLE);
+		if (!hasAntiAliasing)
+			glDisable(GL_MULTISAMPLE);
 	}
 
 	void OpenGL21Renderer::drawSolidRectangle(const float _x, const float _y, const float _w, const float _h, const unsigned int _fillColor, const unsigned int _borderColor, float borderWidth, float cornerRadius)

--- a/es-core/src/renderers/Renderer_GLES20.cpp
+++ b/es-core/src/renderers/Renderer_GLES20.cpp
@@ -500,6 +500,15 @@ namespace Renderer
 		SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER,       1);
 		SDL_GL_SetAttribute(SDL_GL_ACCELERATED_VISUAL, 1);
 
+#if OPENGL_EXTENSIONS
+		int antiAliasing = Settings::getInstance()->getInt("AntiAliasing");
+		if (antiAliasing == 2 || antiAliasing == 4)
+		{
+			SDL_GL_SetAttribute(SDL_GL_MULTISAMPLEBUFFERS, 1);
+			SDL_GL_SetAttribute(SDL_GL_MULTISAMPLESAMPLES, antiAliasing);
+		}
+#endif
+
 	} // setupWindow
 
 //////////////////////////////////////////////////////////////////////////
@@ -599,6 +608,16 @@ namespace Renderer
 		GL_CHECK_ERROR(glPixelStorei(GL_PACK_ALIGNMENT, 1));
 		GL_CHECK_ERROR(glPixelStorei(GL_UNPACK_ALIGNMENT, 1));
 		
+#if OPENGL_EXTENSIONS
+		int antiAliasing = Settings::getInstance()->getInt("AntiAliasing");
+		if (antiAliasing == 2 || antiAliasing == 4)
+		{
+			GL_CHECK_ERROR(glEnable(GL_MULTISAMPLE));
+			LOG(LogInfo) << "Anti-aliasing: " << antiAliasing << "x MSAA";
+		}
+		else
+			LOG(LogInfo) << "Anti-aliasing: disabled";
+#endif
 	} // createContext
 
 //////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This adds a MSAA setting in Emulationstation:

- add an opt-in frontend MSAA setting with disabled, 2x, and 4x modes
- apply the selected MSAA level during desktop OpenGL context creation
- add a --anti-aliasing command-line override

Some virtual display / streaming setups flicker in the frontend. ES-DE exposes this setting and documents 2x MSAA as a workaround for severe frontend flickering on buggy Windows GPU drivers; RetroBat did not expose an equivalent setting.

Related: https://github.com/VirtualDrivers/Virtual-Display-Driver/issues/299