### PR TITLE
WIN32: fix slow opening of menu

### DIFF
--- a/es-app/src/Win32ApiSystem.cpp
+++ b/es-app/src/Win32ApiSystem.cpp
@@ -933,6 +933,14 @@ bool Win32ApiSystem::canUpdate(std::vector<std::string>& output)
 	return false;
 }
 
+bool Win32ApiSystem::canLocalUpdate()
+{
+	// This is a Batocera-Linux ('batocera-upgrade') function only (update from USB-key). 
+	// Without this surcharge the implementation spams a cmd.exe (popen) on the UI thread on each menu opening,
+	// which slows down the menu on Windows for nothing.
+	return false;
+}
+
 bool Win32ApiSystem::launchKodi(Window *window)
 {
 	std::string command = Paths::getKodiPath();

--- a/es-app/src/Win32ApiSystem.h
+++ b/es-app/src/Win32ApiSystem.h
@@ -32,6 +32,7 @@ public:
 	// Updates
 	std::pair<std::string, int> updateSystem(const std::function<void(const std::string)>& func, bool fromlocalmedia) override;
 	bool canUpdate(std::vector<std::string>& output) override;
+	bool canLocalUpdate() override;
 
 	bool ping() override;
 


### PR DESCRIPTION
Method canLocalUpdate() was added in batocera to enable update from USB key, it is useless for Windows.
==> This was added in may 2026

This commit overrides it in WIN32apisystems so that it does not trigger a cmd in Windows (RetroBat).

As a result, the update menu does not take multiple seconds to open anymore.

