### PR TITLE
feat: multi-user profiles UI (proof of concept — looking for design feedback)

### DIFF
--- a/es-app/CMakeLists.txt
+++ b/es-app/CMakeLists.txt
@@ -87,7 +87,8 @@ set(ES_HEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/src/guis/GuiNetPlay.h # batocera
 	${CMAKE_CURRENT_SOURCE_DIR}/src/guis/GuiNetPlaySettings.h
     ${CMAKE_CURRENT_SOURCE_DIR}/src/guis/GuiRetroAchievements.h
-	${CMAKE_CURRENT_SOURCE_DIR}/src/guis/GuiRetroAchievementsSettings.h	
+	${CMAKE_CURRENT_SOURCE_DIR}/src/guis/GuiRetroAchievementsSettings.h
+	${CMAKE_CURRENT_SOURCE_DIR}/src/guis/GuiProfilesSettings.h
 	${CMAKE_CURRENT_SOURCE_DIR}/src/guis/GuiSystemInformation.h
 	${CMAKE_CURRENT_SOURCE_DIR}/src/guis/GuiBluetoothDevices.h
 	${CMAKE_CURRENT_SOURCE_DIR}/src/guis/GuiBluetoothPair.h
@@ -193,6 +194,7 @@ set(ES_SOURCES
 	${CMAKE_CURRENT_SOURCE_DIR}/src/guis/GuiNetPlaySettings.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/guis/GuiRetroAchievements.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/guis/GuiRetroAchievementsSettings.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/src/guis/GuiProfilesSettings.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/guis/GuiSystemInformation.cpp	
 	${CMAKE_CURRENT_SOURCE_DIR}/src/guis/GuiBluetoothDevices.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/guis/GuiBluetoothPair.cpp

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -18,6 +18,7 @@
 #include "guis/GuiImageViewer.h"
 #include "guis/GuiNetPlaySettings.h"
 #include "guis/GuiRetroAchievementsSettings.h"
+#include "guis/GuiProfilesSettings.h"
 #include "guis/GuiSystemInformation.h"
 #include "guis/GuiControllersSettings.h"
 #include "views/UIModeController.h"
@@ -2133,6 +2134,9 @@ void GuiMenu::openSystemSettings()
 	}
 #endif
 	
+	// Profiles
+	s->addEntry(_("PROFILES"), true, [this] { openProfilesSettings(); });
+
 	// Developer options
 	if (isFullUI)
 		s->addEntry(_("FRONTEND DEVELOPER OPTIONS"), true, [this] { openDeveloperSettings(); });
@@ -2195,9 +2199,14 @@ void GuiMenu::openRetroachievementsSettings()
 	mWindow->pushGui(new GuiRetroAchievementsSettings(mWindow));
 }
 
+void GuiMenu::openProfilesSettings()
+{
+	mWindow->pushGui(new GuiProfilesSettings(mWindow));
+}
+
 void GuiMenu::openNetplaySettings()
 {
-	mWindow->pushGui(new GuiNetPlaySettings(mWindow));	
+	mWindow->pushGui(new GuiNetPlaySettings(mWindow));
 }
 
 void GuiMenu::addDecorationSetOptionListComponent(Window* window, GuiSettings* parentWindow, const std::vector<DecorationSetInfo>& sets, const std::string& configName)

--- a/es-app/src/guis/GuiMenu.h
+++ b/es-app/src/guis/GuiMenu.h
@@ -62,6 +62,7 @@ private:
         void openDeveloperSettings();
         void openNetplaySettings(); 
         void openRetroachievementsSettings();
+        void openProfilesSettings();
         void openMissingBiosSettings();
         void openFormatDriveSettings();
         void exitKidMode();

--- a/es-app/src/guis/GuiProfilesSettings.cpp
+++ b/es-app/src/guis/GuiProfilesSettings.cpp
@@ -41,6 +41,41 @@ static std::string readCurrentProfile()
 	return s;
 }
 
+// Read a named field from a profile conf file (key=value format).
+static std::string readConfField(const std::string& confPath, const std::string& key)
+{
+	FILE* f = fopen(confPath.c_str(), "r");
+	if (!f)
+		return "";
+	std::string prefix = key + "=";
+	char line[256];
+	while (fgets(line, sizeof(line), f))
+	{
+		std::string s(line);
+		while (!s.empty() && (s.back() == '\n' || s.back() == '\r'))
+			s.pop_back();
+		if (s.size() > prefix.size() && s.substr(0, prefix.size()) == prefix)
+		{
+			fclose(f);
+			return s.substr(prefix.size());
+		}
+	}
+	fclose(f);
+	return "";
+}
+
+// Resolve display label for a profile: display_name > RA username > fallback.
+static std::string profileDisplayName(const std::string& confPath, const std::string& fallback)
+{
+	std::string dn = readConfField(confPath, "display_name");
+	if (!dn.empty())
+		return dn;
+	std::string ra = readConfField(confPath, "username");
+	if (!ra.empty())
+		return ra;
+	return fallback;
+}
+
 static bool isValidProfileName(const std::string& name)
 {
 	if (name.empty())
@@ -60,9 +95,11 @@ GuiProfilesSettings::GuiProfilesSettings(Window* window)
 	addGroup(_("SWITCH PROFILE"));
 
 	// DEFAULT entry — always present
+	std::string defaultConf = "/userdata/profiles/.default-retroachievements.conf";
+	std::string defaultName = profileDisplayName(defaultConf, _("DEFAULT"));
 	std::string defaultLabel = current.empty()
-		? (_("DEFAULT") + " (" + _("ACTIVE") + ")")
-		: _("DEFAULT");
+		? (defaultName + " (" + _("ACTIVE") + ")")
+		: defaultName;
 	addEntry(defaultLabel, false,
 		[window]
 		{
@@ -75,14 +112,15 @@ GuiProfilesSettings::GuiProfilesSettings(Window* window)
 	for (auto p : profiles)
 	{
 		bool isActive = (p == current);
+		std::string conf = "/userdata/profiles/" + p + "/retroachievements.conf";
+		std::string displayName = profileDisplayName(conf, p);
 		std::string label = isActive
-			? (p + " (" + _("ACTIVE") + ")")
-			: p;
+			? (displayName + " (" + _("ACTIVE") + ")")
+			: displayName;
 		addEntry(label, false,
 			[window, p]
 			{
-				system(
-					("batocera-profiles switch \"" + p + "\"").c_str());
+				system(("batocera-profiles switch \"" + p + "\"").c_str());
 				window->pushGui(new GuiMsgBox(window,
 					_("SWITCHED TO PROFILE:") + "\n" + p + "\n\n" +
 					_("TAKES EFFECT ON NEXT GAME LAUNCH."),
@@ -106,10 +144,35 @@ GuiProfilesSettings::GuiProfilesSettings(Window* window)
 							_("OK"), nullptr));
 						return;
 					}
-					system(
-						("batocera-profiles create \"" + name + "\"").c_str());
+					system(("batocera-profiles create \"" + name + "\"").c_str());
 					window->pushGui(new GuiMsgBox(window,
 						_("PROFILE CREATED:") + "\n" + name,
+						_("OK"), nullptr));
+				}, false));
+		});
+
+	// RENAME — sets display_name for any profile (default or named)
+	addEntry(_("RENAME PROFILE"), true,
+		[window, current, profiles]
+		{
+			// Build label for the profile being renamed
+			std::string confPath = current.empty()
+				? "/userdata/profiles/.default-retroachievements.conf"
+				: "/userdata/profiles/" + current + "/retroachievements.conf";
+			std::string existing = readConfField(confPath, "display_name");
+
+			window->pushGui(new GuiTextEditPopupKeyboard(window,
+				_("DISPLAY NAME"), existing,
+				[window, current, confPath](const std::string& newName)
+				{
+					// Write display_name= into the profile's conf file via shell
+					// (avoids rewriting the entire file in C++)
+					std::string cmd = "grep -v '^display_name=' \"" + confPath + "\" > /tmp/ra_conf.tmp 2>/dev/null;"
+						" echo 'display_name=" + newName + "' >> /tmp/ra_conf.tmp;"
+						" mv /tmp/ra_conf.tmp \"" + confPath + "\"";
+					system(cmd.c_str());
+					window->pushGui(new GuiMsgBox(window,
+						_("DISPLAY NAME SET TO:") + "\n" + newName,
 						_("OK"), nullptr));
 				}, false));
 		});
@@ -126,8 +189,7 @@ GuiProfilesSettings::GuiProfilesSettings(Window* window)
 					[window, current]
 					{
 						system("batocera-profiles switch");
-						system(
-							("batocera-profiles delete \"" + current + "\"").c_str());
+						system(("batocera-profiles delete \"" + current + "\"").c_str());
 						window->pushGui(new GuiMsgBox(window,
 							_("PROFILE DELETED. SWITCHED TO DEFAULT."),
 							_("OK"), nullptr));

--- a/es-app/src/guis/GuiProfilesSettings.cpp
+++ b/es-app/src/guis/GuiProfilesSettings.cpp
@@ -76,6 +76,26 @@ static std::string profileDisplayName(const std::string& confPath, const std::st
 	return fallback;
 }
 
+// Open the rename keyboard for a given profile conf file.
+static void openRenameKeyboard(Window* window, const std::string& confPath)
+{
+	std::string existing = readConfField(confPath, "display_name");
+	window->pushGui(new GuiTextEditPopupKeyboard(window,
+		_("DISPLAY NAME"), existing,
+		[window, confPath](const std::string& newName)
+		{
+			// Update display_name= in place, preserving all other fields.
+			std::string cmd =
+				"grep -v '^display_name=' \"" + confPath + "\" > /tmp/ra_conf.tmp 2>/dev/null;"
+				" echo 'display_name=" + newName + "' >> /tmp/ra_conf.tmp;"
+				" mv /tmp/ra_conf.tmp \"" + confPath + "\"";
+			system(cmd.c_str());
+			window->pushGui(new GuiMsgBox(window,
+				_("DISPLAY NAME SET TO:") + "\n" + newName,
+				_("OK"), nullptr));
+		}, false));
+}
+
 static bool isValidProfileName(const std::string& name)
 {
 	if (name.empty())
@@ -151,30 +171,30 @@ GuiProfilesSettings::GuiProfilesSettings(Window* window)
 				}, false));
 		});
 
-	// RENAME: sets display_name for any profile (default or named)
+	// RENAME: picker lists all profiles, then opens keyboard for chosen one.
 	addEntry(_("RENAME PROFILE"), true,
-		[window, current, profiles]
+		[window, profiles, defaultConf, defaultName]
 		{
-			// Build label for the profile being renamed
-			std::string confPath = current.empty()
-				? "/userdata/profiles/.default-retroachievements.conf"
-				: "/userdata/profiles/" + current + "/retroachievements.conf";
-			std::string existing = readConfField(confPath, "display_name");
+			auto* picker = new GuiSettings(window, _("RENAME WHICH PROFILE?").c_str());
 
-			window->pushGui(new GuiTextEditPopupKeyboard(window,
-				_("DISPLAY NAME"), existing,
-				[window, current, confPath](const std::string& newName)
+			picker->addEntry(defaultName, false,
+				[window, defaultConf]
 				{
-					// Write display_name= into the profile's conf file via shell
-					// (avoids rewriting the entire file in C++)
-					std::string cmd = "grep -v '^display_name=' \"" + confPath + "\" > /tmp/ra_conf.tmp 2>/dev/null;"
-						" echo 'display_name=" + newName + "' >> /tmp/ra_conf.tmp;"
-						" mv /tmp/ra_conf.tmp \"" + confPath + "\"";
-					system(cmd.c_str());
-					window->pushGui(new GuiMsgBox(window,
-						_("DISPLAY NAME SET TO:") + "\n" + newName,
-						_("OK"), nullptr));
-				}, false));
+					openRenameKeyboard(window, defaultConf);
+				});
+
+			for (const auto& p : profiles)
+			{
+				std::string conf = "/userdata/profiles/" + p + "/retroachievements.conf";
+				std::string dn = profileDisplayName(conf, p);
+				picker->addEntry(dn, false,
+					[window, conf]
+					{
+						openRenameKeyboard(window, conf);
+					});
+			}
+
+			window->pushGui(picker);
 		});
 
 	if (!current.empty())

--- a/es-app/src/guis/GuiProfilesSettings.cpp
+++ b/es-app/src/guis/GuiProfilesSettings.cpp
@@ -1,10 +1,10 @@
 #include "GuiProfilesSettings.h"
 #include "guis/GuiMsgBox.h"
 #include "guis/GuiTextEditPopupKeyboard.h"
-#include "ApiSystem.h"
 #include "LocaleES.h"
 #include <cctype>
 #include <cstdio>
+#include <cstdlib>
 #include <string>
 #include <vector>
 
@@ -66,7 +66,7 @@ GuiProfilesSettings::GuiProfilesSettings(Window* window)
 	addEntry(defaultLabel, false,
 		[window]
 		{
-			ApiSystem::getInstance()->executeScript("batocera-profiles switch");
+			system("batocera-profiles switch");
 			window->pushGui(new GuiMsgBox(window,
 				_("SWITCHED TO DEFAULT PROFILE.\nTAKES EFFECT ON NEXT GAME LAUNCH."),
 				_("OK"), nullptr));
@@ -81,7 +81,7 @@ GuiProfilesSettings::GuiProfilesSettings(Window* window)
 		addEntry(label, false,
 			[window, p]
 			{
-				ApiSystem::getInstance()->executeScript(
+				system(
 					"batocera-profiles switch \"" + p + "\"");
 				window->pushGui(new GuiMsgBox(window,
 					_("SWITCHED TO PROFILE:") + "\n" + p + "\n\n" +
@@ -106,7 +106,7 @@ GuiProfilesSettings::GuiProfilesSettings(Window* window)
 							_("OK"), nullptr));
 						return;
 					}
-					ApiSystem::getInstance()->executeScript(
+					system(
 						"batocera-profiles create \"" + name + "\"");
 					window->pushGui(new GuiMsgBox(window,
 						_("PROFILE CREATED:") + "\n" + name,
@@ -125,8 +125,8 @@ GuiProfilesSettings::GuiProfilesSettings(Window* window)
 					_("YES"),
 					[window, current]
 					{
-						ApiSystem::getInstance()->executeScript("batocera-profiles switch");
-						ApiSystem::getInstance()->executeScript(
+						system("batocera-profiles switch");
+						system(
 							"batocera-profiles delete \"" + current + "\"");
 						window->pushGui(new GuiMsgBox(window,
 							_("PROFILE DELETED. SWITCHED TO DEFAULT."),

--- a/es-app/src/guis/GuiProfilesSettings.cpp
+++ b/es-app/src/guis/GuiProfilesSettings.cpp
@@ -94,7 +94,7 @@ GuiProfilesSettings::GuiProfilesSettings(Window* window)
 
 	addGroup(_("SWITCH PROFILE"));
 
-	// DEFAULT entry — always present
+	// DEFAULT entry: always present
 	std::string defaultConf = "/userdata/profiles/.default-retroachievements.conf";
 	std::string defaultName = profileDisplayName(defaultConf, _("DEFAULT"));
 	std::string defaultLabel = current.empty()
@@ -151,7 +151,7 @@ GuiProfilesSettings::GuiProfilesSettings(Window* window)
 				}, false));
 		});
 
-	// RENAME — sets display_name for any profile (default or named)
+	// RENAME: sets display_name for any profile (default or named)
 	addEntry(_("RENAME PROFILE"), true,
 		[window, current, profiles]
 		{

--- a/es-app/src/guis/GuiProfilesSettings.cpp
+++ b/es-app/src/guis/GuiProfilesSettings.cpp
@@ -1,0 +1,139 @@
+#include "GuiProfilesSettings.h"
+#include "guis/GuiMsgBox.h"
+#include "guis/GuiTextEditPopupKeyboard.h"
+#include "ApiSystem.h"
+#include "LocaleES.h"
+#include <cctype>
+#include <cstdio>
+#include <string>
+#include <vector>
+
+static std::vector<std::string> readProfileList()
+{
+	std::vector<std::string> profiles;
+	FILE* pipe = popen("batocera-profiles list 2>/dev/null", "r");
+	if (!pipe)
+		return profiles;
+	char line[256];
+	while (fgets(line, sizeof(line), pipe))
+	{
+		std::string s(line);
+		while (!s.empty() && (s.back() == '\n' || s.back() == '\r'))
+			s.pop_back();
+		if (!s.empty())
+			profiles.push_back(s);
+	}
+	pclose(pipe);
+	return profiles;
+}
+
+static std::string readCurrentProfile()
+{
+	FILE* pipe = popen("batocera-profiles current 2>/dev/null", "r");
+	if (!pipe)
+		return "";
+	char line[256] = "";
+	fgets(line, sizeof(line), pipe);
+	pclose(pipe);
+	std::string s(line);
+	while (!s.empty() && (s.back() == '\n' || s.back() == '\r'))
+		s.pop_back();
+	return s;
+}
+
+static bool isValidProfileName(const std::string& name)
+{
+	if (name.empty())
+		return false;
+	for (char c : name)
+		if (!isalnum((unsigned char)c) && c != ' ' && c != '_' && c != '-')
+			return false;
+	return true;
+}
+
+GuiProfilesSettings::GuiProfilesSettings(Window* window)
+	: GuiSettings(window, _("PROFILES").c_str())
+{
+	std::string current = readCurrentProfile();
+	std::vector<std::string> profiles = readProfileList();
+
+	addGroup(_("SWITCH PROFILE"));
+
+	// DEFAULT entry — always present
+	std::string defaultLabel = current.empty()
+		? (_("DEFAULT") + " (" + _("ACTIVE") + ")")
+		: _("DEFAULT");
+	addEntry(defaultLabel, false,
+		[window]
+		{
+			ApiSystem::getInstance()->executeScript("batocera-profiles switch");
+			window->pushGui(new GuiMsgBox(window,
+				_("SWITCHED TO DEFAULT PROFILE.\nTAKES EFFECT ON NEXT GAME LAUNCH."),
+				_("OK"), nullptr));
+		});
+
+	for (auto p : profiles)
+	{
+		bool isActive = (p == current);
+		std::string label = isActive
+			? (p + " (" + _("ACTIVE") + ")")
+			: p;
+		addEntry(label, false,
+			[window, p]
+			{
+				ApiSystem::getInstance()->executeScript(
+					"batocera-profiles switch \"" + p + "\"");
+				window->pushGui(new GuiMsgBox(window,
+					_("SWITCHED TO PROFILE:") + "\n" + p + "\n\n" +
+					_("TAKES EFFECT ON NEXT GAME LAUNCH."),
+					_("OK"), nullptr));
+			});
+	}
+
+	addGroup(_("MANAGE"));
+
+	addEntry(_("CREATE NEW PROFILE"), true,
+		[window]
+		{
+			window->pushGui(new GuiTextEditPopupKeyboard(window,
+				_("NEW PROFILE NAME"), "",
+				[window](const std::string& name)
+				{
+					if (!isValidProfileName(name))
+					{
+						window->pushGui(new GuiMsgBox(window,
+							_("INVALID PROFILE NAME.\nUSE LETTERS, NUMBERS, SPACES, - OR _ ONLY."),
+							_("OK"), nullptr));
+						return;
+					}
+					ApiSystem::getInstance()->executeScript(
+						"batocera-profiles create \"" + name + "\"");
+					window->pushGui(new GuiMsgBox(window,
+						_("PROFILE CREATED:") + "\n" + name,
+						_("OK"), nullptr));
+				}, false));
+		});
+
+	if (!current.empty())
+	{
+		addEntry(_("DELETE CURRENT PROFILE"), true,
+			[window, current]
+			{
+				window->pushGui(new GuiMsgBox(window,
+					_("DELETE PROFILE") + " \"" + current + "\"?\n" +
+					_("ALL SAVES IN THIS PROFILE WILL ALSO BE DELETED."),
+					_("YES"),
+					[window, current]
+					{
+						ApiSystem::getInstance()->executeScript("batocera-profiles switch");
+						ApiSystem::getInstance()->executeScript(
+							"batocera-profiles delete \"" + current + "\"");
+						window->pushGui(new GuiMsgBox(window,
+							_("PROFILE DELETED. SWITCHED TO DEFAULT."),
+							_("OK"), nullptr));
+					},
+					_("NO"), nullptr,
+					GuiMsgBoxIcon::ICON_WARNING));
+			});
+	}
+}

--- a/es-app/src/guis/GuiProfilesSettings.cpp
+++ b/es-app/src/guis/GuiProfilesSettings.cpp
@@ -82,7 +82,7 @@ GuiProfilesSettings::GuiProfilesSettings(Window* window)
 			[window, p]
 			{
 				system(
-					"batocera-profiles switch \"" + p + "\"");
+					("batocera-profiles switch \"" + p + "\"").c_str());
 				window->pushGui(new GuiMsgBox(window,
 					_("SWITCHED TO PROFILE:") + "\n" + p + "\n\n" +
 					_("TAKES EFFECT ON NEXT GAME LAUNCH."),
@@ -107,7 +107,7 @@ GuiProfilesSettings::GuiProfilesSettings(Window* window)
 						return;
 					}
 					system(
-						"batocera-profiles create \"" + name + "\"");
+						("batocera-profiles create \"" + name + "\"").c_str());
 					window->pushGui(new GuiMsgBox(window,
 						_("PROFILE CREATED:") + "\n" + name,
 						_("OK"), nullptr));
@@ -127,7 +127,7 @@ GuiProfilesSettings::GuiProfilesSettings(Window* window)
 					{
 						system("batocera-profiles switch");
 						system(
-							"batocera-profiles delete \"" + current + "\"");
+							("batocera-profiles delete \"" + current + "\"").c_str());
 						window->pushGui(new GuiMsgBox(window,
 							_("PROFILE DELETED. SWITCHED TO DEFAULT."),
 							_("OK"), nullptr));

--- a/es-app/src/guis/GuiProfilesSettings.h
+++ b/es-app/src/guis/GuiProfilesSettings.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "GuiSettings.h"
+
+class Window;
+
+class GuiProfilesSettings : public GuiSettings
+{
+public:
+	GuiProfilesSettings(Window* window);
+};


### PR DESCRIPTION
## What this is

A working proof-of-concept for multi-user profile support in EmulationStation. We've been running this in production on OctaneOS (Radxa Cubie A7S / Allwinner A733) and it works well. We're opening this early to start a conversation about the right approach, not to request a merge.

## What it does

Adds a **Profiles** entry to the main ES menu that opens `GuiProfilesSettings`, which lets users:

- **Switch profiles** — each profile has its own RetroAchievements credentials (username, password, token, enabled/disabled) and its own save/state directories
- **Create new profiles** — named profiles stored under `/userdata/profiles/<name>/`
- **Rename profiles** — a picker lists all profiles; selecting one opens a keyboard to set a custom display name
- **Delete profiles** — with confirmation, deletes profile dir and switches back to default

**Display name priority:** custom `display_name` → RetroAchievements username → directory name. So profiles naturally show the RA handle without any manual setup.

**Save isolation:** `/userdata/saves` and `/userdata/states` are symlinks that repoint on every switch. configgen continues writing to `/userdata/saves` as always — the symlink transparently redirects to the active profile's directory. This was necessary because configgen hardcodes `SAVES = /userdata/saves` and overwrites `savefile_directory` at every game launch.

## What we know needs work

**ApiSystem integration:** The C++ currently calls `popen("batocera-profiles list ...")` and `system("batocera-profiles switch ...")` directly. We know these should move into `ApiSystem.cpp` as proper methods. We intentionally left this for v2 so we can get design feedback on the approach before doing the cleanup.

**Platform gating:** The backend script (`batocera-profiles`) uses `/userdata/profiles/` which is standard Batocera userdata layout, but we haven't added platform feature-flags yet.

**ES restart after switch:** RA widget on the main menu reflects the old session until ES restarts. We document this rather than solving it today.

## The backend

Profile management is handled by a `batocera-profiles` shell script (separate PR to batocera.linux if this direction is approved). It handles create/switch/delete, credential save/restore, and save directory symlink management.

## Running hardware

Tested on Radxa Cubie A7S with two real user profiles, wired and BLE controllers, SNES/GBA/NES saves, and RetroAchievements accounts. Works daily.

We'd love feedback on the overall approach before we invest in the ApiSystem refactor. Happy to iterate.