### PR TITLE
Fix for quicksearch/random system

### DIFF
--- a/es-app/src/SystemData.cpp
+++ b/es-app/src/SystemData.cpp
@@ -1435,29 +1435,19 @@ unsigned int SystemData::getGameCount() const
 
 SystemData* SystemData::getRandomSystem()
 {
-	//  this is a bit brute force. It might be more efficient to just to a while (!gameSystem) do random again...
-	unsigned int total = sSystemVector.count([](auto sys) { return sys->isGameSystem(); });
+	// Only pick among systems actually shown in the system view. Hidden systems and systems
+	// merged into a group are present in sSystemVector but not in the carousel, and setting
+	// the cursor to one of them silently does nothing (IList::setCursor returns false).
+	std::vector<SystemData*> visibleSystems;
 
-	// get random number in range
-	int target = Randomizer::random(total);
-	//int target = (int)Math::round((std::rand() / (float)RAND_MAX) * (total - 1));
-	for (auto it = sSystemVector.cbegin(); it != sSystemVector.cend(); it++)
-	{
-		if ((*it)->isGameSystem())
-		{
-			if (target > 0)
-			{
-				target--;
-			}
-			else
-			{
-				return (*it);
-			}
-		}
-	}
+	for (auto system : sSystemVector)
+		if (system->isGameSystem() && system->isVisible())
+			visibleSystems.push_back(system);
 
-	// if we end up here, there is no valid system
-	return NULL;
+	if (visibleSystems.empty())
+		return nullptr;
+
+	return visibleSystems[Randomizer::random((int)visibleSystems.size())];
 }
 
 FileData* SystemData::getRandomGame()

--- a/es-app/src/views/SystemView.cpp
+++ b/es-app/src/views/SystemView.cpp
@@ -377,7 +377,13 @@ bool SystemView::input(InputConfig* config, Input input)
 {
 	if (mYButton.isShortPressed(config, input))
 	{
-		showQuickSearch();
+		// Quick search needs the "all games" collection : when the user disabled it, fall back
+		// to a random system instead of silently doing nothing.
+		if (SystemData::getSystem("all") != nullptr)
+			showQuickSearch();
+		else
+			mCarousel.setCursor(SystemData::getRandomSystem());
+
 		return true;
 	}
 
@@ -615,14 +621,11 @@ void SystemView::update(int deltaTime)
 
 	GuiComponent::update(deltaTime);
 
+	// Long press on the west button always selects a random system, matching the game list view.
+	// It used to do so only when netplay was enabled, and otherwise just repeated the quick
+	// search already bound to the short press.
 	if (mYButton.isLongPressed(deltaTime))
-	{
-		bool netPlay = SystemData::isNetplayActivated() && SystemConf::getInstance()->getBool("global.netplay");
-		if (netPlay)
-			mCarousel.setCursor(SystemData::getRandomSystem());
-		else
-			showQuickSearch();
-	}
+		mCarousel.setCursor(SystemData::getRandomSystem());
 }
 
 void SystemView::updateExtraTextBinding()
@@ -904,7 +907,9 @@ std::vector<HelpPrompt> SystemView::getHelpPrompts()
 	{
 		prompts.push_back(HelpPrompt("x", _("RANDOM")));
 		if (SystemData::getSystem("all") != nullptr)
-			prompts.push_back(HelpPrompt("y", _("SEARCH"), [&] { showQuickSearch(); })); // QUICK 
+			prompts.push_back(HelpPrompt("y", _("SEARCH") + std::string("/") + _("RANDOM"), [&] { showQuickSearch(); })); // QUICK 
+		else
+			prompts.push_back(HelpPrompt("y", _("RANDOM"), [&] { mCarousel.setCursor(SystemData::getRandomSystem()); }));
 	}
 
 	if (SystemData::IsManufacturerSupported)


### PR DESCRIPTION
In system view, align the behaviour to gamelist view:
- Fix random system: always works (based on visible systems now !)
- longpress now does random (same behaviour as in gamelists)
- If "allgames" collection is disabled, WEST now does random instead of doing nothing

NOTE: maybe in the future fix the quicksearch to not depend on the ALL GAMES collection, but that's another topic.