### PR TITLE
[WIN32] Fix crash on virtual mouse devices

### DIFF
--- a/es-core/src/GunManager.cpp
+++ b/es-core/src/GunManager.cpp
@@ -10,6 +10,7 @@
 #include "LocaleES.h"
 #include "renderers/Renderer.h"
 #include "InputManager.h"
+#include <vector>
 
 #ifdef HAVE_UDEV
 #include <poll.h>
@@ -49,10 +50,10 @@ enum class LightGunType
 class RawInputManager
 {
 public:
-	static LightGunType getLightGunType(HANDLE hDevice)
-	{
-		std::string name = GetRawInputDevicePath(hDevice);
+	static bool sWiimoteGunRunning;
 
+	static LightGunType getLightGunType(const std::string& name)
+	{
 		std::string sindenDeviceIds[] = { "VID_16C0&PID_0F01", "VID_16C0&PID_0F02", "VID_16C0&PID_0F38", "VID_16C0&PID_0F39" };
 		for (auto id : sindenDeviceIds)
 			if (name.find(id) != std::string::npos)
@@ -93,49 +94,60 @@ public:
 			if (name.find(id) != std::string::npos)
 				return LightGunType::AELightgun;
 
-		if (name.find("vmulti") != std::string::npos)
+		if (sWiimoteGunRunning && name.find("vmulti") != std::string::npos)
 			return LightGunType::VirtualHID;
 
 		return LightGunType::Mouse;
+	}
+
+	static LightGunType getLightGunType(HANDLE hDevice)
+	{
+		return getLightGunType(GetRawInputDevicePath(hDevice));
 	}
 
 	static std::string GetRawInputDevicePath(HANDLE hDevice)
 	{
 		UINT bufferSize = 0;
 
-		// Get the required buffer size for the device name
-		if (GetRawInputDeviceInfoA(hDevice, RIDI_DEVICENAME, nullptr, &bufferSize) != 0) {
-			return "";
-		}
-
-		// Allocate memory for the device name
-		char* lpDeviceName = new char[bufferSize];
-		if (lpDeviceName == nullptr)
+		// Required size. With pData == nullptr, the API returns 0 on success.
+		if (GetRawInputDeviceInfoA(hDevice, RIDI_DEVICENAME, nullptr, &bufferSize) != 0)
 			return "";
 
-		// Get the device name
-		if (GetRawInputDeviceInfoA(hDevice, RIDI_DEVICENAME, lpDeviceName, &bufferSize) == -1) {
-			delete[] lpDeviceName;
+		// Safeguard: a device path is never 4 KB.
+		if (bufferSize == 0 || bufferSize > 4096)
 			return "";
-		}
 
-		std::string deviceName(lpDeviceName);
-		delete[] lpDeviceName;
-		return deviceName;
+		std::vector<char> buffer(bufferSize + 1, '\0');
+
+		if (GetRawInputDeviceInfoA(hDevice, RIDI_DEVICENAME, buffer.data(), &bufferSize) == (UINT)-1)
+			return "";
+
+		buffer[buffer.size() - 1] = '\0';   // guaranteed termination
+		return std::string(buffer.data());
 	}
 
 	static std::string GetRawInputDeviceName(HANDLE hDevice)
 	{
 		std::string path = GetRawInputDevicePath(hDevice);
+		if (path.empty())
+			return "";
 
 		std::string ret;
 
-		HANDLE hhid = CreateFileA(path.c_str(), 0, 3, nullptr, 3, 0x00000080, nullptr);
+		HANDLE hhid = CreateFileA(path.c_str(), 0,
+			FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr,
+			OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
+
 		if (hhid != INVALID_HANDLE_VALUE)
 		{
-			wchar_t buf[255];
-			if (HidD_GetProductString(hhid, &buf[0], 255))
+			wchar_t buf[256] = { 0 };
+
+			// HidD_GetProductString attend une longueur en OCTETS, pas en caractères.
+			if (HidD_GetProductString(hhid, &buf[0], sizeof(buf) - sizeof(wchar_t)))
+			{
+				buf[255] = L'\0';
 				ret = Utils::String::convertFromWideString(buf);
+			}
 
 			CloseHandle(hhid);
 		}
@@ -143,6 +155,7 @@ public:
 		return ret;
 	}
 };
+bool RawInputManager::sWiimoteGunRunning = false;
 #endif
 
 GunManager::GunManager()
@@ -183,6 +196,10 @@ GunManager::~GunManager()
 	}
 #elif WIN32
 	enableRawInputCapture(false);
+	for (auto gun : mGuns)
+		delete gun;
+
+	mGuns.clear();
 #endif
 }
 
@@ -514,11 +531,11 @@ void GunManager::updateGuns(Window* window)
 			bGunborder = false;
 
 			if (val_gunborder != NULL && strncmp(val_gunborder, "1", 1) == 0)
-			  bGunborder = true;
+				bGunborder = true;
 
 			action = udev_device_get_action(dev);
 
-			if (val_gun != NULL && strncmp(val_gun, "1", 1) == 0)
+			if (action != NULL && val_gun != NULL && strncmp(val_gun, "1", 1) == 0)
 			{
 				if (strncmp(action, "add", 3) == 0)
 				{
@@ -545,39 +562,62 @@ void GunManager::updateGuns(Window* window)
 	{
 		updateGunCheck = 0;
 
-		// Get the number of raw input devices
-		UINT numDevices;
-		if (GetRawInputDeviceList(NULL, &numDevices, sizeof(RAWINPUTDEVICELIST)) == -1)
-			return;
+		std::vector<RAWINPUTDEVICELIST> deviceList;
+		UINT numDevices = 0;
 
-		// Allocate memory for the device list
-		RAWINPUTDEVICELIST* deviceList = new RAWINPUTDEVICELIST[numDevices];
-		if (deviceList == nullptr)
-			return;
+		for (int attempt = 0; attempt < 3; attempt++)
+		{
+			UINT count = 0;
+			if (GetRawInputDeviceList(nullptr, &count, sizeof(RAWINPUTDEVICELIST)) == (UINT)-1 || count == 0)
+				return;
 
-		// Get the raw input device list
-		if (GetRawInputDeviceList(deviceList, &numDevices, sizeof(RAWINPUTDEVICELIST)) == -1)
-			delete[] deviceList;
+			deviceList.resize(count);
 
-		// Enumerate and print information about connected mice
+			UINT ret = GetRawInputDeviceList(deviceList.data(), &count, sizeof(RAWINPUTDEVICELIST));
+			if (ret != (UINT)-1)
+			{
+				numDevices = ret;   // number actually written, not the allocated size
+				break;
+			}
+
+			deviceList.clear();
+
+			if (GetLastError() != ERROR_INSUFFICIENT_BUFFER)
+				return;             // real failure, no need to retry
+		}
+
+		if (numDevices == 0)
+			return;                 // unstable list: will try again in 11 frames
+
+		// Only one GetRawInputDeviceInfo call per device and per pass.
+		std::vector<std::string> devicePaths(numDevices);
+		for (UINT i = 0; i < numDevices; i++)
+			devicePaths[i] = RawInputManager::GetRawInputDevicePath(deviceList[i].hDevice);
+
+		// Diagnostic : trace rawinput list when it changes.
+		{
+			static std::set<std::string> lastKnownRawPaths;
+			std::set<std::string> currentRawPaths;
+
+			for (UINT i = 0; i < numDevices; i++)
+				currentRawPaths.insert(std::to_string(deviceList[i].dwType) + "|" + devicePaths[i]);
+
+			if (currentRawPaths != lastKnownRawPaths)
+			{
+				LOG(LogInfo) << "[RawInput] device list changed (" << numDevices << " device(s))";
+				for (const auto& p : currentRawPaths)
+					LOG(LogInfo) << "[RawInput]   " << p;
+
+				lastKnownRawPaths = currentRawPaths;
+			}
+		}
+
+		Window* notifyWindow = mInitialScan ? nullptr : window;
 
 		std::set<std::string> knownPaths;
 
-		bool hasPhysicalGuns = false;
-
-#if FORCE_REPLACEMOUSE
-		hasPhysicalGuns = true;
-#else
-		for (UINT i = 0; i < numDevices; i++)
-		{
-			std::string devicePath = RawInputManager::GetRawInputDevicePath(deviceList[i].hDevice);
-			if (deviceList[i].dwType != RIM_TYPEMOUSE && RawInputManager::getLightGunType(deviceList[i].hDevice) != LightGunType::Mouse)
-			{
-				hasPhysicalGuns = true;
-				break;
-			}
-		}
-#endif
+		// WiimoteGun must be detected BEFORE classifying devices:
+		// it allows interpreting "vmulti" as a lightgun.
 		bool hasWiimoteGun = false;
 
 		HWND hWndWiimoteGun = FindWindow("WiimoteGun", NULL);
@@ -587,6 +627,24 @@ void GunManager::updateGuns(Window* window)
 			hasWiimoteGun = (mode == 1);
 		}
 
+		RawInputManager::sWiimoteGunRunning = hasWiimoteGun;
+
+		bool hasPhysicalGuns = false;
+
+#if FORCE_REPLACEMOUSE
+		hasPhysicalGuns = true;
+#else
+		for (UINT i = 0; i < numDevices; i++)
+		{
+			if (deviceList[i].dwType != RIM_TYPEMOUSE &&
+				RawInputManager::getLightGunType(devicePaths[i]) != LightGunType::Mouse)
+			{
+				hasPhysicalGuns = true;
+				break;
+			}
+		}
+#endif
+
 		if (hasPhysicalGuns || hasWiimoteGun)
 		{
 			for (UINT i = 0; i < numDevices; i++)
@@ -595,15 +653,18 @@ void GunManager::updateGuns(Window* window)
 					continue;
 
 				HANDLE hDevice = deviceList[i].hDevice;
+				const std::string& devicePath = devicePaths[i];
 
-				auto gunType = RawInputManager::getLightGunType(hDevice);
+				if (devicePath.empty())
+					continue;
+
+				auto gunType = RawInputManager::getLightGunType(devicePath);
 				if (hasWiimoteGun && gunType == LightGunType::Mouse)
 					continue;
 
-				std::string devicePath = RawInputManager::GetRawInputDevicePath(hDevice);
 				knownPaths.insert(devicePath);
 
-				if (std::any_of(mGuns.cbegin(), mGuns.cend(), [devicePath](Gun* pGun) { return pGun->mPath == devicePath; }))
+				if (std::any_of(mGuns.cbegin(), mGuns.cend(), [&devicePath](Gun* pGun) { return pGun->mPath == devicePath; }))
 					continue;
 
 				Gun* newgun = new Gun();
@@ -621,8 +682,8 @@ void GunManager::updateGuns(Window* window)
 					newgun->mX = newgun->m_internalX = x;
 					newgun->mY = newgun->m_internalY = y;
 				}
-				else if (window != NULL && !newgun->mName.empty() && Settings::getInstance()->getBool("ShowGunsNotifications"))
-					window->displayNotificationMessage(_U("\uF05B ") + Utils::String::format(_("%s connected").c_str(), Utils::String::trim(newgun->mName).c_str()));
+				else if (notifyWindow != NULL && !newgun->mName.empty() && Settings::getInstance()->getBool("ShowGunsNotifications"))
+					notifyWindow->displayNotificationMessage(_U("\uF05B ") + Utils::String::format(_("%s connected").c_str(), Utils::String::trim(newgun->mName).c_str()));
 
 				mGuns.push_back(newgun);
 			}
@@ -638,8 +699,8 @@ void GunManager::updateGuns(Window* window)
 				iter++;
 			else
 			{
-				if (window != NULL && !gun->m_isMouse && Settings::getInstance()->getBool("ShowGunsNotifications"))
-					window->displayNotificationMessage(_U("\uF05B ") + Utils::String::format(_("%s disconnected").c_str(), Utils::String::trim(gun->mName).c_str()));
+				if (notifyWindow != NULL && !gun->m_isMouse && Settings::getInstance()->getBool("ShowGunsNotifications"))
+					notifyWindow->displayNotificationMessage(_U("\uF05B ") + Utils::String::format(_("%s disconnected").c_str(), Utils::String::trim(gun->mName).c_str()));
 
 				LOG(LogInfo) << "Gun removed found at " << gun->mPath;
 
@@ -659,8 +720,8 @@ void GunManager::updateGuns(Window* window)
 
 			mGuns.push_back(newgun);
 
-			if (window != NULL && Settings::getInstance()->getBool("ShowGunsNotifications"))
-				window->displayNotificationMessage(_U("\uF05B ") + Utils::String::format(_("%s connected").c_str(), Utils::String::trim(newgun->mName).c_str()));
+			if (notifyWindow != NULL && Settings::getInstance()->getBool("ShowGunsNotifications"))
+				notifyWindow->displayNotificationMessage(_U("\uF05B ") + Utils::String::format(_("%s connected").c_str(), Utils::String::trim(newgun->mName).c_str()));
 		}
 		else if (!hasWiimoteGun && mGuns.size())
 		{
@@ -669,8 +730,8 @@ void GunManager::updateGuns(Window* window)
 				Gun* gun = *it;
 				if (gun->mName == WIIMOTE_GUN)
 				{
-					if (window != NULL && Settings::getInstance()->getBool("ShowGunsNotifications"))
-						window->displayNotificationMessage(_U("\uF05B ") + Utils::String::format(_("%s disconnected").c_str(), Utils::String::trim(gun->mName).c_str()));
+					if (notifyWindow != NULL && Settings::getInstance()->getBool("ShowGunsNotifications"))
+						notifyWindow->displayNotificationMessage(_U("\uF05B ") + Utils::String::format(_("%s disconnected").c_str(), Utils::String::trim(gun->mName).c_str()));
 
 					mGuns.erase(it);
 					delete gun;
@@ -689,7 +750,7 @@ void GunManager::updateGuns(Window* window)
 		else if (!hasPhysicalGuns && mMessageHookRegistered)
 			enableRawInputCapture(false);
 
-		delete[] deviceList;
+		mInitialScan = false;
 	}
 #endif
 
@@ -747,6 +808,8 @@ void GunManager::updateGuns(Window* window)
 		if (gun->isMButtonDown() != oldGun.isMButtonDown())
 		{
 			auto config = InputManager::getInstance()->getInputConfigByDevice(DEVICE_KEYBOARD);
+			if (config == nullptr)
+				continue;
 
 			Input input;
 			if (config->getInputByName(BUTTON_OK, &input))
@@ -756,6 +819,8 @@ void GunManager::updateGuns(Window* window)
 		if (gun->isStartButtonDown() != oldGun.isStartButtonDown())
 		{
 			auto config = InputManager::getInstance()->getInputConfigByDevice(DEVICE_KEYBOARD);
+			if (config == nullptr)
+				continue;
 
 			Input input;
 			if (config->getInputByName("start", &input))
@@ -765,6 +830,8 @@ void GunManager::updateGuns(Window* window)
 		if (gun->isSelectButtonDown() != oldGun.isSelectButtonDown())
 		{
 			auto config = InputManager::getInstance()->getInputConfigByDevice(DEVICE_KEYBOARD);
+			if (config == nullptr)
+				continue;
 
 			Input input;
 			if (config->getInputByName("select", &input))

--- a/es-core/src/GunManager.h
+++ b/es-core/src/GunManager.h
@@ -148,6 +148,7 @@ private:
 	static bool mMessageHookRegistered;	
 	static void WindowsMessageHook(void* userdata, void* hWnd, unsigned int message, Uint64 wParam, Sint64 lParam);
 	void enableRawInputCapture(bool enable);
+	bool mInitialScan = true;
 #endif
 };
 


### PR DESCRIPTION
Impacts only if WIN32 sections.

1) Ensure vmulti is not always classified as lightgun (only when wiimotegun is running) 2) Fix buffer issue in GetRawInputDevicePath
3) Fix truncated names in GetRawInputDeviceName
4) Fix potential crash due to insufficient buffer if rawdevice list changes due to potential HID virtual device disconnection 5) Gun creation loop should consume devicePaths[i] instead of calling the system again 6) Protect nullptr risk
7) Added a diagnostic trace